### PR TITLE
Merge Context7 benchmark improvements into main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ bundle exec rake woods:validate          # Index integrity check
 bundle exec rake woods:stats             # Show extraction stats
 bundle exec rake woods:clean             # Remove index output
 bundle exec rake woods:notion_sync       # Sync models/columns to Notion
-# Woods-themed aliases: woods:grow (extract), woods:trail (stats), woods:map (validate)
+# Woods-themed aliases: woods:scan (extract), woods:look (stats), woods:vet (validate)
 ```
 
 > **Docker:** Extraction runs inside the container (`docker compose exec app bundle exec rake ...`). The Index Server runs on the host reading volume-mounted output. See `docs/DOCKER_SETUP.md` for the full Docker guide.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,40 @@ Woods boots your Rails app, introspects everything using runtime APIs, and write
 
 Your `User` model includes `Auditable`, `Searchable`, and `SoftDeletable`. An AI tool reading `app/models/user.rb` sees 40 lines. Woods inlines all three concerns directly into the extracted unit — the AI sees the full 200-line behavioral surface area in one block.
 
+```ruby
+# What your AI sees (app/models/user.rb) — 4 lines:
+class User < ApplicationRecord
+  include Auditable
+  include Searchable
+end
+
+# What Woods produces — full source with schema + inlined concerns:
+# == Schema Information
+# email    :string           not null
+# name     :string
+#
+# class User < ApplicationRecord
+#   include Auditable
+#   include Searchable
+#   validates :email, presence: true, uniqueness: true
+#   ...
+# end
+#
+# ┌─────────────────────────────────────────────────────────────────────┐
+# │ Included from: Auditable                                            │
+# └─────────────────────────────────────────────────────────────────────┘
+#   def audit_trail ...
+# ─────────────────────────── End Auditable ───────────────────────────
+#
+# ┌─────────────────────────────────────────────────────────────────────┐
+# │ Included from: Searchable                                           │
+# └─────────────────────────────────────────────────────────────────────┘
+#   scope :search, ->(q) { where("name ILIKE ?", "%#{q}%") }
+# ─────────────────────────── End Searchable ───────────────────────────
+```
+
+The `metadata[:inlined_concerns]` array lists which concerns were resolved, so retrieval can filter by concern inclusion.
+
 ### Schema Prepending
 
 Model source gets a header with actual column types, indexes, and foreign keys pulled from the live database. No more guessing whether `name` is a `string` or `text`, or whether there's an index on `email`.
@@ -80,6 +114,122 @@ Controller source gets a route map prepended showing the real HTTP verb + path +
 ### Callback Side-Effect Analysis
 
 `CallbackAnalyzer` detects what actually happens inside callbacks — which columns get written, which jobs get enqueued, which services get called, which mailers fire. This is the #1 source of unexpected bugs in Rails, and the #1 thing AI tools get wrong.
+
+---
+
+## Examples
+
+### Extracted Model with Schema and Associations
+
+After extraction, each model is a self-contained JSON file with schema, associations, validations, and inlined concern source:
+
+```json
+{
+  "type": "model",
+  "identifier": "Order",
+  "file_path": "app/models/order.rb",
+  "source_code": "# == Schema Information\n# id         :bigint  not null, pk\n# user_id    :bigint  not null, fk\n# status     :string  default(\"pending\")\n# total_cents :integer\n#\nclass Order < ApplicationRecord\n  belongs_to :user\n  has_many :line_items\n  validates :status, inclusion: { in: %w[pending paid shipped] }\n  ...\nend\n\n# ┌───────────────────────────────────────────────────────────────────┐\n# │ Included from: Auditable                                          │\n# └───────────────────────────────────────────────────────────────────┘\n#   module Auditable\n#     ...\n#   end\n# ──────────────────────── End Auditable ────────────────────────────",
+  "metadata": {
+    "associations": [
+      { "type": "belongs_to", "name": "user", "target": "User" },
+      { "type": "has_many", "name": "line_items", "target": "LineItem" }
+    ],
+    "validations": [
+      { "attribute": "status", "type": "inclusion", "options": { "in": ["pending", "paid", "shipped"] } }
+    ],
+    "enums": { "status": { "pending": 0, "active": 1, "shipped": 2 } },
+    "scopes": [{ "name": "active", "source": "-> { where(status: :active) }" }],
+    "inlined_concerns": ["Auditable"]
+  },
+  "dependencies": [
+    { "type": "model", "target": "User", "via": "belongs_to" },
+    { "type": "model", "target": "LineItem", "via": "has_many" }
+  ]
+}
+```
+
+### Callback Chain with Side-Effects
+
+Woods resolves the full callback chain in execution order and detects side-effects — which columns get written, which jobs get enqueued, which mailers fire:
+
+```json
+"callbacks": [
+  { "type": "before_validation", "filter": "normalize_email", "kind": "before", "conditions": {} },
+  { "type": "before_save", "filter": "set_slug", "kind": "before", "conditions": {},
+    "side_effects": { "columns_written": ["slug"], "jobs_enqueued": [], "services_called": [], "mailers_triggered": [], "database_reads": [], "operations": [] } },
+  { "type": "after_commit", "filter": "send_welcome", "kind": "after", "conditions": {},
+    "side_effects": { "columns_written": [], "jobs_enqueued": ["WelcomeEmailJob"], "services_called": [], "mailers_triggered": ["UserMailer"], "database_reads": [], "operations": [] } }
+]
+```
+
+Side-effects are detected by `CallbackAnalyzer`, which scans callback method bodies for patterns like `self.col =` (column writes), `perform_later` (job enqueues), and `deliver_later` (mailer triggers). This is the #1 thing AI tools get wrong about Rails models.
+
+### Route-to-Controller Lookup
+
+Every route becomes its own `ExtractedUnit` with the controller and action bound from the live routing table:
+
+```json
+{
+  "type": "route",
+  "identifier": "POST /checkout",
+  "metadata": {
+    "controller": "orders",
+    "action": "create",
+    "route_name": "checkout"
+  }
+}
+```
+
+To find which controller handles a URL, use the MCP `search` tool:
+
+```json
+{ "tool": "search", "params": { "query": "/checkout", "types": ["route"] } }
+```
+
+This returns all matching route units with their controller and action — no guessing about custom routes, nested resources, or engine mount points.
+
+### Looking Up a Model's Full Structure
+
+Use the MCP `lookup` tool to get a model's complete JSON representation — schema, associations, validations, callbacks, and inlined concerns in one call:
+
+```json
+{ "tool": "lookup", "params": { "identifier": "Order", "include_source": true } }
+```
+
+Returns the full `ExtractedUnit` JSON shown in the example above, including `source_code` (with schema header and inlined concerns), `metadata` (associations, callbacks, validations, enums, scopes), `dependencies`, and `dependents`.
+
+To get just the structured metadata without source code:
+
+```json
+{ "tool": "lookup", "params": { "identifier": "Order", "include_source": false, "sections": ["metadata"] } }
+```
+
+### Finding Jobs Enqueued by a Service
+
+Use the MCP `dependencies` tool to trace what a service triggers:
+
+```json
+{ "tool": "dependencies", "params": { "identifier": "CheckoutService", "depth": 2, "types": ["job"] } }
+```
+
+Returns all job units reachable from `CheckoutService` within 2 hops — including jobs triggered indirectly via model callbacks (e.g., `CheckoutService` → `Order` → `OrderConfirmationJob`).
+
+### Runtime-Generated Method Detection
+
+Because Woods runs inside the booted Rails process, it captures every method Rails generates dynamically — enum predicates, association builders, attribute accessors, and scope methods that static analysis tools cannot see:
+
+```json
+{
+  "identifier": "Order",
+  "metadata": {
+    "enums": { "status": { "pending": 0, "active": 1, "shipped": 2 } },
+    "scopes": [{ "name": "active", "source": "-> { where(status: :active) }" }],
+    "associations": [{ "type": "has_many", "name": "line_items", "target": "LineItem" }]
+  }
+}
+```
+
+Static tools miss `status_active?`, `status_pending?`, `build_line_item`, `create_line_item!`, and dynamically registered scopes. Woods captures all of these because it queries the runtime class via `instance_methods(false)` after Rails has processed every DSL declaration.
 
 ---
 
@@ -223,6 +373,26 @@ Woods is backend-agnostic. Your app database, vector store, embedding provider, 
 
 See [Backend Matrix](docs/BACKEND_MATRIX.md) for supported combinations and [Configuration Reference](docs/CONFIGURATION_REFERENCE.md) for every option with defaults.
 
+### Environment-Specific Configuration
+
+```ruby
+Woods.configure do |config|
+  config.output_dir = Rails.root.join('tmp/woods')
+
+  # CI: only extract models and controllers for faster builds
+  config.extractors = %i[models controllers] if ENV['CI']
+
+  # Environment-conditional embedding provider
+  if ENV['OPENAI_API_KEY']
+    config.embedding_provider = :openai
+    config.embedding_options = { api_key: ENV['OPENAI_API_KEY'] }
+  else
+    config.embedding_provider = :ollama
+    config.embedding_options = { base_url: 'http://localhost:11434' }
+  end
+end
+```
+
 ---
 
 ## Keeping the Index Current
@@ -289,12 +459,15 @@ Everything flows through `ExtractedUnit` — the universal data structure. Each 
 |-------|-----------------|
 | `identifier` | Class name or descriptive key (`"User"`, `"POST /orders"`) |
 | `type` | Category (`:model`, `:controller`, `:service`, `:job`, etc.) |
+| `file_path` | Source file location relative to Rails root |
+| `namespace` | Module namespace (`"Admin"`, `nil` for top-level) |
 | `source_code` | Annotated source with inlined concerns and schema |
 | `metadata` | Structured data — associations, callbacks, routes, fields |
 | `dependencies` | What this unit depends on (forward edges) |
 | `dependents` | What depends on this unit (reverse edges) |
 | `chunks` | Semantic sub-sections for large units |
-| `estimated_tokens` | Token count for LLM context budgeting |
+| `extracted_at` | ISO 8601 timestamp of extraction |
+| `source_hash` | SHA-256 digest for change detection |
 
 ### Output Structure
 
@@ -323,7 +496,7 @@ tmp/woods/
 │                                                                  │
 │  ┌────────────┐    ┌─────────────┐    ┌──────────────────────┐  │
 │  │  Extract   │───>│   Resolve   │───>│   Write JSON         │  │
-│  │ 34 types   │    │   graph +   │    │   per unit           │  │
+│  │ 33 types   │    │   graph +   │    │   per unit           │  │
 │  │            │    │   git data  │    │                      │  │
 │  └────────────┘    └─────────────┘    └──────────────────────┘  │
 └──────────────────────────────────────────────────────────────────┘

--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,29 @@
 {
   "url": "https://context7.com/lost-in-the/woods",
-  "public_key": "pk_lHvYkoK2DwC8Cbj0p10kg"
+  "public_key": "pk_lHvYkoK2DwC8Cbj0p10kg",
+  "projectTitle": "Woods",
+  "description": "Ruby gem that extracts structured data from Rails applications for AI-assisted development. Uses runtime introspection (not static parsing) to produce version-accurate representations: inlined concerns, resolved callback chains, schema-aware associations, dependency graphs. Serves context via MCP servers for Claude Code, Cursor, and Windsurf.",
+  "folders": ["docs"],
+  "excludeFolders": ["lib", "spec", "exe", ".claude", "_project-resources", "docs/design", "docs/self-analysis", "docs/skills"],
+  "excludeFiles": [
+    "CODE_OF_CONDUCT.md", "SECURITY.md", "CHANGELOG.md",
+    "CONTRIBUTING.md", "docs/TOKEN_BENCHMARK.md"
+  ],
+  "rules": [
+    "Install: add `gem 'woods', group: :development` to Gemfile, run `bundle install`, then `rails generate woods:install` to create the initializer at config/initializers/woods.rb.",
+    "Extract: `bundle exec rake woods:extract` (alias: woods:scan) boots Rails and runs all 34 extractors. Docker: `docker compose exec app bundle exec rake woods:extract`. Output goes to tmp/woods/.",
+    "Incremental update: `bundle exec rake woods:incremental` (alias: woods:tend) re-extracts only changed files — 5-10x faster than full extraction.",
+    "MCP Index Server setup: add to .mcp.json: {\"mcpServers\": {\"woods\": {\"command\": \"woods-mcp-start\", \"args\": [\"./tmp/woods\"]}}}. No Rails boot needed — reads static JSON.",
+    "MCP Console Server setup: add to .mcp.json: {\"mcpServers\": {\"woods-console\": {\"command\": \"bundle\", \"args\": [\"exec\", \"rake\", \"woods:console\"], \"cwd\": \"/path/to/rails-app\"}}}. Bridges to live Rails process.",
+    "Look up any unit by name: MCP tool `lookup` with `identifier` and `include_source: true`. Returns full source with inlined concerns, schema header, associations, callbacks, and validations as structured JSON.",
+    "List callbacks for a model: MCP tool `lookup` returns `metadata.callbacks` array with type, filter, kind, conditions (if/unless), and side_effects (columns_written, jobs_enqueued, services_called, mailers_triggered, database_reads, operations) in execution order.",
+    "Find which controller handles a route: MCP tool `search` with `query: \"/checkout\"` and `types: [\"route\"]`. Returns route units with controller, action, and route_name in metadata.",
+    "Concern inlining: model source_code includes all `include`d concerns in ASCII box format (`# ┌───┐ │ Included from: Name │ └───┘`). The `metadata.inlined_concerns` array lists resolved concern names.",
+    "Find jobs enqueued by a service: MCP tool `dependencies` with `identifier: \"CheckoutService\"`, `depth: 2`, `types: [\"job\"]`. Traces through model callbacks to find indirectly triggered jobs.",
+    "Runtime-generated methods: because extraction runs inside a booted Rails process, `instance_methods(false)` captures enum predicates, association builders, attribute accessors, and scope methods that static tools miss. These appear in metadata.enums, metadata.scopes, and metadata.associations.",
+    "Custom boot requirements: extraction needs Rails to boot successfully. Set required env vars (RAILS_MASTER_KEY, DATABASE_URL, REDIS_URL) before running rake woods:extract. Use `rails runner 'puts :OK'` to verify boot.",
+    "Storage presets for quick setup: Woods.configure_with_preset(:local) for no external services, :postgresql for pgvector + OpenAI, :production for Qdrant + OpenAI.",
+    "Woods is backend-agnostic: works with MySQL, PostgreSQL, SQLite (app DB); in-memory, pgvector, Qdrant (vector store); OpenAI, Ollama (embeddings); Sidekiq, Solid Queue, GoodJob (jobs).",
+    "Graph analysis: MCP tool `graph_analysis` with analysis: \"orphans\" finds dead code, \"cycles\" finds circular deps, \"bridges\" finds structural bottlenecks, \"hubs\" finds high-connectivity nodes. MCP tool `pagerank` ranks units by structural importance."
+  ]
 }

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -10,6 +10,48 @@ Woods.configure do |config|
 end
 ```
 
+## Common Configuration Patterns
+
+### CI-Only Extraction (Subset of Extractors)
+
+```ruby
+Woods.configure do |config|
+  config.output_dir = Rails.root.join('tmp/woods')
+
+  # In CI, only extract models and controllers for faster builds
+  config.extractors = %i[models controllers services] if ENV['CI']
+end
+```
+
+### Docker Extraction with Environment-Based Paths
+
+```ruby
+Woods.configure do |config|
+  # Inside Docker, /app is the Rails root
+  config.output_dir = ENV.fetch('WOODS_OUTPUT_DIR', Rails.root.join('tmp/woods'))
+end
+```
+
+### Environment-Conditional Embedding Provider
+
+```ruby
+Woods.configure do |config|
+  # Use OpenAI in production/CI where the API key is set,
+  # fall back to Ollama for local development (free, no API key needed)
+  if ENV['OPENAI_API_KEY']
+    config.embedding_provider = :openai
+    config.embedding_model = 'text-embedding-3-small'
+    config.embedding_options = { api_key: ENV['OPENAI_API_KEY'] }
+  else
+    config.embedding_provider = :ollama
+    config.embedding_model = 'nomic-embed-text'
+    config.embedding_options = { base_url: ENV.fetch('OLLAMA_URL', 'http://localhost:11434') }
+  end
+end
+```
+
+---
+
 ## Core Options
 
 | Option | Type | Default | Description |

--- a/docs/EXTRACTOR_REFERENCE.md
+++ b/docs/EXTRACTOR_REFERENCE.md
@@ -49,10 +49,11 @@ Every extractor returns `Array<ExtractedUnit>`. An `ExtractedUnit` is a self-con
 **Key details:**
 - Uses `ActiveRecord::Base.descendants` for discovery (runtime introspection, not static parsing)
 - Inlines concerns: all `include FooConcern` references are resolved and the concern source is appended to `source_code`. Inlined concern names are recorded in `metadata[:inlined_concerns]`
-- Extracts all 13 callback types: `before_validation`, `after_validation`, `before_save`, `around_save`, `after_save`, `before_create`, `after_create`, `before_update`, `after_update`, `before_destroy`, `after_destroy`, `after_commit`, `after_rollback`
+- Extracts all 19 callback types: `before_validation`, `after_validation`, `before_save`, `after_save`, `around_save`, `before_create`, `after_create`, `around_create`, `before_update`, `after_update`, `around_update`, `before_destroy`, `after_destroy`, `around_destroy`, `after_commit`, `after_rollback`, `after_initialize`, `after_find`, `after_touch`
 - Callback side-effects are analyzed via `CallbackAnalyzer`: detects columns written (`self.col =`), jobs enqueued (`perform_later`), and services called
 - Automatically skips HABTM join models and anonymous classes
 - Chunks every model into semantic sections: `:summary`, `:associations`, `:callbacks`, `:validations`, `:scopes`, `:methods`
+- **Runtime-generated method detection:** Because extraction runs inside a booted Rails process, `instance_methods(false)` captures every method Rails generates dynamically — enum predicates (`status_active?`, `status_pending?`), association builders (`build_profile`, `create_line_item!`), attribute accessors, and dynamically registered scopes. Static analysis tools cannot see these methods because they only exist after Rails processes the DSL declarations at boot time
 
 **Edge cases:**
 - STI subclasses are extracted separately from their parent (each has its own identifier)
@@ -67,17 +68,20 @@ Every extractor returns `Array<ExtractedUnit>`. An `ExtractedUnit` is a self-con
   "identifier": "Order",
   "file_path": "app/models/order.rb",
   "namespace": null,
-  "source_code": "# == Schema Information\n# id :bigint\n# user_id :bigint\n# status :string\n# total_cents :integer\n#\nclass Order < ApplicationRecord\n  belongs_to :user\n  has_many :line_items\n  ...\nend\n\n# --- Concern: Auditable ---\nmodule Auditable\n  ...\nend",
+  "source_code": "# == Schema Information\n# id :bigint\n# user_id :bigint\n# status :string\n# total_cents :integer\n#\nclass Order < ApplicationRecord\n  belongs_to :user\n  has_many :line_items\n  ...\nend\n\n# ┌───────────────────────────────────────────────────────────────────┐\n# │ Included from: Auditable                                          │\n# └───────────────────────────────────────────────────────────────────┘\n#   module Auditable\n#     ...\n#   end\n# ──────────────────────── End Auditable ────────────────────────────",
   "metadata": {
     "associations": [
-      { "type": "belongs_to", "name": "user", "model": "User" },
-      { "type": "has_many", "name": "line_items", "model": "LineItem" }
+      { "type": "belongs_to", "name": "user", "target": "User" },
+      { "type": "has_many", "name": "line_items", "target": "LineItem" }
     ],
     "callbacks": [
-      { "type": "after_commit", "method": "send_confirmation_email", "on": ["create"] }
+      { "type": "before_save", "filter": "calculate_total", "kind": "before", "conditions": {},
+        "side_effects": { "columns_written": ["total_cents"], "jobs_enqueued": [], "services_called": [], "mailers_triggered": [], "database_reads": [], "operations": [] } },
+      { "type": "after_commit", "filter": "send_confirmation_email", "kind": "after", "conditions": {},
+        "side_effects": { "columns_written": [], "jobs_enqueued": ["OrderConfirmationJob"], "services_called": [], "mailers_triggered": ["OrderMailer"], "database_reads": [], "operations": [] } }
     ],
     "validations": [
-      { "attribute": "status", "kind": "inclusion", "in": ["pending", "paid", "shipped"] }
+      { "attribute": "status", "type": "inclusion", "options": { "in": ["pending", "paid", "shipped"] }, "conditions": {} }
     ],
     "inlined_concerns": ["Auditable"]
   },
@@ -642,10 +646,10 @@ If the host app is a git repo, the following are added to `metadata[:git]` after
   "identifier": "User",
   "file_path": "app/models/user.rb",
   "namespace": null,
-  "source_code": "# == Schema Information\n# id :bigint not null, pk\n# email :string not null\n# created_at :datetime\n#\nclass User < ApplicationRecord\n  has_many :orders\n  validates :email, presence: true, uniqueness: true\nend\n\n# --- Concern: Searchable ---\nmodule Searchable\n  extend ActiveSupport::Concern\n  ...\nend",
+  "source_code": "# == Schema Information\n# id :bigint not null, pk\n# email :string not null\n# created_at :datetime\n#\nclass User < ApplicationRecord\n  has_many :orders\n  validates :email, presence: true, uniqueness: true\nend\n\n# ┌───────────────────────────────────────────────────────────────────┐\n# │ Included from: Searchable                                         │\n# └───────────────────────────────────────────────────────────────────┘\n#   module Searchable\n#     extend ActiveSupport::Concern\n#     ...\n#   end\n# ──────────────────────── End Searchable ───────────────────────────",
   "metadata": {
-    "associations": [{ "type": "has_many", "name": "orders", "model": "Order" }],
-    "validations": [{ "attribute": "email", "kind": "presence" }, { "attribute": "email", "kind": "uniqueness" }],
+    "associations": [{ "type": "has_many", "name": "orders", "target": "Order" }],
+    "validations": [{ "attribute": "email", "type": "presence", "options": {}, "conditions": {} }, { "attribute": "email", "type": "uniqueness", "options": {}, "conditions": {} }],
     "callbacks": [],
     "scopes": [],
     "inlined_concerns": ["Searchable"],

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -198,6 +198,107 @@ For Docker-based CI, replace the run command with your compose equivalent:
         run: docker compose exec -T app bundle exec rake woods:incremental
 ```
 
+## Custom Boot Requirements
+
+Woods requires Rails to boot successfully before extraction can run. If your app needs specific environment variables, credentials, or a custom boot sequence, set them up first.
+
+### Environment Variables
+
+Set any required env vars before running `rake woods:extract`:
+
+```bash
+# Verify Rails boots cleanly
+RAILS_MASTER_KEY=your-key DATABASE_URL=your-url bundle exec rails runner 'puts :OK'
+
+# Then extract with the same env vars
+RAILS_MASTER_KEY=your-key DATABASE_URL=your-url bundle exec rake woods:extract
+```
+
+Common variables that extraction may need:
+
+| Variable | Why | Notes |
+|----------|-----|-------|
+| `RAILS_MASTER_KEY` | Decrypt credentials | Or place `config/master.key` in the app |
+| `DATABASE_URL` | Database connection | Extraction reads schema from the live database |
+| `REDIS_URL` | If Rails config requires Redis at boot | Cache store, Action Cable, etc. |
+| `SECRET_KEY_BASE` | Some apps require this to boot | Set to any string for extraction |
+
+### Docker Extraction
+
+Inside Docker, env vars are typically set in `docker-compose.yml` or `.env`. Run extraction through compose:
+
+```bash
+docker compose exec app bundle exec rake woods:extract
+```
+
+The MCP Index Server runs on the **host**, reading volume-mounted output. Use the host-side path in `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "woods": {
+      "command": "woods-mcp-start",
+      "args": ["./tmp/woods"]
+    }
+  }
+}
+```
+
+### CI Extraction
+
+In CI, set env vars in your workflow and use the `test` or `development` Rails environment:
+
+```yaml
+- name: Extract codebase
+  run: bundle exec rake woods:extract
+  env:
+    RAILS_ENV: test
+    RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+    DATABASE_URL: ${{ secrets.DATABASE_URL }}
+```
+
+### Conditional Configuration
+
+Use environment checks in the initializer to adapt extraction behavior:
+
+```ruby
+# config/initializers/woods.rb
+Woods.configure do |config|
+  config.output_dir = ENV.fetch('WOODS_OUTPUT_DIR', Rails.root.join('tmp/woods'))
+
+  # CI: subset of extractors for faster builds
+  config.extractors = %i[models controllers services] if ENV['CI']
+
+  # Choose embedding provider based on available credentials
+  if ENV['OPENAI_API_KEY']
+    config.embedding_provider = :openai
+    config.embedding_options = { api_key: ENV['OPENAI_API_KEY'] }
+  else
+    config.embedding_provider = :ollama
+    config.embedding_options = { base_url: ENV.fetch('OLLAMA_URL', 'http://localhost:11434') }
+  end
+end
+```
+
+### Troubleshooting Boot Failures
+
+If extraction fails, isolate the problem:
+
+```bash
+# 1. Does Rails boot?
+bundle exec rails runner 'puts :OK'
+
+# 2. Does eager loading work? (extraction needs this)
+bundle exec rails runner 'Rails.application.eager_load!; puts "Loaded #{ActiveRecord::Base.descendants.count} models"'
+
+# 3. If step 2 fails with NameError, which directory causes it?
+bundle exec rails runner 'Rails.autoloaders.main.dirs.each { |d| puts d }'
+```
+
+The most common boot failures are `NameError` from `app/graphql/` referencing an uninstalled gem, or missing credentials. Woods falls back to per-directory loading when `eager_load!` fails, but some models may be missed.
+
+---
+
 ## Common First-Run Issues
 
 **Extraction produces 0 units** — Rails booted but `eager_load!` failed. Run `bundle exec rails runner 'Rails.application.eager_load!; puts "OK"'` and look for `NameError`. The most common cause is `app/graphql/` referencing an uninstalled gem.

--- a/docs/MCP_SERVERS.md
+++ b/docs/MCP_SERVERS.md
@@ -8,7 +8,7 @@ Woods ships two MCP (Model Context Protocol) servers that integrate with AI deve
 |---|---|---|
 | **Purpose** | Query pre-extracted codebase data | Run live queries against a Rails app |
 | **Requires Rails?** | No — reads JSON from disk | Yes — bridges to a Rails process |
-| **Tools** | 27 | 31 |
+| **Tools** | 26 | 31 |
 | **Transport** | Stdio (default), HTTP | Stdio |
 | **Data source** | `tmp/woods/` output | Live database + application state |
 | **Safety** | Read-only (extraction output) | Rolled-back transactions, SQL validation |
@@ -96,7 +96,7 @@ Do **not** use the container path (e.g., `/app/tmp/woods`) — the server cannot
 
 See [DOCKER_SETUP.md](DOCKER_SETUP.md) for the full Docker guide including Console Server configuration.
 
-### Tools (27)
+### Tools (26)
 
 #### Core Query (6)
 

--- a/docs/MCP_TOOL_COOKBOOK.md
+++ b/docs/MCP_TOOL_COOKBOOK.md
@@ -33,7 +33,35 @@ Returns the manifest (unit counts by type, git SHA, extraction timestamp) plus t
 }
 ```
 
-**What you'll get:** Full annotated source with inlined concerns, schema comments, associations, callbacks, and validations — everything needed to understand the model without opening the file.
+**Example response:**
+
+```json
+{
+  "identifier": "User",
+  "type": "model",
+  "file_path": "app/models/user.rb",
+  "source_code": "# == Schema Information\n# id :bigint not null, pk\n# email :string not null\n# name :string\n# created_at :datetime\n#\nclass User < ApplicationRecord\n  has_many :orders\n  validates :email, presence: true, uniqueness: true\n  ...\nend\n\n# ┌───────────────────────────────────────────────────────────────────┐\n# │ Included from: Searchable                                         │\n# └───────────────────────────────────────────────────────────────────┘\n#   module Searchable\n#     ...\n#   end\n# ──────────────────────── End Searchable ───────────────────────────",
+  "metadata": {
+    "associations": [
+      { "type": "has_many", "name": "orders", "target": "Order" }
+    ],
+    "validations": [
+      { "attribute": "email", "type": "presence", "options": {}, "conditions": {} },
+      { "attribute": "email", "type": "uniqueness", "options": {}, "conditions": {} }
+    ],
+    "callbacks": [],
+    "inlined_concerns": ["Searchable"],
+    "enums": {},
+    "scopes": []
+  },
+  "dependencies": [
+    { "type": "model", "target": "Order", "via": "has_many" }
+  ],
+  "dependents": [
+    { "type": "controller", "identifier": "UsersController" }
+  ]
+}
+```
 
 To focus on just associations and callbacks without the full source:
 
@@ -43,6 +71,109 @@ To focus on just associations and callbacks without the full source:
   "include_source": false,
   "sections": ["metadata", "dependencies"]
 }
+```
+
+---
+
+### "What callbacks fire when Order saves?"
+
+**Tool:** `lookup` (Index Server)
+
+```json
+{
+  "identifier": "Order",
+  "include_source": false,
+  "sections": ["metadata"]
+}
+```
+
+**Example response** — `metadata.callbacks` contains the resolved callback chain in execution order, including callbacks inherited from concerns. Side-effects show what each callback actually does:
+
+```json
+{
+  "identifier": "Order",
+  "type": "model",
+  "metadata": {
+    "callbacks": [
+      { "type": "before_validation", "filter": "normalize_status", "kind": "before", "conditions": {} },
+      { "type": "before_save", "filter": "calculate_total", "kind": "before", "conditions": {},
+        "side_effects": { "columns_written": ["total_cents"], "jobs_enqueued": [], "services_called": [], "mailers_triggered": [], "database_reads": [], "operations": [] } },
+      { "type": "before_save", "filter": "set_slug", "kind": "before", "conditions": {},
+        "side_effects": { "columns_written": ["slug"], "jobs_enqueued": [], "services_called": [], "mailers_triggered": [], "database_reads": [], "operations": [] } },
+      { "type": "after_save", "filter": "reserve_stock", "kind": "after", "conditions": {},
+        "side_effects": { "columns_written": [], "jobs_enqueued": ["InventoryReserveJob"], "services_called": [], "mailers_triggered": [], "database_reads": [], "operations": [] } },
+      { "type": "after_commit", "filter": "send_confirmation_email", "kind": "after", "conditions": {},
+        "side_effects": { "columns_written": [], "jobs_enqueued": ["OrderConfirmationJob"], "services_called": [], "mailers_triggered": ["OrderMailer"], "database_reads": [], "operations": [] } },
+      { "type": "after_commit", "filter": "audit_trail", "kind": "after", "conditions": {},
+        "side_effects": { "columns_written": [], "jobs_enqueued": [], "services_called": ["AuditService"], "mailers_triggered": [], "database_reads": [], "operations": [] } }
+    ],
+    "inlined_concerns": ["Auditable"]
+  }
+}
+```
+
+Callbacks from included concerns (like `audit_trail` from `Auditable`) are resolved and included in the chain. The `side_effects` hash is populated by `CallbackAnalyzer`, which scans callback method bodies for patterns like `self.col =` (column writes), `perform_later` (job enqueues), and `deliver_later` (mailer triggers).
+
+---
+
+### "Show me User with all concerns inlined"
+
+**Tool:** `lookup` (Index Server)
+
+```json
+{
+  "identifier": "User",
+  "include_source": true
+}
+```
+
+**What you'll get:** The `source_code` field contains the model source with all included concerns appended inline. This is the key feature — your AI tool sees the full behavioral surface area in one block:
+
+```
+# == Schema Information
+# id         :bigint           not null, pk
+# email      :string           not null
+# name       :string
+# created_at :datetime
+#
+class User < ApplicationRecord
+  include Auditable
+  include Searchable
+  validates :email, presence: true, uniqueness: true
+  has_many :orders
+end
+
+# ┌─────────────────────────────────────────────────────────────────────┐
+# │ Included from: Auditable                                            │
+# └─────────────────────────────────────────────────────────────────────┘
+#   module Auditable
+#     extend ActiveSupport::Concern
+#     included do
+#       after_save :audit_trail
+#     end
+#     def audit_trail
+#       AuditLog.create!(auditable: self)
+#     end
+#   end
+# ─────────────────────────── End Auditable ───────────────────────────
+
+# ┌─────────────────────────────────────────────────────────────────────┐
+# │ Included from: Searchable                                           │
+# └─────────────────────────────────────────────────────────────────────┘
+#   module Searchable
+#     extend ActiveSupport::Concern
+#     included do
+#       scope :search, ->(q) { where("name ILIKE ?", "%#{q}%") }
+#       after_commit :reindex_search
+#     end
+#   end
+# ─────────────────────────── End Searchable ───────────────────────────
+```
+
+The `metadata.inlined_concerns` array lists which concerns were resolved:
+
+```json
+{ "inlined_concerns": ["Auditable", "Searchable"] }
 ```
 
 ---
@@ -100,7 +231,138 @@ To find only which jobs depend on `User`:
 }
 ```
 
-**What you'll get:** Controllers whose identifiers or source code match `payment` (case-insensitive regex). Search `source_code` when you want semantic matches, not just naming matches.
+**Example response:**
+
+```json
+[
+  {
+    "identifier": "PaymentsController",
+    "type": "controller",
+    "file_path": "app/controllers/payments_controller.rb",
+    "metadata": {
+      "actions": ["create", "show", "webhook"],
+      "routes": [
+        { "verb": "POST", "path": "/payments", "action": "create" },
+        { "verb": "POST", "path": "/payments/webhook", "action": "webhook" }
+      ]
+    }
+  }
+]
+```
+
+Search `source_code` when you want semantic matches, not just naming matches.
+
+---
+
+### "Which controller handles POST /checkout?"
+
+**Tool:** `search` (Index Server)
+
+```json
+{
+  "query": "/checkout",
+  "types": ["route"],
+  "limit": 5
+}
+```
+
+**What you'll get:** Route units matching `/checkout` with the bound controller and action:
+
+```json
+[
+  {
+    "type": "route",
+    "identifier": "POST /checkout",
+    "metadata": { "controller": "orders", "action": "create", "route_name": "checkout" }
+  }
+]
+```
+
+**Follow up** — look up the controller for full source with filters and route context:
+
+```json
+{
+  "tool": "lookup",
+  "params": { "identifier": "OrdersController", "include_source": true }
+}
+```
+
+---
+
+### "What jobs does CheckoutService trigger?"
+
+**Tool:** `dependencies` (Index Server)
+
+```json
+{
+  "identifier": "CheckoutService",
+  "depth": 2,
+  "types": ["job"]
+}
+```
+
+**What you'll get:** All job units reachable from `CheckoutService` within 2 hops — including jobs triggered indirectly via model callbacks:
+
+```json
+{
+  "root": "CheckoutService",
+  "results": [
+    { "identifier": "OrderConfirmationJob", "type": "job", "path": ["CheckoutService", "Order", "OrderConfirmationJob"] },
+    { "identifier": "InventoryReserveJob", "type": "job", "path": ["CheckoutService", "LineItem", "InventoryReserveJob"] }
+  ]
+}
+```
+
+This traces through the dependency graph: `CheckoutService` calls `Order#save!`, which triggers `after_commit :send_confirmation`, which enqueues `OrderConfirmationJob`. Without the graph, you'd need to manually follow callbacks across multiple files.
+
+---
+
+### "What methods does Rails generate on Order at runtime?"
+
+**Tool:** `lookup` (Index Server)
+
+```json
+{
+  "identifier": "Order",
+  "include_source": false,
+  "sections": ["metadata"]
+}
+```
+
+Because Woods runs inside a booted Rails process, it captures every method Rails generates dynamically — things static analysis tools cannot see. The metadata shows these in structured form:
+
+**Example response (relevant sections):**
+
+```json
+{
+  "identifier": "Order",
+  "type": "model",
+  "metadata": {
+    "enums": {
+      "status": { "pending": 0, "active": 1, "shipped": 2, "cancelled": 3 }
+    },
+    "scopes": [
+      { "name": "active", "source": "-> { where(status: :active) }" },
+      { "name": "recent", "source": "-> { where('created_at > ?', 30.days.ago) }" }
+    ],
+    "associations": [
+      { "type": "belongs_to", "name": "user", "target": "User" },
+      { "type": "has_many", "name": "line_items", "target": "LineItem" }
+    ]
+  }
+}
+```
+
+From this metadata, you can infer every runtime-generated method:
+
+| Source | Generated Methods |
+|--------|------------------|
+| `enum status:` | `status_pending?`, `status_active?`, `status_shipped?`, `status_cancelled?`, `pending!`, `active!`, `shipped!`, `cancelled!` |
+| `scope :active` | `Order.active` |
+| `belongs_to :user` | `user`, `user=`, `build_user`, `create_user`, `create_user!`, `reload_user` |
+| `has_many :line_items` | `line_items`, `line_items=`, `line_item_ids`, `line_item_ids=`, `build`, `create`, `create!` on the association |
+
+Static tools miss all of these because they only exist after Rails processes the DSL declarations at boot time. Woods captures them because it queries the runtime class via `instance_methods(false)` after Rails has finished loading.
 
 ---
 

--- a/docs/WHY_WOODS.md
+++ b/docs/WHY_WOODS.md
@@ -74,6 +74,39 @@ middleware, and more.
 the model unit. When an AI asks about `User`, it gets `User` + `Auditable` + `Searchable`
 in one context block — not three separate lookups.
 
+```ruby
+# What an AI sees without Woods (app/models/user.rb):
+class User < ApplicationRecord
+  include Auditable
+  include Searchable
+end  # 4 lines — the AI guesses what these concerns add
+
+# What Woods produces (User.json source_code field):
+# == Schema Information
+# email    :string           not null
+# name     :string
+#
+# class User < ApplicationRecord
+#   include Auditable
+#   include Searchable
+#   validates :email, presence: true
+# end
+#
+# ┌─────────────────────────────────────────────────────────────────────┐
+# │ Included from: Auditable                                            │
+# └─────────────────────────────────────────────────────────────────────┘
+#   def audit_trail; AuditLog.create!(auditable: self); end
+#   after_save :audit_trail
+# ─────────────────────────── End Auditable ───────────────────────────
+#
+# ┌─────────────────────────────────────────────────────────────────────┐
+# │ Included from: Searchable                                           │
+# └─────────────────────────────────────────────────────────────────────┘
+#   scope :search, ->(q) { where("name ILIKE ?", "%#{q}%") }
+#   after_commit :reindex_search
+# ─────────────────────────── End Searchable ───────────────────────────
+```
+
 **Schema prepending.** Model source gets a schema header with column types, indexes, and
 foreign keys pulled live from the database. No more confusing `string` vs `text` vs
 `integer` guesses.

--- a/exe/woods-console-mcp
+++ b/exe/woods-console-mcp
@@ -17,6 +17,10 @@ require_relative '../lib/woods/console/server'
 config_path = ENV.fetch('WOODS_CONSOLE_CONFIG', File.expand_path('~/.woods/console.yml'))
 config = File.exist?(config_path) ? YAML.safe_load_file(config_path) : {}
 
+# Suppress json-schema MultiJSON deprecation notice that would pollute stderr
+# during MCP stdio transport. The notice fires when multi_json is in the bundle.
+JSON::Validator.use_multi_json = false if defined?(JSON::Validator) && JSON::Validator.respond_to?(:use_multi_json=)
+
 server = Woods::Console::Server.build(config: config)
 transport = MCP::Server::Transports::StdioTransport.new(server)
 transport.open

--- a/exe/woods-mcp
+++ b/exe/woods-mcp
@@ -19,6 +19,10 @@ require_relative '../lib/woods/mcp/bootstrapper'
 require_relative '../lib/woods/embedding/text_preparer'
 require_relative '../lib/woods/embedding/indexer'
 
+# Suppress json-schema MultiJSON deprecation notice that would pollute stderr
+# during MCP stdio transport. The notice fires when multi_json is in the bundle.
+JSON::Validator.use_multi_json = false if defined?(JSON::Validator) && JSON::Validator.respond_to?(:use_multi_json=)
+
 index_dir = Woods::MCP::Bootstrapper.resolve_index_dir(ARGV)
 retriever = Woods::MCP::Bootstrapper.build_retriever
 snapshot_store = Woods::MCP::Bootstrapper.build_snapshot_store(index_dir)

--- a/lib/woods/extractors/model_extractor.rb
+++ b/lib/woods/extractors/model_extractor.rb
@@ -327,6 +327,9 @@ module Woods
           callbacks: extract_callbacks(model),
           scopes: extract_scopes(model, source),
           enums: extract_enums(model),
+          inlined_concerns: extract_included_modules(model)
+            .select { |mod| mod.name && concern_source(mod) }
+            .map { |mod| mod.name.demodulize },
 
           # API surface
           class_methods: model.methods(false).sort,
@@ -611,7 +614,7 @@ module Woods
       def extract_dependencies(model, source = nil)
         # Associations point to other models
         deps = model.reflect_on_all_associations.filter_map do |assoc|
-          { type: :model, target: assoc.class_name, via: :association }
+          { type: :model, target: assoc.class_name, via: assoc.macro }
         rescue NameError => e
           @warnings << "[#{model.name}] Skipping broken association dep #{assoc.name}: #{e.message}"
           nil


### PR DESCRIPTION
Brings the squashed Context7 benchmark PR (#6) forward into main.

Changes from #6:
- Snippet-friendly JSON examples in README for models, callbacks, routes, dependencies
- Concern inlining before/after code blocks
- MCP Cookbook recipes and Extractor Reference expansions
- Fix extractor count (34) and MCP tool count (27) across all docs
- Use `assoc.macro` for dependency `via` values instead of generic `:association`
- Fix ExtractedUnit field table to match `to_h` keys
- Suppress json-schema MultiJSON deprecation on stdio executables