### PR TITLE
Add Unblocked exporter, domain clusters, and bug fixes

### DIFF
--- a/lib/woods/graph_analyzer.rb
+++ b/lib/woods/graph_analyzer.rb
@@ -307,11 +307,10 @@ module Woods
         # Find which other cluster this one connects to most
         target = find_merge_target(cluster, clusters, name)
 
-        if target
-          clusters[target][:members].concat(cluster[:members])
-          cluster[:members].each { |id| clusters[target][:member_set].add(id) }
-        end
+        break unless target
 
+        clusters[target][:members].concat(cluster[:members])
+        cluster[:members].each { |id| clusters[target][:member_set].add(id) }
         clusters.delete(name)
       end
     end

--- a/lib/woods/mcp/renderers/markdown_renderer.rb
+++ b/lib/woods/mcp/renderers/markdown_renderer.rb
@@ -147,7 +147,9 @@ module Woods
             lines << "### #{section.tr('_', ' ').capitalize}"
             lines << ''
             items.each do |item|
-              lines << if item.is_a?(Hash)
+              lines << if item.is_a?(Hash) && item.key?('score')
+                         "- **#{item['identifier']}** (#{item['type']}) — score: #{item['score']}"
+                       elsif item.is_a?(Hash)
                          "- **#{item['identifier']}** (#{item['type']}) — #{item['dependent_count']} dependents"
                        else
                          "- #{item}"

--- a/lib/woods/unblocked/client.rb
+++ b/lib/woods/unblocked/client.rb
@@ -118,7 +118,7 @@ module Woods
           http.request(req)
         rescue Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET, Errno::ECONNREFUSED => e
           attempts += 1
-          raise Woods::Error, "Network error after #{attempts} retries: #{e.message}" if attempts >= MAX_RETRIES
+          raise Woods::Error, "Network error after #{attempts} retries: #{e.message}" if attempts > MAX_RETRIES
 
           sleep(2**attempts)
           retry

--- a/lib/woods/unblocked/exporter.rb
+++ b/lib/woods/unblocked/exporter.rb
@@ -51,7 +51,7 @@ module Woods
         api_token = config.unblocked_api_token
         raise ConfigurationError, 'unblocked_api_token is required' unless api_token
 
-        budget = ENV.fetch('UNBLOCKED_DAILY_BUDGET', RateLimiter::DEFAULT_BUDGET).to_i
+        budget = ENV.fetch('UNBLOCKED_DAILY_BUDGET', RateLimiter::DEFAULT_BUDGET.to_s).to_i
         limiter = RateLimiter.new(daily_budget: budget)
 
         @client = client || Client.new(api_token: api_token, rate_limiter: limiter)

--- a/spec/graph_analyzer_spec.rb
+++ b/spec/graph_analyzer_spec.rb
@@ -184,4 +184,107 @@ RSpec.describe Woods::GraphAnalyzer do
       expect(stats).to have_key(:cycle_count)
     end
   end
+
+  describe '#domain_clusters' do
+    it 'groups namespaced units into clusters' do
+      graph.register(make_unit(type: :model, identifier: 'Order::Item'))
+      graph.register(make_unit(type: :model, identifier: 'Order::Payment'))
+      graph.register(make_unit(type: :model, identifier: 'Order::Refund'))
+      graph.register(make_unit(type: :model, identifier: 'Shipping::Label'))
+      graph.register(make_unit(type: :model, identifier: 'Shipping::Rate'))
+      graph.register(make_unit(type: :model, identifier: 'Shipping::Carrier'))
+
+      clusters = analyzer.domain_clusters(min_size: 2)
+      names = clusters.map { |c| c[:name] }
+
+      expect(names).to contain_exactly('Order', 'Shipping')
+    end
+
+    it 'returns enriched cluster hashes with expected keys' do
+      graph.register(make_unit(type: :model, identifier: 'Order::Item'))
+      graph.register(make_unit(type: :model, identifier: 'Order::Payment'))
+      graph.register(make_unit(type: :model, identifier: 'Order::Refund'))
+
+      clusters = analyzer.domain_clusters(min_size: 2)
+      cluster = clusters.first
+
+      expect(cluster).to have_key(:name)
+      expect(cluster).to have_key(:hub)
+      expect(cluster).to have_key(:members)
+      expect(cluster).to have_key(:member_count)
+      expect(cluster).to have_key(:entry_points)
+      expect(cluster).to have_key(:boundary_edges)
+      expect(cluster).to have_key(:types)
+      expect(cluster).not_to have_key(:member_set)
+    end
+
+    it 'assigns unnamespaced units to their most-connected cluster' do
+      graph.register(make_unit(type: :model, identifier: 'Order::Item'))
+      graph.register(make_unit(type: :model, identifier: 'Order::Payment'))
+      graph.register(make_unit(type: :model, identifier: 'Order::Refund'))
+      graph.register(make_unit(type: :service, identifier: 'Checkout',
+                               dependencies: [{ type: :model, target: 'Order::Item' },
+                                              { type: :model, target: 'Order::Payment' }]))
+
+      clusters = analyzer.domain_clusters(min_size: 2)
+      order_cluster = clusters.find { |c| c[:name] == 'Order' }
+
+      expect(order_cluster[:members]).to include('Checkout')
+    end
+
+    it 'filters by types when specified' do
+      graph.register(make_unit(type: :model, identifier: 'Order::Item'))
+      graph.register(make_unit(type: :service, identifier: 'Order::Sync'))
+      graph.register(make_unit(type: :model, identifier: 'Order::Payment'))
+
+      clusters = analyzer.domain_clusters(min_size: 2, types: ['model'])
+      order_cluster = clusters.find { |c| c[:name] == 'Order' }
+
+      expect(order_cluster[:members]).to contain_exactly('Order::Item', 'Order::Payment')
+    end
+
+    it 'returns empty for empty graph' do
+      expect(analyzer.domain_clusters).to eq([])
+    end
+
+    it 'preserves disconnected small clusters when no merge target exists' do
+      # Two disconnected components, both below min_size
+      graph.register(make_unit(type: :model, identifier: 'Alpha::One'))
+      graph.register(make_unit(type: :model, identifier: 'Beta::One'))
+
+      clusters = analyzer.domain_clusters(min_size: 3)
+      names = clusters.map { |c| c[:name] }
+
+      # Both should survive — neither should be silently dropped
+      expect(names).to contain_exactly('Alpha', 'Beta')
+    end
+
+    it 'merges small clusters into connected neighbors' do
+      graph.register(make_unit(type: :model, identifier: 'Order::Item'))
+      graph.register(make_unit(type: :model, identifier: 'Order::Payment'))
+      graph.register(make_unit(type: :model, identifier: 'Order::Refund'))
+      graph.register(make_unit(type: :model, identifier: 'Tax::Calculator',
+                               dependencies: [{ type: :model, target: 'Order::Item' }]))
+
+      clusters = analyzer.domain_clusters(min_size: 2)
+      names = clusters.map { |c| c[:name] }
+
+      # Tax has only 1 member but connects to Order, so it should merge
+      expect(names).to include('Order')
+      expect(names).not_to include('Tax')
+    end
+
+    it 'sorts clusters by member count descending' do
+      graph.register(make_unit(type: :model, identifier: 'Small::One'))
+      graph.register(make_unit(type: :model, identifier: 'Small::Two'))
+      graph.register(make_unit(type: :model, identifier: 'Big::One'))
+      graph.register(make_unit(type: :model, identifier: 'Big::Two'))
+      graph.register(make_unit(type: :model, identifier: 'Big::Three'))
+
+      clusters = analyzer.domain_clusters(min_size: 2)
+      counts = clusters.map { |c| c[:member_count] }
+
+      expect(counts).to eq(counts.sort.reverse)
+    end
+  end
 end

--- a/spec/mcp/server_spec.rb
+++ b/spec/mcp/server_spec.rb
@@ -263,6 +263,36 @@ RSpec.describe Woods::MCP::Server do
     end
   end
 
+  describe 'tool: domain_clusters' do
+    it 'returns clusters from the graph' do
+      response = call_tool(server, 'domain_clusters')
+      data = parse_response(response)
+      expect(data).to have_key('clusters')
+      expect(data).to have_key('total')
+      expect(data['clusters']).to be_an(Array)
+    end
+
+    it 'respects min_size parameter' do
+      response = call_tool(server, 'domain_clusters', min_size: 100)
+      data = parse_response(response)
+      # With a very high min_size, all clusters should still be present
+      # (disconnected clusters are preserved, not dropped)
+      expect(data['clusters']).to be_an(Array)
+    end
+
+    it 'coerces string min_size' do
+      response = call_tool(server, 'domain_clusters', min_size: '3')
+      data = parse_response(response)
+      expect(data['clusters']).to be_an(Array)
+    end
+
+    it 'filters by types' do
+      response = call_tool(server, 'domain_clusters', types: ['model'])
+      data = parse_response(response)
+      expect(data['clusters']).to be_an(Array)
+    end
+  end
+
   describe 'tool: pagerank' do
     it 'returns ranked nodes with scores' do
       response = call_tool(server, 'pagerank')


### PR DESCRIPTION
## Summary

- **Unblocked Documents API exporter** — Client, DocumentBuilder, Exporter, RateLimiter for syncing extracted units to Unblocked's knowledge base
- **Domain cluster detection** — `GraphAnalyzer#domain_clusters` groups units by namespace + graph connectivity; exposed as MCP tool (28 tools total)
- **Bug fixes** — retry off-by-one in Unblocked client, silent data loss in cluster merging, bridge rendering in MarkdownRenderer
- **Test coverage** — 12 new specs for domain_clusters (GraphAnalyzer + MCP server)
- **Dependency updates** — rubocop-rspec ~> 3.9, actions/checkout 6.0.2, ruby/setup-ruby 1.295.0, softprops/action-gh-release 2.6.1
- Version bump to 1.2.0

## Test plan

- [ ] `bundle exec rake spec` passes (3332 examples, 0 failures)
- [ ] `bundle exec rubocop` clean
- [ ] CI green on Ruby 3.0–3.3
- [ ] Verify domain_clusters MCP tool returns expected cluster shape in a host app
- [ ] Verify Unblocked exporter with a valid API token in a host app