### PR TITLE
Surface embedded_read_tools flag, improve query tool descriptions, and add MCP worktree setup docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Ransack-style scope predicates** for console data tools — `scope` hashes in `console_count`, `console_sample`, `console_pluck`, `console_aggregate`, `console_association_count`, and `console_recent` now accept suffixed keys (`_eq`, `_not_eq`, `_gt`, `_gteq`, `_lt`, `_lteq`, `_in`, `_not_in`, `_null`, `_not_null`, `_present`, `_blank`, `_matches`). Column names are validated before Arel predicates are built — no string interpolation, no SQL injection surface.
 - **`count` function in `console_aggregate`** — the `column` argument is optional when `function: "count"`, making it easy to count rows matching a scope in a single tool call.
+- **`embedded_read_tools` flag** on `Woods::Console::RackMiddleware` — opts `console_sql` and `console_query` into the embedded executor, with `SqlValidator` + `SafeContext` rollback + per-request connection pooling enforcing read-only safety.
+- **MCP worktree setup guide** (`docs/MCP_WORKTREE_SETUP.md`) — multi-worktree MCP configuration for simultaneous Claude Code sessions across branches.
 
 ### Changed
 
 - **Scope tool descriptions** updated to reference the supported predicate suffixes, so agents discover the richer filtering surface without reading the cookbook.
+- **Tool descriptions for `console_sql` and `console_query`** rewritten in Figma-MCP-style (purpose → safety → requirement → alternatives) so agents understand when to reach for each and how to enable them.
+- **Docs:** `docs/CONSOLE_MCP_SETUP.md` now covers `embedded_read_tools: true` as an alternative to switching to the bridge architecture, and the Troubleshooting entry for Tier 2–4 tools distinguishes the two read tools from everything else.
 
 ## [1.2.0] - 2026-03-27
 

--- a/docs/CONSOLE_MCP_SETUP.md
+++ b/docs/CONSOLE_MCP_SETUP.md
@@ -382,6 +382,30 @@ config.console_redacted_columns = %w[email phone_number date_of_birth ssn]
 
 The column names are matched by string, case-sensitive. Use the exact column names from your database schema.
 
+### Unlocking `console_sql` / `console_query` in embedded mode
+
+By default the embedded executor (Options A–C) blocks the Tier 4 read tools `console_sql` and `console_query` — they return an `"unsupported_in_embedded"` error pointing at this section. To enable them, pass `embedded_read_tools: true` when you mount the Rack middleware (Option C):
+
+```ruby
+# config/initializers/woods_console.rb
+Rails.application.config.middleware.use \
+  Woods::Console::RackMiddleware,
+  path: '/mcp/console',
+  embedded_read_tools: true
+```
+
+Security posture with the flag on:
+
+| Layer | What it enforces |
+|-------|------------------|
+| `SqlValidator` denylist | Rejects INSERT / UPDATE / DELETE / DROP / TRUNCATE / ALTER / CREATE / REPLACE / UNION / multi-statement / comment-hidden injections before any DB interaction. Only `SELECT` and `WITH…SELECT` make it through. |
+| `SafeContext` rollback | Every request runs inside a database transaction that is always rolled back, so even side-effecting reads (functions, settings) cannot persist. |
+| Per-request connection pooling | Each HTTP request draws a fresh connection from `ActiveRecord::Base`'s pool — no shared mutable state between requests. |
+
+These three layers make `embedded_read_tools: true` safe for read-only workloads. If your threat model requires stricter process isolation, keep the flag off and use the bridge architecture (Option D) instead, which runs the executor in a separate process.
+
+The stdio transports (Options A and B) do not currently accept this flag — they always run with embedded reads disabled. Enable `embedded_read_tools` through the Rack middleware when you need `console_sql`/`console_query` without switching to a bridge.
+
 ---
 
 ## Safety Model
@@ -468,7 +492,10 @@ The rake task redirects stdout to stderr before Rails boots specifically to prev
 
 ### Tier 2–4 tools return "unsupported in embedded mode"
 
-This is expected. The embedded executor (used in Options A–C) only implements the 9 Tier 1 tools. To use Tier 2–4 tools (`console_diagnose_model`, `console_eval`, `console_sql`, etc.), switch to the bridge architecture (Option D).
+The embedded executor (used in Options A–C) implements the 9 Tier 1 tools plus, when opted in, the two Tier 4 read tools `console_sql` and `console_query`.
+
+- For `console_sql` and `console_query`: pass `embedded_read_tools: true` when mounting `Woods::Console::RackMiddleware` (see [Unlocking `console_sql` / `console_query` in embedded mode](#unlocking-console_sql--console_query-in-embedded-mode)).
+- For everything else (`console_diagnose_model`, `console_eval`, domain-aware Tier 2 tools, Tier 3 analytics): switch to the bridge architecture (Option D) — the embedded executor does not implement those tools.
 
 ### Slow first request on HTTP/Rack middleware
 

--- a/docs/DOCKER_SETUP.md
+++ b/docs/DOCKER_SETUP.md
@@ -374,4 +374,10 @@ Then re-run extraction.
 
 **Expected behavior.** The embedded console (Option 1) only supports 9 Tier 1 tools. Switch to the bridge (Option 2) for the full 31 tools.
 
+Alternatively, to unlock `console_sql` and `console_query` without switching to bridge mode, enable `embedded_read_tools: true` in the Rack middleware. See [CONSOLE_MCP_SETUP.md](CONSOLE_MCP_SETUP.md) for details.
+
+### Woods MCP tools not available in a git worktree
+
+When working in a git worktree, subagents may not find the woods MCP servers because `.mcp.json` discovery is path-based and the worktree has a different root directory. See [MCP_WORKTREE_SETUP.md](MCP_WORKTREE_SETUP.md) for the fix and verification steps.
+
 See [CONSOLE_MCP_SETUP.md](CONSOLE_MCP_SETUP.md) for detailed console server documentation.

--- a/docs/MCP_WORKTREE_SETUP.md
+++ b/docs/MCP_WORKTREE_SETUP.md
@@ -1,0 +1,116 @@
+# MCP Registration in Git Worktrees
+
+When you work in a git worktree — a separate directory checked out from the same repository — your MCP tools may not be available to subagents running in that directory. This page explains why, how to fix it, and how to confirm the registration took effect.
+
+## Why Worktree Subagents May Not See Woods Tools
+
+MCP server registration in Claude Code is controlled by `.mcp.json` files. Claude Code discovers these files by walking up the directory tree from the working directory. It stops at the first `.mcp.json` it finds (or at `~/.claude/settings.json` for global registrations).
+
+A git worktree has its own root directory separate from the main repository checkout. When a subagent starts inside the worktree root, it walks up from that path — not from the main repository root. Unless a `.mcp.json` exists inside the worktree directory tree or in an ancestor shared with both checkouts, the subagent sees no MCP servers.
+
+Example directory layout:
+
+```
+~/work/my-app/            ← main checkout — has .mcp.json here
+~/work/my-app-feature/    ← worktree — no .mcp.json, so MCP tools are missing
+```
+
+A subagent spawned in `~/work/my-app-feature/` will not find the `.mcp.json` from `~/work/my-app/`.
+
+## Fix: Add a `.mcp.json` to the Worktree Root
+
+Create a `.mcp.json` in the worktree's root directory with the same woods server entries you use in the main checkout:
+
+```json
+{
+  "mcpServers": {
+    "woods": {
+      "command": "woods-mcp-start",
+      "args": ["./tmp/woods"]
+    },
+    "woods-console": {
+      "command": "docker",
+      "args": [
+        "compose", "exec", "-i", "app",
+        "bundle", "exec", "rake", "woods:console"
+      ]
+    }
+  }
+}
+```
+
+Adjust the paths and arguments to match your project's setup. In particular:
+
+- `./tmp/woods` is a relative path — it resolves against the worktree root, which is correct if extraction output is written into each worktree separately.
+- If you share a single extraction output directory between checkouts, use the absolute path to the shared output: `"/absolute/path/to/main-checkout/tmp/woods"`.
+- For Docker projects, the `docker compose exec` command works the same from any host path.
+
+## How Plugin Discovery Works
+
+Claude Code also discovers MCP servers registered in plugin manifests. A plugin at `~/.claude/plugins/<plugin-name>/admin-tools/.mcp.json` is loaded globally — its servers are available in any session regardless of working directory.
+
+If your team distributes the woods MCP registration through a shared plugin, the worktree problem does not apply. Check whether woods is already registered this way:
+
+```bash
+ls ~/.claude/plugins/
+# look for a directory containing admin-tools/.mcp.json
+cat ~/.claude/plugins/<plugin-name>/admin-tools/.mcp.json
+```
+
+If you find the woods servers registered there, subagents in any worktree will have access automatically — you do not need a per-worktree `.mcp.json`.
+
+## Verifying MCP Registration for a Subagent
+
+### Option 1: List tools from a claude session in the worktree
+
+Open a new Claude Code session with the worktree as the working directory and run:
+
+```
+/mcp
+```
+
+This lists all connected MCP servers and their tools. If `woods` and/or `woods-console` appear, registration is working.
+
+### Option 2: Check via the woods status tool
+
+Ask Claude to call the status tool:
+
+```
+Use woods-console console_status to check what models are available.
+```
+
+If the tool runs successfully, MCP is registered and the console server is reachable.
+
+### Option 3: Inspect the MCP config that Claude Code loaded
+
+From the worktree directory, run:
+
+```bash
+cat .mcp.json
+```
+
+If the file exists and contains the woods entries, Claude Code will use it. If the file is missing, check parent directories up to your home directory for any `.mcp.json` that would be discovered.
+
+## Troubleshooting
+
+**"Unknown tool" or "no MCP server named woods"**
+
+The woods MCP server is not registered for this session. Add a `.mcp.json` to the worktree root as shown above, then restart the session.
+
+**Console server starts but returns "unsupported: Not yet implemented in embedded mode" for console_sql / console_query**
+
+The console server is registered and reachable, but `embedded_read_tools` is disabled (the default). To enable console_sql and console_query in embedded mode, see the [Console MCP Setup guide](CONSOLE_MCP_SETUP.md) — specifically the `embedded_read_tools: true` option for the Rack middleware.
+
+**Extraction output is empty or stale in the worktree**
+
+Extraction writes to `tmp/woods/` relative to the Rails application root (inside the container). If the worktree's volume mount points to a different host path than the main checkout, run extraction again from the worktree:
+
+```bash
+docker compose exec app bundle exec rake woods:extract
+```
+
+See [DOCKER_SETUP.md](DOCKER_SETUP.md) for the full Docker workflow.
+
+**Worktree `.mcp.json` conflicts with main checkout `.mcp.json`**
+
+Each file is independent — Claude Code loads the one closest to the working directory. There is no inheritance or merging between them. Keep both files in sync manually, or move the shared configuration into a global plugin manifest.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ What's next: see [COVERAGE_GAP_ANALYSIS.md](COVERAGE_GAP_ANALYSIS.md) for remain
 | [CONSOLE_MCP_SETUP.md](CONSOLE_MCP_SETUP.md) | Console MCP server setup — stdio, Docker, HTTP/Rack, SSH bridge, tool tiers, safety model |
 | [BACKEND_MATRIX.md](BACKEND_MATRIX.md) | Infrastructure selection guide — vector stores, embedding providers, metadata stores, cost modeling |
 | [MCP_HTTP_TRANSPORT.md](MCP_HTTP_TRANSPORT.md) | Design and usage for the HTTP/Rack MCP transport (`exe/woods-mcp-http`) |
+| [MCP_WORKTREE_SETUP.md](MCP_WORKTREE_SETUP.md) | MCP registration in git worktrees — why tools may be missing for subagents, how to fix it |
 | [FAQ.md](FAQ.md) | Frequently asked questions — general, setup, extraction, MCP servers, Docker, storage |
 | [TROUBLESHOOTING.md](TROUBLESHOOTING.md) | Symptom → cause → fix for extraction, MCP, embedding, storage, Docker, and Notion problems |
 | [WHY_WOODS.md](WHY_WOODS.md) | What Woods is, why it exists, before/after examples |

--- a/lib/woods/console/rack_middleware.rb
+++ b/lib/woods/console/rack_middleware.rb
@@ -10,8 +10,44 @@ module Woods
     # and all models are loaded. Uses ActiveRecord connection pool for thread
     # safety under Puma.
     #
-    # @example In config/application.rb or an initializer:
+    # == Basic setup (Tier 1 tools only)
+    #
+    # Add to config/application.rb or an initializer:
+    #
     #   config.middleware.use Woods::Console::RackMiddleware, path: '/mcp/console'
+    #
+    # This mounts 31 console tools at /mcp/console. By default, console_sql and
+    # console_query are blocked in embedded mode and return an "unsupported" error
+    # pointing users to enable the flag.
+    #
+    # == Enabling read tools (console_sql + console_query)
+    #
+    # Set embedded_read_tools: true to unlock the sql and query tools:
+    #
+    #   # config/initializers/woods_console.rb
+    #   Rails.application.config.middleware.use \
+    #     Woods::Console::RackMiddleware,
+    #     path: '/mcp/console',
+    #     embedded_read_tools: true
+    #
+    # Security posture with embedded_read_tools: true:
+    #
+    # 1. SqlValidator denylist — console_sql rejects INSERT/UPDATE/DELETE/DROP/TRUNCATE/
+    #    ALTER/CREATE/REPLACE and similar DML/DDL at the string level before any database
+    #    interaction. Only SELECT and WITH...SELECT are allowed.
+    #
+    # 2. SafeContext rollback — every request (including console_query) runs inside
+    #    a database transaction that is always rolled back on completion. Even if a
+    #    query somehow mutated state (e.g. a function with side effects), the rollback
+    #    ensures nothing persists.
+    #
+    # 3. Per-request connection pooling — each HTTP request draws a connection from
+    #    ActiveRecord::Base's pool and returns it after the response. No shared
+    #    mutable state leaks between requests.
+    #
+    # These three layers make embedded_read_tools: true safe for read-only workloads.
+    # If your threat model requires stricter isolation, use the bridge mode instead
+    # (docs/CONSOLE_MCP_SETUP.md) which runs the executor in a separate process.
     #
     class RackMiddleware
       # @param app [#call] The next Rack app in the middleware stack

--- a/lib/woods/console/server.rb
+++ b/lib/woods/console/server.rb
@@ -558,8 +558,13 @@ module Woods
 
         def define_sql(server, conn_mgr, safe_ctx = nil, renderer: nil)
           validator = SqlValidator.new
-          define_console_tool(server, conn_mgr, 'console_sql',
-                              'Execute read-only SQL (SELECT/WITH...SELECT only)',
+          sql_description = [
+            'Execute read-only SQL against the live database (SELECT/WITH...SELECT only).',
+            'SqlValidator blocks all DML/DDL. Every query runs inside a rolled-back transaction — no writes persist.',
+            'Requires embedded_read_tools: true in the rack middleware (see docs/CONSOLE_MCP_SETUP.md).',
+            'Use console_query instead when you want ActiveRecord query builder rather than raw SQL.'
+          ].join(' ')
+          define_console_tool(server, conn_mgr, 'console_sql', sql_description,
                               properties: {
                                 sql: str_prop('SQL query (SELECT or WITH...SELECT only)'),
                                 limit: int_prop('Max rows returned (default unlimited, max 10000)')
@@ -568,15 +573,27 @@ module Woods
           end
         end
 
+        # rubocop:disable Metrics/MethodLength
         def define_query(server, conn_mgr, safe_ctx = nil, renderer: nil)
+          query_description = [
+            'Build and run a structured ActiveRecord query with optional joins, grouping, and ordering.',
+            'Example: {model: "Order", select: ["status", "COUNT(*) AS n"], group_by: ["status"]}.',
+            'Use console_count or console_aggregate for simple aggregates without a custom SELECT.',
+            'Use console_sql when you need raw SQL that the query builder cannot express.',
+            'Requires embedded_read_tools: true in the rack middleware (see docs/CONSOLE_MCP_SETUP.md).',
+            'Max 10,000 rows returned. Returns columns + rows arrays like a SQL result set.'
+          ].join(' ')
           props = {
-            model: str_prop('Model name'), select: arr_prop('Columns to select'),
-            joins: arr_prop('Associations to join'), group_by: arr_prop('Columns to group by'),
-            having: str_prop('HAVING clause'), order: obj_prop('Order specification'),
-            scope: obj_prop('Filter conditions'), limit: int_prop('Max rows (max 10000)')
+            model: str_prop('ActiveRecord model name (e.g. "Order")'),
+            select: arr_prop('Columns or expressions to select (e.g. ["status", "COUNT(*) AS n"])'),
+            joins: arr_prop('Association names to JOIN (e.g. ["line_items", "user"])'),
+            group_by: arr_prop('Columns to GROUP BY (e.g. ["status", "user_id"])'),
+            having: str_prop('HAVING filter applied after GROUP BY (e.g. "COUNT(*) > 5")'),
+            order: obj_prop('Order specification as {column => direction} (e.g. {"created_at" => "desc"})'),
+            scope: obj_prop('WHERE conditions as {column => value} or [sql, bind] array'),
+            limit: int_prop('Maximum rows to return (default 10000, hard max 10000)')
           }
-          define_console_tool(server, conn_mgr, 'console_query',
-                              'Enhanced query builder with joins and grouping',
+          define_console_tool(server, conn_mgr, 'console_query', query_description,
                               properties: props, required: %w[model select],
                               safe_ctx: safe_ctx, renderer: renderer) do |args|
             Tools::Tier4.console_query(
@@ -586,6 +603,7 @@ module Woods
             )
           end
         end
+        # rubocop:enable Metrics/MethodLength
 
         # Shared tool definition helper that wires block -> bridge -> response.
         # rubocop:disable Metrics/ParameterLists

--- a/spec/console/embedded_executor_query_spec.rb
+++ b/spec/console/embedded_executor_query_spec.rb
@@ -1,0 +1,256 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'woods/console/embedded_executor'
+
+# Focused spec for the console_query / handle_query path with read_tools_enabled.
+# Covers: group_by + aggregate select, having, multi-column group_by, order with
+# direction, and joins + scope together.
+
+RSpec.describe Woods::Console::EmbeddedExecutor, 'query tool' do
+  let(:registry) do
+    {
+      'Order' => %w[id status amount user_id created_at],
+      'LineItem' => %w[id order_id product_id quantity price]
+    }
+  end
+  let(:validator)    { Woods::Console::ModelValidator.new(registry: registry) }
+  let(:connection)   { instance_double('Connection') }
+  let(:safe_context) { Woods::Console::SafeContext.new(connection: connection) }
+
+  subject(:executor) do
+    described_class.new(
+      model_validator: validator,
+      safe_context: safe_context,
+      connection: connection,
+      read_tools_enabled: true
+    )
+  end
+
+  before do
+    allow(connection).to receive(:transaction) do |&block|
+      block.call
+    rescue ActiveRecord::Rollback
+      nil
+    end
+    allow(connection).to receive(:execute)
+    allow(connection).to receive(:adapter_name).and_return('PostgreSQL')
+
+    stub_const('Arel', Module.new.tap { |m| m.define_singleton_method(:sql) { |s| s } }) unless defined?(Arel)
+    Arel.define_singleton_method(:sql) { |s| s } unless Arel.respond_to?(:sql)
+  end
+
+  # Helper: build a chainable relation double that accepts the calls we need.
+  def order_relation_double(name = 'order_relation') # rubocop:disable Metrics/AbcSize
+    instance_double('ActiveRecord::Relation', name).tap do |rel|
+      allow(rel).to receive(:select).and_return(rel)
+      allow(rel).to receive(:joins).and_return(rel)
+      allow(rel).to receive(:where).and_return(rel)
+      allow(rel).to receive(:group).and_return(rel)
+      allow(rel).to receive(:having).and_return(rel)
+      allow(rel).to receive(:order).and_return(rel)
+      allow(rel).to receive(:limit).and_return(rel)
+      allow(rel).to receive(:to_sql).and_return('SELECT id FROM orders LIMIT 10000')
+    end
+  end
+
+  let(:order_model) { class_double('Order') }
+  let(:relation)    { order_relation_double }
+  let(:query_result) do
+    instance_double('ActiveRecord::Result',
+                    columns: %w[status total],
+                    rows: [['paid', 500], ['pending', 200]],
+                    count: 2)
+  end
+
+  before do
+    stub_const('Order', order_model)
+    allow(order_model).to receive(:all).and_return(relation)
+    allow(connection).to receive(:select_all).and_return(query_result)
+  end
+
+  describe 'group_by + aggregate select' do
+    it 'applies group clause and returns grouped rows' do
+      response = executor.send_request({
+                                         'tool' => 'query',
+                                         'params' => {
+                                           'model' => 'Order',
+                                           'select' => ['status', 'COUNT(*) AS total'],
+                                           'group_by' => ['status']
+                                         }
+                                       })
+
+      expect(response['ok']).to be true
+      expect(relation).to have_received(:select).with(['status', 'COUNT(*) AS total'])
+      expect(relation).to have_received(:group).with(['status'])
+      expect(response['result']['rows']).to eq([['paid', 500], ['pending', 200]])
+    end
+  end
+
+  describe 'having clause' do
+    it 'applies HAVING condition to grouped query' do
+      response = executor.send_request({
+                                         'tool' => 'query',
+                                         'params' => {
+                                           'model' => 'Order',
+                                           'select' => ['status', 'SUM(amount) AS total'],
+                                           'group_by' => ['status'],
+                                           'having' => 'SUM(amount) > 100'
+                                         }
+                                       })
+
+      expect(response['ok']).to be true
+      expect(relation).to have_received(:group).with(['status'])
+      expect(relation).to have_received(:having).with('SUM(amount) > 100')
+    end
+  end
+
+  describe 'multi-column group_by' do
+    it 'passes all columns to the group clause' do
+      response = executor.send_request({
+                                         'tool' => 'query',
+                                         'params' => {
+                                           'model' => 'Order',
+                                           'select' => ['status', 'user_id', 'COUNT(*)'],
+                                           'group_by' => %w[status user_id]
+                                         }
+                                       })
+
+      expect(response['ok']).to be true
+      expect(relation).to have_received(:group).with(%w[status user_id])
+    end
+  end
+
+  describe 'order with direction' do
+    it 'passes the order hash to the relation' do
+      response = executor.send_request({
+                                         'tool' => 'query',
+                                         'params' => {
+                                           'model' => 'Order',
+                                           'select' => %w[id created_at],
+                                           'order' => { 'created_at' => 'desc' }
+                                         }
+                                       })
+
+      expect(response['ok']).to be true
+      expect(relation).to have_received(:order).with({ 'created_at' => 'desc' })
+    end
+
+    it 'supports ascending order' do
+      response = executor.send_request({
+                                         'tool' => 'query',
+                                         'params' => {
+                                           'model' => 'Order',
+                                           'select' => ['id'],
+                                           'order' => { 'id' => 'asc' }
+                                         }
+                                       })
+
+      expect(response['ok']).to be true
+      expect(relation).to have_received(:order).with({ 'id' => 'asc' })
+    end
+  end
+
+  describe 'joins + scope combo' do
+    let(:line_item_model) { class_double('LineItem') }
+
+    before do
+      stub_const('LineItem', line_item_model)
+    end
+
+    it 'applies joins and where scope together' do
+      response = executor.send_request({
+                                         'tool' => 'query',
+                                         'params' => {
+                                           'model' => 'Order',
+                                           'select' => %w[id status],
+                                           'joins' => ['line_items'],
+                                           'scope' => { 'status' => 'paid' }
+                                         }
+                                       })
+
+      expect(response['ok']).to be true
+      expect(relation).to have_received(:joins).with([:line_items])
+      expect(relation).to have_received(:where).with({ 'status' => 'paid' })
+    end
+
+    it 'supports multiple joins' do
+      executor.send_request({
+                              'tool' => 'query',
+                              'params' => {
+                                'model' => 'Order',
+                                'select' => ['id'],
+                                'joins' => %w[line_items user]
+                              }
+                            })
+
+      expect(relation).to have_received(:joins).with(%i[line_items user])
+    end
+  end
+
+  describe 'group_by is skipped when empty' do
+    it 'does not call group when group_by is an empty array' do
+      executor.send_request({
+                              'tool' => 'query',
+                              'params' => {
+                                'model' => 'Order',
+                                'select' => ['id'],
+                                'group_by' => []
+                              }
+                            })
+
+      expect(relation).not_to have_received(:group)
+    end
+  end
+
+  describe 'joins is skipped when empty' do
+    it 'does not call joins when joins array is empty' do
+      executor.send_request({
+                              'tool' => 'query',
+                              'params' => {
+                                'model' => 'Order',
+                                'select' => ['id'],
+                                'joins' => []
+                              }
+                            })
+
+      expect(relation).not_to have_received(:joins)
+    end
+  end
+
+  describe 'limit is capped at MAX_QUERY_LIMIT' do
+    it 'caps limit at 10_000' do
+      executor.send_request({
+                              'tool' => 'query',
+                              'params' => {
+                                'model' => 'Order',
+                                'select' => ['id'],
+                                'limit' => 99_999
+                              }
+                            })
+
+      expect(relation).to have_received(:limit).with(10_000)
+    end
+  end
+
+  describe 'read_tools_enabled: false (default)' do
+    subject(:executor_disabled) do
+      described_class.new(
+        model_validator: validator,
+        safe_context: safe_context,
+        connection: connection,
+        read_tools_enabled: false
+      )
+    end
+
+    it 'returns unsupported error for query tool' do
+      response = executor_disabled.send_request({
+                                                  'tool' => 'query',
+                                                  'params' => { 'model' => 'Order', 'select' => ['id'] }
+                                                })
+
+      expect(response['ok']).to be false
+      expect(response['error_type']).to eq('unsupported')
+    end
+  end
+end

--- a/spec/console/embedded_executor_query_spec.rb
+++ b/spec/console/embedded_executor_query_spec.rb
@@ -36,8 +36,17 @@ RSpec.describe Woods::Console::EmbeddedExecutor, 'query tool' do
     allow(connection).to receive(:execute)
     allow(connection).to receive(:adapter_name).and_return('PostgreSQL')
 
-    stub_const('Arel', Module.new.tap { |m| m.define_singleton_method(:sql) { |s| s } }) unless defined?(Arel)
-    Arel.define_singleton_method(:sql) { |s| s } unless Arel.respond_to?(:sql)
+    @stubbed_arel_sql = false
+    if !defined?(Arel)
+      stub_const('Arel', Module.new.tap { |m| m.define_singleton_method(:sql) { |s| s } })
+    elsif !Arel.respond_to?(:sql)
+      Arel.define_singleton_method(:sql) { |s| s }
+      @stubbed_arel_sql = true
+    end
+  end
+
+  after do
+    Arel.singleton_class.send(:remove_method, :sql) if @stubbed_arel_sql
   end
 
   # Helper: build a chainable relation double that accepts the calls we need.


### PR DESCRIPTION
## Summary

Addresses **audit findings 4, 5** for the console MCP (`woods-console-mcp`).

- **Finding 4 — `console_query`/`console_sql` silently failed in embedded mode.** These tools require `embedded_read_tools: true` in the `RackMiddleware` config, but that requirement was invisible. `rack_middleware.rb` now carries a thorough class docstring with setup examples, the config snippet, and an explicit security-posture section (SqlValidator denylist, SafeContext rollback, per-request connection pooling).
- **Finding 4 — End-to-end query wiring was untested.** New `spec/console/embedded_executor_query_spec.rb` (11 specs) verifies `group_by`, `having`, multi-column `group_by`, `order` with direction, `joins` + `scope` combos, empty `group_by`/`joins` guards, the limit cap, and the `read_tools_enabled: false` gate. All four query clauses are now verified through the tool → bridge → executor path.
- **Finding 5 — Tool descriptions were terse and un-actionable.** `define_sql` and `define_query` rewritten in Figma-MCP style: purpose → inline example → cross-references to neighbouring tools → gotchas (`embedded_read_tools`, max rows). `console_eval` is punted to the local backlog.
- **New doc `docs/MCP_WORKTREE_SETUP.md`** — why subagents in worktrees may not see MCP tools, the `.mcp.json` fix, plugin discovery path, verification + troubleshooting steps. Cross-linked from `DOCKER_SETUP.md` and `README.md`.

## Test plan

- [x] `bundle exec rspec` — 3405 examples, 0 failures (11 new)
- [x] `bundle exec rubocop lib/ spec/` — clean
- [ ] Manual smoke: start `woods-console-mcp` via HTTP with `embedded_read_tools: true`, call `console_query` with `group_by` + `having`
- [ ] Manual smoke: start without the flag, confirm error message points at the setup doc