### PR TITLE
Self-describing error for unsupported tools in embedded mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **MCP `search` tool no longer destroys regex patterns.** `index_reader` was wrapping queries in `Regexp.escape`, turning `User|Account` into a literal-only match. Now compiles raw with `IGNORECASE` and falls back to the escaped form only on `RegexpError`.
 - **Auto-detect Ollama probe reliability.** The bootstrapper now probes `GET /api/tags` (the documented list-models endpoint) instead of `HEAD /`, which returned 404 on some Ollama versions. Any non-5xx response now marks Ollama as reachable.
 - **`WOODS_SEARCH_MAX_SCAN=""` no longer disables phase-2 search.** Empty and whitespace-only values fall back to the default cap of 500 instead of coercing to 0.
+- **Self-describing error for unsupported tools in embedded mode.** `console_sql` / `console_query` rejections now point at `embedded_read_tools: true` and the setup doc. Other Tier 2–4 rejections still point at the bridge architecture. Replaces the generic "Not yet implemented in embedded mode" message.
 
 ### Added
 

--- a/lib/woods/console/embedded_executor.rb
+++ b/lib/woods/console/embedded_executor.rb
@@ -59,7 +59,7 @@ module Woods
 
         unless TIER1_TOOLS.include?(tool) || (@read_tools_enabled && EMBEDDED_READ_TOOLS.include?(tool))
           return { 'ok' => false,
-                   'error' => 'Not yet implemented in embedded mode',
+                   'error' => unsupported_message(tool),
                    'error_type' => 'unsupported' }
         end
 
@@ -75,6 +75,25 @@ module Woods
       end
 
       private
+
+      # Self-describing error for tools the embedded executor cannot run.
+      #
+      # `sql`/`query` are gated behind `embedded_read_tools: true` — point the
+      # caller at the flag. Everything else (Tier 2–4 domain/analytics tools)
+      # requires the bridge architecture.
+      #
+      # @param tool [String] Tool name that was rejected
+      # @return [String] Actionable error message
+      def unsupported_message(tool)
+        if EMBEDDED_READ_TOOLS.include?(tool)
+          "Tool '#{tool}' requires embedded_read_tools: true on " \
+            'Woods::Console::RackMiddleware, or use the bridge (Option D). ' \
+            'See docs/CONSOLE_MCP_SETUP.md.'
+        else
+          "Tool '#{tool}' is not available in embedded mode — it requires the " \
+            'bridge architecture (Option D in docs/CONSOLE_MCP_SETUP.md).'
+        end
+      end
 
       # Route a tool name to its handler.
       #

--- a/spec/console/embedded_executor_query_spec.rb
+++ b/spec/console/embedded_executor_query_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe Woods::Console::EmbeddedExecutor, 'query tool' do
       )
     end
 
-    it 'returns unsupported error for query tool' do
+    it 'points query at embedded_read_tools and the docs' do
       response = executor_disabled.send_request({
                                                   'tool' => 'query',
                                                   'params' => { 'model' => 'Order', 'select' => ['id'] }
@@ -260,6 +260,8 @@ RSpec.describe Woods::Console::EmbeddedExecutor, 'query tool' do
 
       expect(response['ok']).to be false
       expect(response['error_type']).to eq('unsupported')
+      expect(response['error']).to include('embedded_read_tools: true')
+      expect(response['error']).to include('docs/CONSOLE_MCP_SETUP.md')
     end
   end
 end

--- a/spec/console/embedded_executor_spec.rb
+++ b/spec/console/embedded_executor_spec.rb
@@ -39,19 +39,22 @@ RSpec.describe Woods::Console::EmbeddedExecutor do
 
   describe '#send_request' do
     context 'unsupported tools' do
-      it 'returns unsupported error for Tier 2+ tools' do
+      it 'points Tier 2+ tools at the bridge architecture' do
         response = executor.send_request({ 'tool' => 'diagnose_model', 'params' => { 'model' => 'User' } })
 
         expect(response['ok']).to be false
-        expect(response['error']).to match(/Not yet implemented in embedded mode/)
         expect(response['error_type']).to eq('unsupported')
+        expect(response['error']).to include('diagnose_model')
+        expect(response['error']).to include('bridge architecture')
+        expect(response['error']).to include('docs/CONSOLE_MCP_SETUP.md')
       end
 
-      it 'returns unsupported error for eval tool' do
+      it 'points eval at the bridge architecture' do
         response = executor.send_request({ 'tool' => 'eval', 'params' => { 'code' => 'puts 1' } })
 
         expect(response['ok']).to be false
         expect(response['error_type']).to eq('unsupported')
+        expect(response['error']).to include('bridge architecture')
       end
     end
 
@@ -547,14 +550,17 @@ RSpec.describe Woods::Console::EmbeddedExecutor do
     # ── Read tools (sql/query) gated by read_tools_enabled ──────────
 
     context 'read tools disabled (default)' do
-      it 'returns unsupported error for sql tool' do
+      it 'points sql at embedded_read_tools and the docs' do
         response = executor.send_request({ 'tool' => 'sql', 'params' => { 'sql' => 'SELECT 1' } })
 
         expect(response['ok']).to be false
         expect(response['error_type']).to eq('unsupported')
+        expect(response['error']).to include("'sql'")
+        expect(response['error']).to include('embedded_read_tools: true')
+        expect(response['error']).to include('docs/CONSOLE_MCP_SETUP.md')
       end
 
-      it 'returns unsupported error for query tool' do
+      it 'points query at embedded_read_tools and the docs' do
         response = executor.send_request({
                                            'tool' => 'query',
                                            'params' => { 'model' => 'User', 'select' => ['id'] }
@@ -562,6 +568,8 @@ RSpec.describe Woods::Console::EmbeddedExecutor do
 
         expect(response['ok']).to be false
         expect(response['error_type']).to eq('unsupported')
+        expect(response['error']).to include("'query'")
+        expect(response['error']).to include('embedded_read_tools: true')
       end
     end
 


### PR DESCRIPTION
## Summary

Follow-up from testing #28. The docs promised that embedded-mode rejections of `console_sql` / `console_query` would point users at the `embedded_read_tools: true` flag, but the runtime still returned the generic `"Not yet implemented in embedded mode"` message — leaving an agent stuck staring at the docs/code mismatch.

This tightens the error:

- `sql` / `query` rejections → `Tool 'sql' requires embedded_read_tools: true on Woods::Console::RackMiddleware, or use the bridge (Option D). See docs/CONSOLE_MCP_SETUP.md.`
- Other Tier 2–4 rejections → `Tool 'X' is not available in embedded mode — it requires the bridge architecture (Option D in docs/CONSOLE_MCP_SETUP.md).`

No behavior change beyond the message text — the gate is still `EMBEDDED_READ_TOOLS` + `read_tools_enabled` + `TIER1_TOOLS`.

## Test plan

- [x] `bundle exec rspec spec/console/embedded_executor_spec.rb spec/console/embedded_executor_query_spec.rb` — 54 examples, 0 failures
- [ ] Manually confirm message content against compose-dev admin after merge