### PR TITLE
Plumb console_embedded_read_tools through configure + stdio transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Auto-detect Ollama probe reliability.** The bootstrapper now probes `GET /api/tags` (the documented list-models endpoint) instead of `HEAD /`, which returned 404 on some Ollama versions. Any non-5xx response now marks Ollama as reachable.
 - **`WOODS_SEARCH_MAX_SCAN=""` no longer disables phase-2 search.** Empty and whitespace-only values fall back to the default cap of 500 instead of coercing to 0.
 - **Self-describing error for unsupported tools in embedded mode.** `console_sql` / `console_query` rejections now point at `embedded_read_tools: true` and the setup doc. Other Tier 2–4 rejections still point at the bridge architecture. Replaces the generic "Not yet implemented in embedded mode" message.
+- **`console_embedded_read_tools` configuration flag.** Flows through `Woods.configure` to both the Rack middleware (Option C) and the stdio transports (Options A and B) — previously only the Rack mount accepted `embedded_read_tools:` directly, so stdio deployments had no way to unlock `console_sql` / `console_query` without patching the executable.
 
 ### Added
 

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -412,6 +412,7 @@ Set these in `config/initializers/woods.rb` (created by `rails generate woods:in
 | `extract_navigation_edges` | `true` | Navigation edges (`link_to`, `redirect_to`, `form_action`) included in extraction |
 | `session_tracer_enabled` | `false` | Required for `session_trace` tool |
 | `console_redacted_columns` | `[]` | Columns hidden from Console Server results |
+| `console_embedded_read_tools` | `false` | Unlocks `console_sql` / `console_query` in embedded transports |
 
 Storage presets set vector store, metadata store, and embedding together:
 

--- a/docs/CONSOLE_MCP_SETUP.md
+++ b/docs/CONSOLE_MCP_SETUP.md
@@ -368,6 +368,11 @@ Woods.configure do |config|
   # Column names to redact from all query results. Default: [].
   # Replaced with "[REDACTED]" in output.
   config.console_redacted_columns = %w[password_digest encrypted_password api_key ssn token]
+
+  # Unlock console_sql / console_query in the embedded executor. Default: false.
+  # Flows through to the Rack middleware AND the stdio entry point (rake / rails runner).
+  # See "Unlocking console_sql / console_query in embedded mode" below.
+  config.console_embedded_read_tools = false
 end
 ```
 
@@ -384,10 +389,21 @@ The column names are matched by string, case-sensitive. Use the exact column nam
 
 ### Unlocking `console_sql` / `console_query` in embedded mode
 
-By default the embedded executor (Options A–C) blocks the Tier 4 read tools `console_sql` and `console_query` — they return an `"unsupported_in_embedded"` error pointing at this section. To enable them, pass `embedded_read_tools: true` when you mount the Rack middleware (Option C):
+By default the embedded executor (Options A–C) blocks the Tier 4 read tools `console_sql` and `console_query` — they return an `"unsupported_in_embedded"` error pointing at this section. To enable them, set `console_embedded_read_tools = true` in `Woods.configure`:
 
 ```ruby
-# config/initializers/woods_console.rb
+# config/initializers/woods.rb
+Woods.configure do |config|
+  config.console_mcp_enabled           = true     # mount the Rack middleware via Railtie
+  config.console_mcp_path              = '/mcp/console'
+  config.console_embedded_read_tools   = true     # unlock console_sql / console_query
+  config.console_redacted_columns      = %w[password_digest encrypted_password api_key token]
+end
+```
+
+This flag flows through to both the Rack middleware (Option C) and the stdio transports (Options A and B) automatically. To override per-mount (e.g., enable it on one mount but not another), pass `embedded_read_tools:` directly:
+
+```ruby
 Rails.application.config.middleware.use \
   Woods::Console::RackMiddleware,
   path: '/mcp/console',
@@ -404,7 +420,7 @@ Security posture with the flag on:
 
 These three layers make `embedded_read_tools: true` safe for read-only workloads. If your threat model requires stricter process isolation, keep the flag off and use the bridge architecture (Option D) instead, which runs the executor in a separate process.
 
-The stdio transports (Options A and B) do not currently accept this flag — they always run with embedded reads disabled. Enable `embedded_read_tools` through the Rack middleware when you need `console_sql`/`console_query` without switching to a bridge.
+All three embedded transports (Options A, B, and C) honour `console_embedded_read_tools` from `Woods.configure` — stdio rake, rails runner, and Rack middleware each read the flag at startup.
 
 ---
 

--- a/exe/woods-console
+++ b/exe/woods-console
@@ -39,16 +39,15 @@ end
 validator = Woods::Console::ModelValidator.new(registry: registry)
 safe_context = Woods::Console::SafeContext.new(connection: ActiveRecord::Base.connection)
 
-redacted_columns = if Woods.respond_to?(:configuration) && Woods.configuration
-                     Array(Woods.configuration.console_redacted_columns)
-                   else
-                     []
-                   end
+config = Woods.configuration if Woods.respond_to?(:configuration)
+redacted_columns = config ? Array(config.console_redacted_columns) : []
+read_tools_enabled = config ? config.console_embedded_read_tools : false
 
 server = Woods::Console::Server.build_embedded(
   model_validator: validator,
   safe_context: safe_context,
-  redacted_columns: redacted_columns
+  redacted_columns: redacted_columns,
+  read_tools_enabled: read_tools_enabled
 )
 
 # Restore the protocol output for MCP transport.

--- a/lib/woods.rb
+++ b/lib/woods.rb
@@ -42,6 +42,7 @@ module Woods
                   :concurrent_extraction, :precompute_flows, :extract_navigation_edges, :enable_snapshots,
                   :session_tracer_enabled, :session_store, :session_id_proc, :session_exclude_paths,
                   :console_mcp_enabled, :console_mcp_path, :console_redacted_columns,
+                  :console_embedded_read_tools,
                   :notion_api_token, :notion_database_ids,
                   :unblocked_api_token, :unblocked_collection_id, :unblocked_repo_url,
                   :cache_store, :cache_options
@@ -70,6 +71,7 @@ module Woods
       @console_mcp_enabled = false
       @console_mcp_path = '/mcp/console'
       @console_redacted_columns = []
+      @console_embedded_read_tools = false
       @notion_api_token = nil
       @notion_database_ids = {}
       @unblocked_api_token = nil

--- a/lib/woods/railtie.rb
+++ b/lib/woods/railtie.rb
@@ -30,7 +30,8 @@ module Woods
 
         app.middleware.use(
           Woods::Console::RackMiddleware,
-          path: config.console_mcp_path
+          path: config.console_mcp_path,
+          embedded_read_tools: config.console_embedded_read_tools
         )
       end
     end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -55,6 +55,25 @@ RSpec.describe Woods::Configuration do
     it 'sets session_exclude_paths to empty array' do
       expect(config.session_exclude_paths).to eq([])
     end
+
+    it 'sets console_mcp_enabled to false' do
+      expect(config.console_mcp_enabled).to eq(false)
+    end
+
+    it 'sets console_embedded_read_tools to false' do
+      expect(config.console_embedded_read_tools).to eq(false)
+    end
+
+    it 'sets console_redacted_columns to empty array' do
+      expect(config.console_redacted_columns).to eq([])
+    end
+  end
+
+  describe 'console MCP configuration' do
+    it 'allows setting console_embedded_read_tools' do
+      config.console_embedded_read_tools = true
+      expect(config.console_embedded_read_tools).to eq(true)
+    end
   end
 
   describe 'session tracer configuration' do


### PR DESCRIPTION
## Summary

Closing the gap #29 exposed: the embedded rejection error now points users at `embedded_read_tools: true` on the Rack middleware — but the stdio transports (the dominant path in compose-dev admin and any `bundle exec rake woods:console` deployment) had no way to honour that flag without patching `exe/woods-console` directly.

This adds `Woods.configuration#console_embedded_read_tools` (default `false`) and wires it through:

- `Woods::Railtie` passes it to `Woods::Console::RackMiddleware` during Rails boot.
- `exe/woods-console` reads it and passes `read_tools_enabled:` to `Server.build_embedded`.

Per-mount `embedded_read_tools:` on the middleware still works as an override — the config flag is just the default/fallback when Railtie auto-mounts or when stdio transports boot.

## Example

```ruby
# config/initializers/woods.rb
Woods.configure do |config|
  config.console_mcp_enabled          = true
  config.console_embedded_read_tools  = true
  config.console_redacted_columns     = %w[password_digest encrypted_password api_key token]
end
```

Now `console_sql` / `console_query` work across **all three** embedded transports (stdio rake, rails runner, and Rack middleware) without any monkey patching.

## Test plan

- [x] `bundle exec rspec spec/configuration_spec.rb spec/console/` — 382 examples, 0 failures
- [x] Default still `false` — verified in `configuration_spec.rb`
- [x] `CHANGELOG.md`, `docs/CONSOLE_MCP_SETUP.md`, `docs/AGENT_GUIDE.md` updated
- [ ] Manually confirm compose-dev admin can run `console_sql` after setting the flag