### PR TITLE
Document console_redacted_columns scope limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Documented `console_redacted_columns` scope limitation.** Redaction only walks the top level of a tool's result hash, so `console_sample`, `console_recent`, `console_find`, `console_pluck`, `console_sql`, and `console_query` return row data untouched even when a matching column name is configured (records are nested under `records` / `record`, or rows are positional arrays under `rows` / `values`). Affects every transport — stdio, Rack, and bridge. `docs/CONSOLE_MCP_SETUP.md` now details the affected tools and recommends treating redaction as best-effort until the fix lands. No code change in this release.
+
 ### Fixed
 
 - **MCP `search` tool no longer destroys regex patterns.** `index_reader` was wrapping queries in `Regexp.escape`, turning `User|Account` into a literal-only match. Now compiles raw with `IGNORECASE` and falls back to the escaped form only on `RegexpError`.

--- a/docs/CONSOLE_MCP_SETUP.md
+++ b/docs/CONSOLE_MCP_SETUP.md
@@ -378,14 +378,37 @@ end
 
 ### `console_redacted_columns`
 
-Redaction applies to all tool results regardless of transport. When a result hash contains a redacted column, the value is replaced with `"[REDACTED]"` before the MCP response is sent.
+Redaction replaces matching column values with `"[REDACTED]"` before the MCP response is sent. Column names are matched by string, case-sensitive — use the exact names from your database schema.
 
 ```ruby
 # Example: redact PII
 config.console_redacted_columns = %w[email phone_number date_of_birth ssn]
 ```
 
-The column names are matched by string, case-sensitive. Use the exact column names from your database schema.
+#### Known limitation: redaction scope
+
+Redaction checks only top-level hash keys, so tools whose results nest row data under another key (`records`, `record`) or expose values positionally (`rows`, `values`) bypass redaction entirely. This affects **every transport** — stdio, Rack, and the bridge architecture — because all tool output flows through the same shallow redaction pass on the server.
+
+| Tool                       | Output shape                                 | Redacted? |
+| -------------------------- | -------------------------------------------- | --------- |
+| `console_count`            | `{count: N}`                                 | n/a — no row data |
+| `console_aggregate`        | `{value: N}` / `{count: N}`                  | n/a — no row data |
+| `console_association_count`| `{count: N}`                                 | n/a — no row data |
+| `console_schema`           | `{columns: [...]}`                           | n/a — no row data |
+| `console_sample`           | `{records: [{col: val, ...}, ...]}`          | **No** — records are nested one level deep |
+| `console_recent`           | `{records: [{col: val, ...}, ...]}`          | **No** — records are nested one level deep |
+| `console_find`             | `{record: {col: val, ...}}`                  | **No** — record is nested one level deep |
+| `console_pluck`            | `{values: [[...], ...]}`                     | **No** — rows are positional arrays |
+| `console_sql`              | `{columns: [...], rows: [[...], ...]}`       | **No** — rows are positional arrays |
+| `console_query`            | `{columns: [...], rows: [[...], ...]}`       | **No** — rows are positional arrays |
+
+Until this is fixed, treat `console_redacted_columns` as **best-effort**. Assume every column reachable by `sample`, `recent`, `find`, `pluck`, `sql`, and `query` is visible to the agent in its raw form, regardless of whether the name appears in `console_redacted_columns`.
+
+Practical guidance:
+
+- Keep plaintext secrets out of database columns where possible (prefer hashed, encrypted, or vault-referenced storage).
+- Only enable `console_embedded_read_tools = true` in environments where direct table access is already an acceptable ceiling (local dev, throwaway staging).
+- For production bridge deployments, prefer agent-side deny rules on the six affected tools over relying on column-name redaction.
 
 ### Unlocking `console_sql` / `console_query` in embedded mode
 


### PR DESCRIPTION
## Summary

Documents a redaction scope limitation discovered while testing the new `console_embedded_read_tools` flag end-to-end against a host Rails app.

`console_redacted_columns` only walks the top level of a tool's result hash. Any tool whose output nests row data (under `records` / `record`) or exposes values positionally (under `rows` / `values`) bypasses redaction — the column name appears in the config, but the raw value still ships to the agent.

## Scope (verified end-to-end)

Ran every Tier 1 / Tier 4 read tool against `accounts` requesting `id, subdomain, crypted_password, salt` and applied the production redaction pipeline to the result:

| Tool | Redacted? |
| ---- | --------- |
| `console_count` / `console_aggregate` / `console_association_count` / `console_schema` | n/a — no row data |
| `console_sample` / `console_recent` / `console_find` | **No** — records nested |
| `console_pluck` / `console_sql` / `console_query` | **No** — positional rows |

Example of the leak (reproducer in commit body):

```json
{
  "record": {
    "crypted_password": "283c99f7420e8da34afbd9d0a23602d49a101f40",
    "salt": "8bba19b2c5ad8aff0274af019cefc8f25b168ddb"
  }
}
```

Affects every transport — stdio, Rack, and bridge — because all tool output runs through the same shallow `apply_redaction` pass on the server (`lib/woods/console/server.rb:169`).

## Why docs-only

A correct fix needs per-shape redaction logic (walk `records`, map positional rows against their `columns` header, etc.) plus test coverage for each tool. Shipping the warning now so operators choosing to run with `console_embedded_read_tools = true` (or any bridge deployment) know the limitation before the fix lands.

## Test plan

- [x] `CONSOLE_MCP_SETUP.md` renders cleanly on GitHub
- [x] CHANGELOG lists the Security entry under `## [Unreleased]`
- [ ] Follow-up PR will fix the redaction pass and remove the "Known limitation" section