### PR TITLE
Redact credential columns in every console tool output shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **Documented `console_redacted_columns` scope limitation.** Redaction only walks the top level of a tool's result hash, so `console_sample`, `console_recent`, `console_find`, `console_pluck`, `console_sql`, and `console_query` return row data untouched even when a matching column name is configured (records are nested under `records` / `record`, or rows are positional arrays under `rows` / `values`). Affects every transport — stdio, Rack, and bridge. `docs/CONSOLE_MCP_SETUP.md` now details the affected tools and recommends treating redaction as best-effort until the fix lands. No code change in this release.
+- **`console_redacted_columns` now covers every tool that returns row data.** Redaction previously only walked top-level hash keys, so `console_sample`, `console_recent`, `console_find`, `console_pluck`, `console_sql`, and `console_query` returned configured credential columns in the clear — records were nested under `records` / `record`, and rows were positional arrays under `rows` / `values`. The server-level redaction pass is now shape-aware: it descends into `record` / `records` hashes and uses the `columns` header to redact positional rows. `console_pluck` now also includes a `columns` field in its response so positional redaction can key off of it. Affects every transport (stdio, Rack, bridge).
 
 ### Fixed
 

--- a/docs/CONSOLE_MCP_SETUP.md
+++ b/docs/CONSOLE_MCP_SETUP.md
@@ -385,30 +385,17 @@ Redaction replaces matching column values with `"[REDACTED]"` before the MCP res
 config.console_redacted_columns = %w[email phone_number date_of_birth ssn]
 ```
 
-#### Known limitation: redaction scope
+Redaction is shape-aware and covers every tool that returns row data:
 
-Redaction checks only top-level hash keys, so tools whose results nest row data under another key (`records`, `record`) or expose values positionally (`rows`, `values`) bypass redaction entirely. This affects **every transport** — stdio, Rack, and the bridge architecture — because all tool output flows through the same shallow redaction pass on the server.
+| Tool                                  | Output shape                                              | How redaction applies |
+| ------------------------------------- | --------------------------------------------------------- | --------------------- |
+| `console_find`                        | `{record: Hash}`                                          | Redacted column keys are replaced inside the nested record |
+| `console_sample`, `console_recent`    | `{records: [Hash, ...]}`                                  | Each record hash is redacted |
+| `console_sql`, `console_query`        | `{columns: [...], rows: [[...], ...], count: N}`          | Positional — rows are redacted by matching the `columns` header |
+| `console_pluck`                       | `{columns: [...], values: [[...], ...]}` or `{values: [...]}` for a single column | Positional — multi-column rows and flat single-column arrays both covered |
+| `console_count`, `console_aggregate`, `console_association_count`, `console_schema` | No row data | Nothing to redact |
 
-| Tool                       | Output shape                                 | Redacted? |
-| -------------------------- | -------------------------------------------- | --------- |
-| `console_count`            | `{count: N}`                                 | n/a — no row data |
-| `console_aggregate`        | `{value: N}` / `{count: N}`                  | n/a — no row data |
-| `console_association_count`| `{count: N}`                                 | n/a — no row data |
-| `console_schema`           | `{columns: [...]}`                           | n/a — no row data |
-| `console_sample`           | `{records: [{col: val, ...}, ...]}`          | **No** — records are nested one level deep |
-| `console_recent`           | `{records: [{col: val, ...}, ...]}`          | **No** — records are nested one level deep |
-| `console_find`             | `{record: {col: val, ...}}`                  | **No** — record is nested one level deep |
-| `console_pluck`            | `{values: [[...], ...]}`                     | **No** — rows are positional arrays |
-| `console_sql`              | `{columns: [...], rows: [[...], ...]}`       | **No** — rows are positional arrays |
-| `console_query`            | `{columns: [...], rows: [[...], ...]}`       | **No** — rows are positional arrays |
-
-Until this is fixed, treat `console_redacted_columns` as **best-effort**. Assume every column reachable by `sample`, `recent`, `find`, `pluck`, `sql`, and `query` is visible to the agent in its raw form, regardless of whether the name appears in `console_redacted_columns`.
-
-Practical guidance:
-
-- Keep plaintext secrets out of database columns where possible (prefer hashed, encrypted, or vault-referenced storage).
-- Only enable `console_embedded_read_tools = true` in environments where direct table access is already an acceptable ceiling (local dev, throwaway staging).
-- For production bridge deployments, prefer agent-side deny rules on the six affected tools over relying on column-name redaction.
+Redaction is defense-in-depth — prefer not storing plaintext secrets in database columns in the first place — but it keeps configured credential columns out of the agent's transcript when `console_sample`, `console_find`, or the Tier 4 read tools return matching rows.
 
 ### Unlocking `console_sql` / `console_query` in embedded mode
 

--- a/lib/woods/console/bridge.rb
+++ b/lib/woods/console/bridge.rb
@@ -134,7 +134,7 @@ module Woods
 
       def handle_pluck(params)
         @model_validator.validate_columns!(params['model'], params['columns']) if params['columns']
-        { 'values' => [] }
+        { 'columns' => Array(params['columns']), 'values' => [] }
       end
 
       def handle_aggregate(params)

--- a/lib/woods/console/embedded_executor.rb
+++ b/lib/woods/console/embedded_executor.rb
@@ -164,7 +164,7 @@ module Woods
         scope = apply_scope(model, params['scope'], model_name: params['model'])
         scope = scope.distinct if params['distinct']
         values = scope.limit(limit).pluck(*columns.map(&:to_sym))
-        { 'values' => values }
+        { 'columns' => Array(columns), 'values' => values }
       end
 
       def handle_aggregate(params)

--- a/lib/woods/console/safe_context.rb
+++ b/lib/woods/console/safe_context.rb
@@ -21,6 +21,9 @@ module Woods
     #   ctx.execute { |c| c.execute("SELECT count(*) FROM users") }
     #
     class SafeContext
+      # @return [Array<String>] Column names whose values are replaced with "[REDACTED]"
+      attr_reader :redacted_columns
+
       # @param connection [Object] Database connection (or mock)
       # @param timeout_ms [Integer] Statement timeout in milliseconds
       # @param redacted_columns [Array<String>] Column names whose values should be redacted

--- a/lib/woods/console/server.rb
+++ b/lib/woods/console/server.rb
@@ -158,23 +158,90 @@ module Woods
           ::MCP::Tool::Response.new([{ type: 'text', text: "Connection error: #{e.message}" }], error: e.message)
         end
 
+        # Data-shape keys used by console tool responses. When any of these keys
+        # appear at the top of a Hash result we treat the value as row data and
+        # descend into it instead of redacting at the envelope level. Keeping
+        # this list narrow avoids accidentally recursing into schema payloads
+        # (e.g. `console_schema` returns {columns: {...}} where `columns` is a
+        # Hash of column metadata, not row values).
+        DATA_ENVELOPE_KEYS = %w[record records rows values].freeze
+        private_constant :DATA_ENVELOPE_KEYS
+
         # Apply SafeContext column redaction to a result value.
         #
-        # Handles Hash (single record) and Array<Hash> (multiple records).
-        # Non-Hash values are returned unchanged.
+        # Redaction is shape-aware:
+        #   - {record: Hash}          (find)         — redact the nested hash
+        #   - {records: [Hash]}       (sample, recent) — redact each nested hash
+        #   - {columns: [...], rows:   [[...]]}  (sql, query) — positional
+        #   - {columns: [...], values: [...|[...]]} (pluck)  — positional
+        #   - Plain Hash              — redact top-level keys
+        #   - Array<Hash>             — redact each hash
         #
-        # @param result [Object] The result from the bridge
+        # @param result [Object] The result from the bridge or embedded executor
         # @param safe_ctx [SafeContext] The context with redacted_columns configured
-        # @return [Object] Redacted result
+        # @return [Object] Redacted result, same shape as input
         def apply_redaction(result, safe_ctx)
           case result
           when Array
-            result.map { |item| item.is_a?(Hash) ? safe_ctx.redact(item) : item }
+            result.map { |item| item.is_a?(Hash) ? apply_redaction(item, safe_ctx) : item }
           when Hash
-            safe_ctx.redact(result)
+            redact_hash(result, safe_ctx)
           else
             result
           end
+        end
+
+        def redact_hash(hash, safe_ctx)
+          string_keyed = hash.transform_keys(&:to_s)
+          return safe_ctx.redact(string_keyed) unless (string_keyed.keys & DATA_ENVELOPE_KEYS).any?
+
+          mask = positional_mask(string_keyed['columns'], safe_ctx)
+          string_keyed.each_with_object({}) do |(key, value), out|
+            out[key] = redact_envelope_value(key, value, mask, safe_ctx)
+          end
+        end
+
+        def redact_envelope_value(key, value, mask, safe_ctx)
+          case key
+          when 'record'         then value.is_a?(Hash) ? safe_ctx.redact(value) : value
+          when 'records'        then redact_hash_array(value, safe_ctx)
+          when 'rows', 'values' then redact_positional(value, mask)
+          else                       value
+          end
+        end
+
+        def redact_hash_array(value, safe_ctx)
+          Array(value).map { |row| row.is_a?(Hash) ? safe_ctx.redact(row) : row }
+        end
+
+        # Precompute the positional redaction mask from a `columns` header.
+        # Returns nil when there is nothing to redact so callers can short-circuit.
+        def positional_mask(columns, safe_ctx)
+          return nil unless columns.is_a?(Array)
+
+          redacted = safe_ctx.redacted_columns
+          return nil if redacted.empty?
+
+          mask = columns.map { |name| redacted.include?(name.to_s) }
+          mask.any? ? mask : nil
+        end
+
+        # Redact positional row data using a precomputed column mask. Handles
+        # both nested arrays (multi-column pluck, sql/query rows) and flat
+        # scalar arrays (pluck with a single column — Rails collapses the
+        # result).
+        def redact_positional(rows, mask)
+          return rows if mask.nil? || !rows.is_a?(Array)
+
+          rows.map { |row| row.is_a?(Array) ? redact_row(row, mask) : redact_scalar(row, mask) }
+        end
+
+        def redact_row(row, mask)
+          row.each_with_index.map { |value, idx| mask[idx] ? '[REDACTED]' : value }
+        end
+
+        def redact_scalar(value, mask)
+          mask.first ? '[REDACTED]' : value
         end
 
         def build_console_renderer

--- a/spec/console/server_spec.rb
+++ b/spec/console/server_spec.rb
@@ -135,5 +135,102 @@ RSpec.describe Woods::Console::Server do
       redacted = described_class.send(:apply_redaction, result, safe_ctx)
       expect(redacted).to eq(42)
     end
+
+    describe 'shape-aware redaction' do
+      let(:safe_ctx) do
+        Woods::Console::SafeContext.new(
+          connection: nil,
+          redacted_columns: %w[crypted_password salt]
+        )
+      end
+
+      it 'redacts records nested under `records` (sample / recent)' do
+        result = {
+          'records' => [
+            { 'id' => 1, 'subdomain' => 'test', 'crypted_password' => 'abcdef' * 8, 'salt' => 'fedcba' * 8 },
+            { 'id' => 2, 'subdomain' => 'other', 'crypted_password' => '0123' * 10, 'salt' => '4567' * 10 }
+          ]
+        }
+        redacted = described_class.send(:apply_redaction, result, safe_ctx)
+        expect(redacted['records'].map { |r| r['crypted_password'] }).to all(eq('[REDACTED]'))
+        expect(redacted['records'].map { |r| r['salt'] }).to all(eq('[REDACTED]'))
+        expect(redacted['records'].map { |r| r['subdomain'] }).to eq(%w[test other])
+      end
+
+      it 'redacts a record nested under `record` (find)' do
+        result = {
+          'record' => { 'id' => 1, 'subdomain' => 'test', 'crypted_password' => 'deadbeef' * 5, 'salt' => 'cafe' * 10 }
+        }
+        redacted = described_class.send(:apply_redaction, result, safe_ctx)
+        expect(redacted['record']['crypted_password']).to eq('[REDACTED]')
+        expect(redacted['record']['salt']).to eq('[REDACTED]')
+        expect(redacted['record']['subdomain']).to eq('test')
+      end
+
+      it 'handles `record` with a nil value (find with no match)' do
+        result = { 'record' => nil }
+        expect(described_class.send(:apply_redaction, result, safe_ctx)).to eq('record' => nil)
+      end
+
+      it 'redacts positional rows using `columns` header (sql / query)' do
+        result = {
+          'columns' => %w[id subdomain crypted_password salt],
+          'rows' => [[1, 'test', 'abcdef' * 8, 'fedcba' * 8]],
+          'count' => 1
+        }
+        redacted = described_class.send(:apply_redaction, result, safe_ctx)
+        expect(redacted['rows']).to eq([[1, 'test', '[REDACTED]', '[REDACTED]']])
+        expect(redacted['columns']).to eq(%w[id subdomain crypted_password salt])
+        expect(redacted['count']).to eq(1)
+      end
+
+      it 'redacts positional multi-column values (pluck with multiple columns)' do
+        result = {
+          'columns' => %w[id subdomain crypted_password salt],
+          'values' => [[1, 'test', 'abcdef' * 8, 'fedcba' * 8]]
+        }
+        redacted = described_class.send(:apply_redaction, result, safe_ctx)
+        expect(redacted['values']).to eq([[1, 'test', '[REDACTED]', '[REDACTED]']])
+      end
+
+      it 'redacts a flat values array (pluck with a single redacted column)' do
+        result = {
+          'columns' => %w[crypted_password],
+          'values' => %w[aaaa bbbb cccc]
+        }
+        redacted = described_class.send(:apply_redaction, result, safe_ctx)
+        expect(redacted['values']).to eq(%w[[REDACTED] [REDACTED] [REDACTED]])
+      end
+
+      it 'leaves a flat values array untouched when the single column is not redacted' do
+        result = {
+          'columns' => %w[subdomain],
+          'values' => %w[alpha beta gamma]
+        }
+        redacted = described_class.send(:apply_redaction, result, safe_ctx)
+        expect(redacted['values']).to eq(%w[alpha beta gamma])
+      end
+
+      it 'does not treat `console_schema` output as row data' do
+        # schema returns {columns: {col_name => meta, ...}} — columns is a Hash,
+        # not an Array, and there are no row/records keys, so redaction should
+        # fall through to top-level key redaction (which is a no-op here).
+        result = {
+          'columns' => { 'id' => { 'type' => 'integer' }, 'crypted_password' => { 'type' => 'string' } }
+        }
+        redacted = described_class.send(:apply_redaction, result, safe_ctx)
+        expect(redacted).to eq(result)
+      end
+
+      it 'leaves rows untouched when no column matches the redacted list' do
+        result = {
+          'columns' => %w[id subdomain],
+          'rows' => [[1, 'test'], [2, 'other']],
+          'count' => 2
+        }
+        redacted = described_class.send(:apply_redaction, result, safe_ctx)
+        expect(redacted['rows']).to eq([[1, 'test'], [2, 'other']])
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes the redaction scope limitation documented in PR #31. `console_redacted_columns` now covers every tool that returns row data.

Six tools were leaking credential columns in the clear:

- `console_sample` / `console_recent` — `{records: [{col: val, ...}]}` — records nested one level deeper than the top-level redactor
- `console_find` — `{record: {col: val, ...}}` — same nesting issue
- `console_pluck` — `{values: [[...]]}` or `{values: [...]}` — positional data with no column key
- `console_sql` / `console_query` — `{columns: [...], rows: [[...]]}` — positional data

All six returned raw values (e.g. 40-char `crypted_password` hashes) even when the column name was listed in `console_redacted_columns`. Affected every transport — stdio, Rack, and the bridge — because all tool output runs through the same `apply_redaction` pass on the server (`lib/woods/console/server.rb`).

## Fix

- **Shape-aware `apply_redaction`.** The server now dispatches on envelope key: `record` / `records` descend into nested hashes and apply `SafeContext#redact`; `rows` / `values` build a positional mask from the sibling `columns` header and replace matching indexes with `"[REDACTED]"`. The mask is precomputed once per result.
- **`console_pluck` includes `columns` in its response.** Previously pluck returned a bare `values` array, so positional redaction had nothing to key off of. Adding `columns` is backward-compatible (consumers that only read `values` keep working) and gives the redactor the information it needs.
- **`SafeContext` exposes `redacted_columns`** via `attr_reader` so the server can build the positional mask without reaching into private state.
- **Schema payloads are unaffected.** `console_schema` returns `{columns: {col => meta}, indexes: [...]}` where `columns` is a Hash, not an Array, and there is no `records` / `rows` / `values` key. The redactor falls through to the original top-level key pass, which is a no-op for schema.

## Verification

Before the fix (from PR #31's verification run):

```
tool                  ok      redaction_leaks?
sample                yes     LEAKS
find                  yes     LEAKS
pluck                 yes     LEAKS
recent                yes     LEAKS
sql                   yes     LEAKS
query                 yes     LEAKS
count                 yes     safe
aggregate             yes     safe
association_count     yes     safe
schema                yes     safe
```

After the fix, all six leaking tools return `[REDACTED]` for `crypted_password` and `salt` columns.

New spec block in `spec/console/server_spec.rb` — `describe 'shape-aware redaction'` — covers every envelope shape plus the schema-passthrough case. Full gem suite: **3456 examples, 0 failures, 2 pending** (pendings unrelated, pre-existing).

## Test plan

- [x] `bundle exec rspec` — full suite green
- [x] `bundle exec rubocop` — 362 files, no offenses
- [x] End-to-end verification against the admin host app (pre-merge extraction)
- [x] CHANGELOG's Security entry updated from "documented limitation" to "fixed"
- [x] `docs/CONSOLE_MCP_SETUP.md` replaces the "Known limitation" section with a shape-coverage table