### PR TITLE
Render console Array values instead of collapsing to 'N items'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Console renderer no longer collapses row data to `"N items"`.** `ConsoleResponseRenderer#render_hash` was summarizing every Array-valued key to a count, which silently elided the actual data from `console_sql`, `console_query`, `console_pluck`, `console_sample`, `console_recent`, and `console_find` responses — the MCP payload carried the rows, but the rendered text agents see only named the shape. Array values now recurse through `render_array` (Array<Hash> → Markdown table, scalar array → bullet list). When `rows` or `values` appears alongside a sibling `columns` array, the renderer emits a positional Markdown table using the columns as headers so sql / query / pluck output is scannable. Metadata-shaped responses (`count`, `aggregate`, `schema`, etc.) are unchanged.
 - **MCP `search` tool no longer destroys regex patterns.** `index_reader` was wrapping queries in `Regexp.escape`, turning `User|Account` into a literal-only match. Now compiles raw with `IGNORECASE` and falls back to the escaped form only on `RegexpError`.
 - **Auto-detect Ollama probe reliability.** The bootstrapper now probes `GET /api/tags` (the documented list-models endpoint) instead of `HEAD /`, which returned 404 on some Ollama versions. Any non-5xx response now marks Ollama as reachable.
 - **`WOODS_SEARCH_MAX_SCAN=""` no longer disables phase-2 search.** Empty and whitespace-only values fall back to the default cap of 500 instead of coercing to 0.

--- a/lib/woods/console/console_response_renderer.rb
+++ b/lib/woods/console/console_response_renderer.rb
@@ -9,11 +9,19 @@ module Woods
     #
     # Auto-detects:
     # - Array<Hash> → Markdown tables
-    # - Single Hash → Key-value bullet lists
+    # - Single Hash → Key-value bullet lists (Array values recurse into tables;
+    #   `rows` / `values` paired with a sibling `columns` render as positional
+    #   Markdown tables so sql/query/pluck output isn't collapsed)
     # - Simple Array → Bullet list
     # - Scalars → Plain text
     #
     class ConsoleResponseRenderer < MCP::ToolResponseRenderer
+      # Keys that carry positional row data in tool responses. When any of
+      # these appears alongside a `columns` array we render a proper table
+      # using the columns as headers instead of dumping bracketed arrays.
+      POSITIONAL_ROW_KEYS = %w[rows values].freeze
+      private_constant :POSITIONAL_ROW_KEYS
+
       # Smart default: auto-detect data shape and render accordingly.
       #
       # @param data [Object] The bridge response result
@@ -43,26 +51,56 @@ module Woods
 
       def render_table(rows)
         keys = rows.first.keys
-        lines = []
-        lines << "| #{keys.join(' | ')} |"
-        lines << "| #{keys.map { '---' }.join(' | ')} |"
-        rows.each do |row|
-          lines << "| #{keys.map { |k| row[k] }.join(' | ')} |"
-        end
-        lines.join("\n")
+        header_row(keys) + rows.map { |row| row_line(keys.map { |k| row[k] }) }.join
       end
 
       def render_hash(data)
-        data.map do |key, value|
-          case value
-          when Hash
-            "**#{key}:**\n" + value.map { |k, v| "  - #{k}: #{v}" }.join("\n")
-          when Array
-            "**#{key}:** #{value.size} items"
-          else
-            "**#{key}:** #{value}"
-          end
-        end.join("\n")
+        columns = stringify_array(data['columns'] || data[:columns])
+        data.map { |key, value| render_hash_entry(key, value, columns) }.join("\n")
+      end
+
+      def render_hash_entry(key, value, sibling_columns)
+        case value
+        when Hash
+          "**#{key}:**\n" + value.map { |k, v| "  - #{k}: #{v}" }.join("\n")
+        when Array
+          "**#{key}:**\n" + render_hash_array_value(key, value, sibling_columns)
+        else
+          "**#{key}:** #{value}"
+        end
+      end
+
+      def render_hash_array_value(key, value, sibling_columns)
+        if POSITIONAL_ROW_KEYS.include?(key.to_s) && sibling_columns && !sibling_columns.empty?
+          render_positional_table(value, sibling_columns)
+        else
+          render_array(value)
+        end
+      end
+
+      # Build a Markdown table from positional row data + a columns header.
+      # Handles both Array<Array> (multi-column rows) and flat scalar arrays
+      # (pluck with a single column — Rails collapses the result).
+      def render_positional_table(rows, columns)
+        return '_(empty)_' if rows.empty?
+
+        header_row(columns) + rows.map { |row| row_line(positional_row_values(row)) }.join
+      end
+
+      def positional_row_values(row)
+        row.is_a?(Array) ? row : [row]
+      end
+
+      def header_row(keys)
+        "| #{keys.join(' | ')} |\n| #{keys.map { '---' }.join(' | ')} |\n"
+      end
+
+      def row_line(values)
+        "| #{values.join(' | ')} |\n"
+      end
+
+      def stringify_array(value)
+        value.is_a?(Array) ? value.map(&:to_s) : nil
       end
     end
 

--- a/spec/console/console_response_renderer_spec.rb
+++ b/spec/console/console_response_renderer_spec.rb
@@ -50,10 +50,77 @@ RSpec.describe Woods::Console::ConsoleResponseRenderer do
       expect(result).to include('  - other: x')
     end
 
-    it 'renders Hash with Array values as item count' do
-      data = { 'items' => [1, 2, 3] }
+    it 'renders Hash with a scalar Array value as a bullet list' do
+      data = { 'items' => %w[one two three] }
       result = renderer.render_default(data)
-      expect(result).to include('**items:** 3 items')
+      expect(result).to include('**items:**')
+      expect(result).to include('- one')
+      expect(result).to include('- two')
+      expect(result).to include('- three')
+    end
+
+    it 'renders Hash with an Array<Hash> value as a Markdown table' do
+      data = { 'records' => [{ 'id' => 1, 'name' => 'Alice' }, { 'id' => 2, 'name' => 'Bob' }] }
+      result = renderer.render_default(data)
+      expect(result).to include('**records:**')
+      expect(result).to include('| id | name |')
+      expect(result).to include('| --- | --- |')
+      expect(result).to include('| 1 | Alice |')
+      expect(result).to include('| 2 | Bob |')
+    end
+
+    it 'renders positional rows as a table using sibling `columns` as headers (sql / query)' do
+      data = {
+        'columns' => %w[id subdomain crypted_password],
+        'rows' => [[1, 'test', '[REDACTED]'], [2, 'other', '[REDACTED]']],
+        'count' => 2
+      }
+      result = renderer.render_default(data)
+      expect(result).to include('**rows:**')
+      expect(result).to include('| id | subdomain | crypted_password |')
+      expect(result).to include('| 1 | test | [REDACTED] |')
+      expect(result).to include('| 2 | other | [REDACTED] |')
+      expect(result).to include('**count:** 2')
+    end
+
+    it 'renders positional multi-column values as a table (pluck multi-column)' do
+      data = {
+        'columns' => %w[id subdomain],
+        'values' => [[1, 'test'], [2, 'other']]
+      }
+      result = renderer.render_default(data)
+      expect(result).to include('| id | subdomain |')
+      expect(result).to include('| 1 | test |')
+      expect(result).to include('| 2 | other |')
+    end
+
+    it 'renders a flat scalar values array against a single-column header (pluck single-column)' do
+      data = {
+        'columns' => %w[subdomain],
+        'values' => %w[alpha beta gamma]
+      }
+      result = renderer.render_default(data)
+      expect(result).to include('| subdomain |')
+      expect(result).to include('| alpha |')
+      expect(result).to include('| beta |')
+      expect(result).to include('| gamma |')
+    end
+
+    it 'renders an empty `rows` array as _(empty)_ with the columns key still labeled' do
+      data = { 'columns' => %w[id], 'rows' => [], 'count' => 0 }
+      result = renderer.render_default(data)
+      expect(result).to include('**rows:**')
+      expect(result).to include('_(empty)_')
+      expect(result).to include('**count:** 0')
+    end
+
+    it 'falls back to bullet-list rendering when `values` has no sibling columns' do
+      data = { 'values' => [1, 2, 3] }
+      result = renderer.render_default(data)
+      expect(result).to include('**values:**')
+      expect(result).to include('- 1')
+      expect(result).to include('- 2')
+      expect(result).to include('- 3')
     end
   end
 


### PR DESCRIPTION
## Summary

`ConsoleResponseRenderer#render_hash` was summarizing every Array-valued key to a count (`"N items"`), silently eliding the actual data from `console_sql`, `console_query`, `console_pluck`, `console_sample`, `console_recent`, and `console_find` responses. The MCP payload carried the rows, but the rendered text agents see only named the shape.

## Fix

- Array values in hashes now recurse through `render_array` (Array<Hash> → Markdown table, scalar array → bullet list).
- When `rows` or `values` appears alongside a sibling `columns` array, the renderer emits a positional Markdown table using the columns as headers so sql / query / pluck output is scannable.
- Metadata-shaped responses (`count`, `aggregate`, `schema`, etc.) are unchanged.

## Test plan

- [x] Replaced the "renders Hash with Array values as item count" spec (which codified the bug) with 6 new specs covering Array<Hash>, scalar arrays, positional sql/query tables, multi-column pluck, single-column flat pluck, and empty rows.
- [x] Full gem spec suite: 3462 examples, 0 failures.
- [x] Rubocop clean on changed files.