### PR TITLE
Harden EvalGuard: close reflection-list + chained-receiver holes

### DIFF
--- a/lib/woods/console/eval_guard.rb
+++ b/lib/woods/console/eval_guard.rb
@@ -45,19 +45,35 @@ module Woods
       DENIED_CONSTANTS = %w[ENV].freeze
 
       # Method names that escape the AST sandbox regardless of receiver.
+      #
+      # In addition to the obvious escapes (eval family, send, binding),
+      # this list covers AST-reachable bypasses identified in PR #34 review:
+      # - `instance_variable_get` — reads arbitrary ivars from any object
+      # - `method` — returns a callable Method object, enabling indirect dispatch
+      # - `define_method` — injects new methods at runtime
+      # - `const_source_location` — leaks load paths and gem install locations
+      # - `_id2ref` — dereferences arbitrary ObjectSpace objects by ID
+      # - `each_object` — enumerates all live objects in the VM heap
       DENIED_REFLECTION = %w[
         eval instance_eval class_eval module_eval
         send public_send const_get binding
+        instance_variable_get method define_method
+        const_source_location _id2ref each_object
       ].freeze
 
       # Receivers + method-name pairs that read credential files from disk.
       # Triggers when the receiver matches AND any literal argument source
       # contains a known credential path fragment. `Pathname.new(...)` is
       # included so `Pathname.new(...).read` chains are caught at construction.
+      #
+      # `open` is included for File and IO to catch chained patterns like
+      # `File.open("config/master.key").read` — the inner `File.open(path)`
+      # node is visited by `scan_send_nodes` and refused here before the
+      # outer `.read` call is even examined (PR #34 review medium #3).
       CREDENTIAL_FILE_READERS = {
-        'File' => %w[read binread readlines],
-        'IO' => %w[read binread readlines],
-        'Pathname' => %w[read binread new]
+        'File' => %w[read binread readlines open],
+        'IO' => %w[read binread readlines open],
+        'Pathname' => %w[read binread new open]
       }.freeze
       CREDENTIAL_PATH_HINTS = %w[
         master.key credentials.yml.enc credentials/

--- a/spec/console/eval_guard_spec.rb
+++ b/spec/console/eval_guard_spec.rb
@@ -91,6 +91,37 @@ RSpec.describe Woods::Console::EvalGuard do
         expect { described_class.check!('binding.local_variables') }
           .to raise_error(Woods::Console::ForbiddenExpressionError, /binding/)
       end
+
+      # PR #34 medium #2: AST-reachable reflection bypasses
+      it 'rejects instance_variable_get' do
+        expect { described_class.check!('User.first.instance_variable_get(:@attributes)') }
+          .to raise_error(Woods::Console::ForbiddenExpressionError, /instance_variable_get/)
+      end
+
+      it 'rejects method reference via .method' do
+        expect { described_class.check!('User.method(:delete_all)') }
+          .to raise_error(Woods::Console::ForbiddenExpressionError, /\bmethod\b/)
+      end
+
+      it 'rejects define_method' do
+        expect { described_class.check!('User.define_method(:pwn) { puts "ok" }') }
+          .to raise_error(Woods::Console::ForbiddenExpressionError, /define_method/)
+      end
+
+      it 'rejects const_source_location' do
+        expect { described_class.check!('Object.const_source_location("User")') }
+          .to raise_error(Woods::Console::ForbiddenExpressionError, /const_source_location/)
+      end
+
+      it 'rejects ObjectSpace._id2ref' do
+        expect { described_class.check!('ObjectSpace._id2ref(42)') }
+          .to raise_error(Woods::Console::ForbiddenExpressionError, /_id2ref/)
+      end
+
+      it 'rejects ObjectSpace.each_object' do
+        expect { described_class.check!('ObjectSpace.each_object(String).to_a') }
+          .to raise_error(Woods::Console::ForbiddenExpressionError, /each_object/)
+      end
     end
 
     context 'with credential file reads' do
@@ -112,6 +143,27 @@ RSpec.describe Woods::Console::EvalGuard do
       it 'rejects Pathname.new(...).read on master.key' do
         expect { described_class.check!('Pathname.new("config/master.key").read') }
           .to raise_error(Woods::Console::ForbiddenExpressionError, /Pathname\.(?:new|read)/)
+      end
+
+      # PR #34 medium #3: chained receiver bypasses
+      it 'rejects File.open(credential_path).read chain' do
+        expect { described_class.check!('File.open("config/master.key").read') }
+          .to raise_error(Woods::Console::ForbiddenExpressionError, /credential file/)
+      end
+
+      it 'rejects File.open(credential_path).readlines chain' do
+        expect { described_class.check!('File.open("config/credentials.yml.enc").readlines') }
+          .to raise_error(Woods::Console::ForbiddenExpressionError, /credential file/)
+      end
+
+      it 'rejects Pathname.new(credential_path).open.read chain' do
+        expect { described_class.check!('Pathname.new("config/master.key").open.read') }
+          .to raise_error(Woods::Console::ForbiddenExpressionError, /credential file/)
+      end
+
+      it 'rejects IO.open(credential_path).read chain' do
+        expect { described_class.check!('IO.open("config/credentials/production.yml.enc").read') }
+          .to raise_error(Woods::Console::ForbiddenExpressionError, /credential file/)
       end
     end
 


### PR DESCRIPTION
## Summary

Closes two security gaps identified in PR #34 review (medium severity findings #2 and #3).

**Backlog items:** `eval-guard-reflection-list-holes`, `eval-guard-chained-file-read-miss`

### eval-guard-reflection-list-holes (PR #34 medium #2)

`DENIED_REFLECTION` was missing six AST-reachable reflection bypass methods. An LLM-generated payload using any of these bypassed parse-time refusal and reached the bridge:

- `instance_variable_get` — reads arbitrary ivars from any live object
- `method` — returns a callable Method object, enabling indirect dispatch
- `define_method` — injects new methods into a class at runtime
- `const_source_location` — leaks gem install paths and load paths
- `_id2ref` — dereferences arbitrary ObjectSpace objects by numeric ID
- `each_object` — enumerates every live object in the VM heap

**Fix:** Added all six to `DENIED_REFLECTION`. Each raises `ForbiddenExpressionError` at parse time. The bridge-side enforcement is the same constant (same `EvalGuard.new` instantiation); the depth gap where the bridge process must independently re-enforce these rules is already documented in the class comment and is tracked as a separate concern.

### eval-guard-chained-file-read-miss (PR #34 medium #3)

`refuse_credential_file_read!` checked `node.receiver` against literal names (`File`, `IO`, `Pathname`). For chains like `File.open("config/master.key").read`, the outer `.read` node has receiver `"File.open"`, so the literal-match check was skipped entirely.

**Fix:** Added `open` to `CREDENTIAL_FILE_READERS` for `File`, `IO`, and `Pathname`. Since `scan_send_nodes` visits every `:send` node in the tree, the inner `File.open(credential_path)` node is visited and refused before the outer `.read` call is examined. This catches all three chained patterns without requiring AST recursion.

## Test plan

- [x] `instance_variable_get` raises `ForbiddenExpressionError`
- [x] `method` raises `ForbiddenExpressionError`
- [x] `define_method` raises `ForbiddenExpressionError`
- [x] `const_source_location` raises `ForbiddenExpressionError`
- [x] `ObjectSpace._id2ref` raises `ForbiddenExpressionError`
- [x] `ObjectSpace.each_object` raises `ForbiddenExpressionError`
- [x] `File.open("config/master.key").read` raises `ForbiddenExpressionError`
- [x] `File.open("config/credentials.yml.enc").readlines` raises `ForbiddenExpressionError`
- [x] `Pathname.new("config/master.key").open.read` raises `ForbiddenExpressionError`
- [x] `IO.open("config/credentials/production.yml.enc").read` raises `ForbiddenExpressionError`
- [x] Full gem suite: 3693 examples, 0 failures
- [x] Rubocop: 0 offenses on changed files