### PR TITLE
Close Layer 3 redaction leak via unlisted envelope keys

### DIFF
--- a/lib/woods/console/server.rb
+++ b/lib/woods/console/server.rb
@@ -288,11 +288,20 @@ module Woods
 
         # Data-shape keys used by console tool responses. When any of these keys
         # appear at the top of a Hash result we treat the value as row data and
-        # descend into it instead of redacting at the envelope level. Keeping
-        # this list narrow avoids accidentally recursing into schema payloads
-        # (e.g. `console_schema` returns {columns: {...}} where `columns` is a
-        # Hash of column metadata, not row values).
-        DATA_ENVELOPE_KEYS = %w[record records rows values].freeze
+        # descend into it instead of redacting at the envelope level.
+        #
+        # Full recursive descent is intentionally NOT used here. Some tools return
+        # Hashes whose keys happen to be column names but whose values are metadata
+        # objects, not row data — e.g. `console_schema` returns
+        # {columns: {col_name => {type:..., null:...}}}. Recursing into that Hash
+        # would incorrectly replace schema metadata with "[REDACTED]" whenever a
+        # column name matches a redacted_columns entry. Keeping a closed list of
+        # envelope keys that carry actual row data is therefore the safer choice.
+        #
+        # When adding a new Tier 2/3 tool that returns row data under a new envelope
+        # key, add that key here AND add a matching `when` branch in
+        # `redact_envelope_value` that applies the appropriate redaction strategy.
+        DATA_ENVELOPE_KEYS = %w[record records rows values associations].freeze
         private_constant :DATA_ENVELOPE_KEYS
 
         # Apply SafeContext column redaction to a result value.
@@ -334,12 +343,31 @@ module Woods
           when 'record'         then value.is_a?(Hash) ? ctx.redact(value) : value
           when 'records'        then redact_hash_array(value, ctx)
           when 'rows', 'values' then redact_positional(value, plan)
+          when 'associations'   then redact_association_map(value, ctx)
           else                       value
           end
         end
 
         def redact_hash_array(value, ctx)
           Array(value).map { |row| row.is_a?(Hash) ? ctx.redact(row) : row }
+        end
+
+        # Redact an associations map returned by console_data_snapshot.
+        #
+        # The associations payload has the shape:
+        #   { "assoc_name" => [Hash, ...], ... }
+        # Each value is an Array of record Hashes. We redact each record
+        # the same way we handle `records` (column-name + EAV rules).
+        #
+        # @param value [Hash, nil] Association map
+        # @param ctx [SafeContext]
+        # @return [Hash, nil]
+        def redact_association_map(value, ctx)
+          return value unless value.is_a?(Hash)
+
+          value.each_with_object({}) do |(assoc_name, assoc_records), out|
+            out[assoc_name] = redact_hash_array(assoc_records, ctx)
+          end
         end
 
         # Precompute everything needed to redact positional rows for a given

--- a/spec/console/server_spec.rb
+++ b/spec/console/server_spec.rb
@@ -233,6 +233,80 @@ RSpec.describe Woods::Console::Server do
       end
     end
 
+    describe 'Layer 3 envelope-key coverage (regression for unlisted keys)' do
+      # Regression: apply_redaction previously only descended into a closed list
+      # of envelope keys (record, records, rows, values). Any other key —
+      # including `associations` returned by console_data_snapshot — was passed
+      # through without redaction, creating a blind spot for custom-named
+      # credential columns that also have no matching CredentialScanner shape.
+      let(:safe_ctx) do
+        Woods::Console::SafeContext.new(
+          connection: nil,
+          redacted_columns: %w[session_hmac internal_token_v2 webhook_secret_v3]
+        )
+      end
+
+      it 'redacts sensitive columns inside `associations` (console_data_snapshot shape)' do
+        # `data_snapshot` returns {record: {...}, associations: {name => [Hash, ...]}}
+        # The `associations` key was NOT in DATA_ENVELOPE_KEYS, so nested hashes
+        # were not walked and credentials leaked.
+        result = {
+          'record' => { 'id' => 1, 'name' => 'Order', 'session_hmac' => 'hmac-value-abc' },
+          'associations' => {
+            'tokens' => [
+              { 'id' => 10, 'internal_token_v2' => 'tok_secret_xyz', 'kind' => 'api' },
+              { 'id' => 11, 'internal_token_v2' => 'tok_secret_def', 'kind' => 'webhook' }
+            ],
+            'webhooks' => [
+              { 'id' => 20, 'webhook_secret_v3' => 'whsec_abc123', 'url' => 'https://example.com' }
+            ]
+          }
+        }
+        redacted = described_class.send(:apply_redaction, result, safe_ctx)
+
+        # record key should still be redacted
+        expect(redacted['record']['session_hmac']).to eq('[REDACTED]')
+        expect(redacted['record']['name']).to eq('Order')
+
+        # associations key must now also be redacted
+        expect(redacted['associations']['tokens'][0]['internal_token_v2']).to eq('[REDACTED]')
+        expect(redacted['associations']['tokens'][1]['internal_token_v2']).to eq('[REDACTED]')
+        expect(redacted['associations']['webhooks'][0]['webhook_secret_v3']).to eq('[REDACTED]')
+
+        # safe columns must pass through
+        expect(redacted['associations']['tokens'][0]['kind']).to eq('api')
+        expect(redacted['associations']['webhooks'][0]['url']).to eq('https://example.com')
+      end
+
+      it 'redacts across all association names in the associations map' do
+        # Verifies that every association name's records are walked, not just the first.
+        result = {
+          'record' => { 'id' => 1, 'session_hmac' => 'hmac-root' },
+          'associations' => {
+            'tokens' => [{ 'id' => 10, 'internal_token_v2' => 'tok_secret_xyz' }],
+            'webhooks' => [{ 'id' => 20, 'webhook_secret_v3' => 'whsec_abc123' }],
+            'addresses' => [{ 'id' => 30, 'street' => '123 Main St' }]
+          }
+        }
+        redacted = described_class.send(:apply_redaction, result, safe_ctx)
+        expect(redacted['associations']['tokens'][0]['internal_token_v2']).to eq('[REDACTED]')
+        expect(redacted['associations']['webhooks'][0]['webhook_secret_v3']).to eq('[REDACTED]')
+        expect(redacted['associations']['addresses'][0]['street']).to eq('123 Main St')
+      end
+
+      it 'does not redact the non-row `columns` metadata in console_schema output' do
+        # Ensures recursive descent does not corrupt schema metadata payloads.
+        result = {
+          'columns' => { 'id' => { 'type' => 'integer' }, 'session_hmac' => { 'type' => 'string' } }
+        }
+        redacted = described_class.send(:apply_redaction, result, safe_ctx)
+        # The *key name* "session_hmac" in schema metadata should not be touched —
+        # only *values* of hash entries whose key is a redacted column should be redacted.
+        expect(redacted['columns'].keys).to include('session_hmac')
+        expect(redacted['columns']['session_hmac']).to eq('type' => 'string')
+      end
+    end
+
     describe 'EAV (key-value) redaction' do
       # Models the real-world `authorizations` table where Stripe Connect
       # tokens live as rows like {key: "stripe_access_token", value: "sk_..."}.


### PR DESCRIPTION
## Backlog item

`console-redaction-envelope-keys-closed-list` — PR #34 review medium #1

## The gap

`Server#apply_redaction` only descended into a closed list of envelope keys (`record`, `records`, `rows`, `values`). The `console_data_snapshot` tool returns an `associations` sub-payload outside this list — a Hash of `{assoc_name => [record, ...]}` — so sensitive columns in those nested records bypassed Layer 3 redaction entirely.

Layer 2 (`CredentialScanner`) also misses this when the column name matches no known credential shape (e.g. `session_hmac`, `internal_token_v2`, `webhook_secret_v3`).

## Tier-by-Tier envelope-key audit

| Tool | Envelope keys | Row data? | Status before fix |
|------|--------------|-----------|-------------------|
| `console_count` | `count` (scalar) | No | Safe |
| `console_sample` / `console_recent` | `records: [Hash]` | Yes | Covered |
| `console_find` | `record: Hash` | Yes | Covered |
| `console_pluck` | `columns: [...]`, `values: [...]` | Yes (positional) | Covered |
| `console_aggregate` | `value` (scalar) | No | Safe |
| `console_association_count` | `count` (scalar) | No | Safe |
| `console_schema` | `columns: Hash` (metadata) | No — schema metadata | Safe |
| `console_status` | `status`, `models` (metadata) | No | Safe |
| `console_sql` / `console_query` | `columns`, `rows` | Yes (positional) | Covered |
| `console_data_snapshot` | `record` + **`associations`** | Yes | **LEAKED** (`associations`) |
| `console_diagnose_model` | `records`, `count` | Yes | Covered via `records` |
| `console_validate_record` | `valid`, `errors` (metadata) | No | Safe |
| `console_check_setting` / `check_eligibility` / etc. | scalar/bool results | No | Safe |
| `console_eval` | arbitrary Ruby result | Varies | Layer 2 handles |

## Approach chosen: A (extend closed list)

Full recursive descent (Approach B) was evaluated and rejected because it would corrupt `console_schema` output: `{columns: {session_hmac: {type: 'string'}}}` would have the schema metadata value replaced with `[REDACTED]` since the key name matches a `redacted_columns` entry — the values are type metadata, not actual data values. There is no clean heuristic to distinguish these cases without the envelope-key shape hints.

Approach A (extend the closed list) is safer here. The fix:

1. Adds `associations` to `DATA_ENVELOPE_KEYS`
2. Adds `redact_association_map` — walks `{assoc_name => [record, ...]}` and applies `ctx.redact` to each record hash (column-name + EAV rules both fire)
3. Adds a detailed comment to `DATA_ENVELOPE_KEYS` explaining the schema-safety rationale and instructing future tool authors to extend both the constant and `redact_envelope_value` when adding new row-data envelope keys

## Test plan

- [x] New spec: `associations` records with `session_hmac`, `internal_token_v2`, `webhook_secret_v3` column names are redacted (was: leaked)
- [x] New spec: all association names in the map are walked (not just the first)
- [x] New spec: `console_schema` metadata (`{columns: {col_name => {type: ...}}}`) is NOT corrupted by the fix
- [x] All 32 server specs pass
- [x] Full suite: 3686 examples, 0 failures
- [x] `rubocop lib/woods/console/server.rb spec/console/server_spec.rb` — no offenses