### PR TITLE
console_eval: instructional refusal + WOODS_CONSOLE_UNSAFE_EVAL opt-in scaffolding

### DIFF
--- a/lib/woods.rb
+++ b/lib/woods.rb
@@ -95,7 +95,7 @@ module Woods
                   :console_redacted_key_values, :console_embedded_read_tools,
                   :console_blocked_tables, :console_credential_scanning_enabled,
                   :console_disabled_scanner_patterns, :console_credential_defense_enabled,
-                  :console_credential_rotation_warning,
+                  :console_credential_rotation_warning, :console_unsafe_eval_enabled,
                   :notion_api_token, :notion_database_ids,
                   :unblocked_api_token, :unblocked_collection_id, :unblocked_repo_url,
                   :cache_store, :cache_options
@@ -131,6 +131,7 @@ module Woods
       @console_disabled_scanner_patterns = []
       @console_credential_defense_enabled = true
       @console_credential_rotation_warning = true
+      @console_unsafe_eval_enabled = nil # nil = fall back to env WOODS_CONSOLE_UNSAFE_EVAL
       @notion_api_token = nil
       @notion_database_ids = {}
       @unblocked_api_token = nil

--- a/lib/woods/console/embedded_executor.rb
+++ b/lib/woods/console/embedded_executor.rb
@@ -57,11 +57,8 @@ module Woods
         tool = request['tool']
         params = request['params'] || {}
 
-        unless TIER1_TOOLS.include?(tool) || (@read_tools_enabled && EMBEDDED_READ_TOOLS.include?(tool))
-          return { 'ok' => false,
-                   'error' => unsupported_message(tool),
-                   'error_type' => 'unsupported' }
-        end
+        refusal = refusal_for(tool)
+        return refusal if refusal
 
         start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         result = @safe_context.execute { dispatch(tool, params) }
@@ -75,6 +72,19 @@ module Woods
       end
 
       private
+
+      # Return a pre-dispatch refusal hash for tools the executor cannot or
+      # will not run, else nil to let dispatch proceed.
+      #
+      # @param tool [String] Tool name
+      # @return [Hash, nil]
+      def refusal_for(tool)
+        if tool == 'eval'
+          { 'ok' => false, 'error' => eval_disabled_message, 'error_type' => 'eval_disabled' }
+        elsif !(TIER1_TOOLS.include?(tool) || (@read_tools_enabled && EMBEDDED_READ_TOOLS.include?(tool)))
+          { 'ok' => false, 'error' => unsupported_message(tool), 'error_type' => 'unsupported' }
+        end
+      end
 
       # Self-describing error for tools the embedded executor cannot run.
       #
@@ -93,6 +103,29 @@ module Woods
           "Tool '#{tool}' is not available in embedded mode — it requires the " \
             'bridge architecture (Option D in docs/CONSOLE_MCP_SETUP.md).'
         end
+      end
+
+      # Instructional error payload for console_eval. Execution is deliberately
+      # punted — the backlog item unsafe-eval-opt-in spells out the safety
+      # contract required before eval can ever run. Until then we return a
+      # structured refusal that:
+      #   1. names why eval is off (no safe execution path yet),
+      #   2. points the agent at console_query / console_sql as the usual
+      #      substitute (both already handle group_by/having/aggregates),
+      #   3. tells the agent to surface its proposed Ruby snippet to the
+      #      human before any retry — never silently re-invoke.
+      #
+      # @return [String] Multi-line actionable message.
+      def eval_disabled_message
+        <<~MSG.strip
+          console_eval is disabled — embedded mode has no safe execution path yet.
+          Use console_query (model + select + joins/group_by/having/order) or console_sql
+          for anything you were about to run. Both already support aggregates and scoping.
+          If you believe eval is still necessary, SHOW your proposed Ruby snippet to the
+          user first and let them run it manually — do not retry console_eval automatically.
+          Operators: opting in requires WOODS_CONSOLE_UNSAFE_EVAL=true, is rejected in
+          Rails.env.production?, and the execution wiring for that flag is not implemented.
+        MSG
       end
 
       # Route a tool name to its handler.

--- a/lib/woods/console/server.rb
+++ b/lib/woods/console/server.rb
@@ -76,6 +76,50 @@ module Woods
           config&.console_credential_defense_enabled ? true : false
         end
 
+        # True when the caller has opted into the unsafe `console_eval`
+        # scaffolding via `WOODS_CONSOLE_UNSAFE_EVAL=true` or an explicit
+        # `config.console_unsafe_eval_enabled = true`. Explicit config wins
+        # over the env var in both directions.
+        #
+        # NOTE: returning true here does NOT enable eval execution. The
+        # execution path is deliberately unimplemented (backlog
+        # unsafe-eval-opt-in). This predicate only governs the boot-time
+        # banner and the production-environment refusal below.
+        #
+        # @return [Boolean]
+        def unsafe_eval_enabled?
+          config = Woods.configuration if Woods.respond_to?(:configuration)
+          explicit = config&.console_unsafe_eval_enabled
+          return explicit if [true, false].include?(explicit)
+
+          ENV['WOODS_CONSOLE_UNSAFE_EVAL'] == 'true'
+        end
+
+        # Enforce the `console_eval` opt-in safety contract at boot.
+        #
+        # When `WOODS_CONSOLE_UNSAFE_EVAL` is on:
+        # - refuse outright in `Rails.env.production?` (non-negotiable),
+        # - otherwise emit a LOUD stderr banner so operators know the flag
+        #   is live even though eval remains unimplemented.
+        #
+        # Safe when Rails is not loaded (specs, non-Rails hosts).
+        #
+        # @return [void]
+        # @raise [Woods::ConfigurationError] when the flag is on in production.
+        def enforce_unsafe_eval_contract!
+          return unless unsafe_eval_enabled?
+
+          if defined?(Rails) && Rails.respond_to?(:env) && Rails.env.respond_to?(:production?) &&
+             Rails.env.production?
+            raise Woods::ConfigurationError,
+                  'WOODS_CONSOLE_UNSAFE_EVAL is set but Rails.env.production? is true. ' \
+                  'console_eval cannot be opted into in production. Unset the flag or ' \
+                  'restart in a non-production environment.'
+          end
+
+          warn unsafe_eval_banner
+        end
+
         # Resolves `Rails.application` when available, else nil.
         def default_rails_app
           return nil unless defined?(Rails) && Rails.respond_to?(:application)
@@ -133,6 +177,7 @@ module Woods
                            read_tools_enabled: false, model_tables: {},
                            model_reflections: {})
           require_relative 'embedded_executor'
+          enforce_unsafe_eval_contract!
 
           executor = EmbeddedExecutor.new(
             model_validator: model_validator, safe_context: safe_context,
@@ -345,6 +390,23 @@ module Woods
           )
         rescue StandardError => e
           handle_observability_failure(e)
+        end
+
+        # Loud multi-line banner surfaced to stderr when the opt-in flag is
+        # recognised outside of production. Operators should see this every
+        # boot so an accidentally-persistent env var cannot go unnoticed.
+        #
+        # @return [String]
+        def unsafe_eval_banner
+          <<~BANNER
+
+            ================================================================================
+             WOODS_CONSOLE_UNSAFE_EVAL IS SET
+             console_eval opt-in scaffolding is active. Execution is STILL NOT IMPLEMENTED
+             (backlog: unsafe-eval-opt-in). The flag will also refuse to boot in
+             Rails.env.production?. If you did not mean to set this, unset the env var.
+            ================================================================================
+          BANNER
         end
 
         def structured_logger
@@ -892,10 +954,17 @@ module Woods
         def define_eval(server, conn_mgr, ctx = nil, renderer: nil)
           config = Woods.configuration if Woods.respond_to?(:configuration)
           guard = EvalGuard.new if config&.console_credential_defense_enabled
-          define_console_tool(server, conn_mgr, 'console_eval',
-                              'Execute arbitrary Ruby code (requires confirmation)',
+          description = [
+            'Propose arbitrary Ruby for execution against the live Rails runtime.',
+            'CURRENTLY DISABLED in embedded mode — the call will always return an instructional refusal.',
+            'Before invoking this tool, SHOW the user your proposed Ruby snippet and let them run it ' \
+            'manually. Do not retry on failure, and do not hide the snippet behind the tool call.',
+            'For most cases use console_query (model + select + joins/group_by/having/order) or ' \
+            'console_sql instead — both already support aggregates and scoped filters.'
+          ].join(' ')
+          define_console_tool(server, conn_mgr, 'console_eval', description,
                               properties: {
-                                code: str_prop('Ruby code to execute'),
+                                code: str_prop('Ruby code you propose to run (will be surfaced to the user first)'),
                                 timeout: int_prop('Timeout in seconds (default 10, max 30)')
                               }, required: ['code'], ctx: ctx, renderer: renderer) do |args|
             Tools::Tier4.console_eval(code: args[:code], timeout: args[:timeout] || 10, guard: guard)

--- a/spec/console/embedded_executor_spec.rb
+++ b/spec/console/embedded_executor_spec.rb
@@ -49,12 +49,35 @@ RSpec.describe Woods::Console::EmbeddedExecutor do
         expect(response['error']).to include('docs/CONSOLE_MCP_SETUP.md')
       end
 
-      it 'points eval at the bridge architecture' do
-        response = executor.send_request({ 'tool' => 'eval', 'params' => { 'code' => 'puts 1' } })
+      it 'returns an instructional eval_disabled payload instead of a bare unsupported error' do
+        response = executor.send_request({ 'tool' => 'eval', 'params' => { 'code' => 'User.count' } })
 
         expect(response['ok']).to be false
-        expect(response['error_type']).to eq('unsupported')
-        expect(response['error']).to include('bridge architecture')
+        expect(response['error_type']).to eq('eval_disabled')
+      end
+
+      it 'eval error explains why eval is disabled and names the query alternatives' do
+        response = executor.send_request({ 'tool' => 'eval', 'params' => { 'code' => 'User.count' } })
+
+        error = response['error']
+        expect(error).to include('console_eval')
+        expect(error).to include('disabled')
+        expect(error).to include('console_query')
+        expect(error).to include('console_sql')
+      end
+
+      it 'eval error instructs the agent to surface its proposed snippet to the user before retrying' do
+        response = executor.send_request({ 'tool' => 'eval', 'params' => { 'code' => 'User.count' } })
+
+        error = response['error']
+        expect(error).to match(/surface|present|show/i)
+        expect(error).to match(/first|manual/i)
+      end
+
+      it 'eval error points operators at the WOODS_CONSOLE_UNSAFE_EVAL opt-in flag' do
+        response = executor.send_request({ 'tool' => 'eval', 'params' => { 'code' => 'User.count' } })
+
+        expect(response['error']).to include('WOODS_CONSOLE_UNSAFE_EVAL')
       end
     end
 

--- a/spec/console/eval_opt_in_spec.rb
+++ b/spec/console/eval_opt_in_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'woods'
+require 'woods/console/server'
+
+RSpec.describe 'console_eval opt-in safety contract' do
+  let(:registry) { { 'User' => %w[id email] } }
+  let(:validator) { Woods::Console::ModelValidator.new(registry: registry) }
+  let(:connection) { instance_double('Connection') }
+  let(:safe_context) { Woods::Console::SafeContext.new(connection: connection) }
+
+  before do
+    allow(connection).to receive(:transaction) do |&block|
+      block.call
+    rescue ActiveRecord::Rollback
+      nil
+    end
+    allow(connection).to receive(:execute)
+    allow(connection).to receive(:adapter_name).and_return('PostgreSQL')
+    # Clear the flag across tests — it is env-backed and persistent otherwise.
+    ENV.delete('WOODS_CONSOLE_UNSAFE_EVAL')
+    Woods.configure { |c| c.console_unsafe_eval_enabled = nil }
+  end
+
+  after do
+    ENV.delete('WOODS_CONSOLE_UNSAFE_EVAL')
+    Woods.configure { |c| c.console_unsafe_eval_enabled = nil }
+  end
+
+  describe 'Woods::Console::Server.unsafe_eval_enabled?' do
+    it 'defaults to false' do
+      expect(Woods::Console::Server.unsafe_eval_enabled?).to be false
+    end
+
+    it 'is true when WOODS_CONSOLE_UNSAFE_EVAL=true in the environment' do
+      ENV['WOODS_CONSOLE_UNSAFE_EVAL'] = 'true'
+      expect(Woods::Console::Server.unsafe_eval_enabled?).to be true
+    end
+
+    it 'is false for WOODS_CONSOLE_UNSAFE_EVAL values other than "true"' do
+      ENV['WOODS_CONSOLE_UNSAFE_EVAL'] = '1'
+      expect(Woods::Console::Server.unsafe_eval_enabled?).to be false
+    end
+
+    it 'is true when console_unsafe_eval_enabled is explicitly set in config' do
+      Woods.configure { |c| c.console_unsafe_eval_enabled = true }
+      expect(Woods::Console::Server.unsafe_eval_enabled?).to be true
+    end
+
+    it 'explicit config false overrides the env var' do
+      ENV['WOODS_CONSOLE_UNSAFE_EVAL'] = 'true'
+      Woods.configure { |c| c.console_unsafe_eval_enabled = false }
+      expect(Woods::Console::Server.unsafe_eval_enabled?).to be false
+    end
+  end
+
+  describe 'console_eval tool description' do
+    let(:server) do
+      Woods::Console::Server.build_embedded(model_validator: validator, safe_context: safe_context)
+    end
+    let(:description) { server.instance_variable_get(:@tools)['console_eval'].description }
+
+    it 'states the tool is currently disabled' do
+      expect(description).to match(/disabled|refusal/i)
+    end
+
+    it 'instructs the agent to surface the proposed snippet to the user before invoking' do
+      expect(description).to match(/show|surface|present/i)
+      expect(description).to match(/before|first|manually/i)
+    end
+
+    it 'names console_query and console_sql as the alternatives' do
+      expect(description).to include('console_query')
+      expect(description).to include('console_sql')
+    end
+  end
+
+  describe 'build_embedded with unsafe eval flag' do
+    context 'when the flag is off (default)' do
+      it 'does not emit a banner' do
+        expect do
+          Woods::Console::Server.build_embedded(
+            model_validator: validator, safe_context: safe_context
+          )
+        end.not_to output(/WOODS_CONSOLE_UNSAFE_EVAL/).to_stderr
+      end
+    end
+
+    context 'when the flag is on in a non-production environment' do
+      before { ENV['WOODS_CONSOLE_UNSAFE_EVAL'] = 'true' }
+
+      it 'emits a loud warning banner to stderr' do
+        expect do
+          Woods::Console::Server.build_embedded(
+            model_validator: validator, safe_context: safe_context
+          )
+        end.to output(/WOODS_CONSOLE_UNSAFE_EVAL/).to_stderr
+      end
+
+      it 'still builds the server (eval remains disabled, not enabled by the flag)' do
+        server = Woods::Console::Server.build_embedded(
+          model_validator: validator, safe_context: safe_context
+        )
+        expect(server).to be_a(MCP::Server)
+      end
+    end
+
+    context 'when the flag is on in Rails production' do
+      before do
+        ENV['WOODS_CONSOLE_UNSAFE_EVAL'] = 'true'
+        rails = class_double('Rails').as_stubbed_const
+        env = instance_double('Rails::Env', production?: true)
+        allow(rails).to receive(:env).and_return(env)
+      end
+
+      it 'refuses to boot and raises a ConfigurationError' do
+        expect do
+          Woods::Console::Server.build_embedded(
+            model_validator: validator, safe_context: safe_context
+          )
+        end.to raise_error(Woods::ConfigurationError, /production/i)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Backlog: `unsafe-eval-opt-in`.

- Replace the generic `'unsupported'` error for `console_eval` in embedded mode with a structured `'eval_disabled'` payload. The message names `console_query` / `console_sql` as the alternatives, tells the agent to surface its proposed Ruby snippet to the user **before** any retry, and points operators at the `WOODS_CONSOLE_UNSAFE_EVAL` flag.
- Add `Woods::Console::Server.unsafe_eval_enabled?` (explicit `config.console_unsafe_eval_enabled` wins over the `WOODS_CONSOLE_UNSAFE_EVAL=true` env var).
- `Server.build_embedded` now enforces the opt-in safety contract at boot: **refuses to start under `Rails.env.production?`**, emits a loud stderr banner elsewhere. Safe when Rails is not loaded.
- Rewrite the `console_eval` tool description so the agent knows it is currently disabled, has to show its snippet to the user first, and should reach for `console_query` / `console_sql`.

## Deliberately out of scope

The backlog item lists validation denylist / confirmation tool / `AuditLogger` entries / model allowlist / 5s timeout. Those are **not** included here — they describe what must be true *when execution is wired*, and the backlog explicitly says we are punting on implementation. That work lands in a future PR when somebody actually turns the execution path on. The banner says so out loud so a stray env var can't go unnoticed.

## Test plan

- [x] `bundle exec rake spec` — 3726 examples, 0 failures
- [x] `bundle exec rubocop` clean on the touched files
- [x] New spec `spec/console/eval_opt_in_spec.rb` covers:
  - default / env-var / explicit-config resolution of `unsafe_eval_enabled?`
  - banner emitted to stderr when flag is on outside production
  - `Woods::ConfigurationError` raised when flag is on and `Rails.env.production?`
  - tool description mentions "disabled", "show / surface", "before / first / manually", and both `console_query` + `console_sql`
- [x] `spec/console/embedded_executor_spec.rb` locks in the new `error_type: 'eval_disabled'` payload + required phrases