### PR TITLE
chore(bench): add benchmark infrastructure for console components

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
   Exclude:
     - 'vendor/**/*'
     - 'tmp/**/*'
+    - 'bench/**/*'
 
 # ── Metrics exclusions ──
 # AST visitors, extractors, MCP registries, flow analysis, and core

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
+  gem 'benchmark-ips', '~> 2.0'
   gem 'debug', '>= 1.0.0'
   # activesupport for specs that don't need full Rails
   gem 'activesupport'

--- a/bench/credential_scanner_bench.rb
+++ b/bench/credential_scanner_bench.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# Benchmark: Woods::Console::CredentialScanner
+#
+# What this measures:
+#   CredentialScanner#scan is called on every Console MCP tool response —
+#   once per response string/hash/array value. This bench covers the four
+#   input shapes the scanner sees in practice:
+#
+#   1. Short clean string     — a typical scalar column value with no credential.
+#   2. Long clean string      — a large text/blob column with no credential.
+#   3. String with a match    — a value that triggers at least one pattern.
+#   4. EAV hash (100 rows)    — a console_data_snapshot-style rows payload where
+#      each element is { key: <name>, value: <data> }. The hot path in production:
+#      the scanner walks the entire hash tree for every page of results.
+#
+# How to run:
+#   bundle exec ruby bench/credential_scanner_bench.rb
+#
+# What "good" looks like:
+#   - Short/long clean strings: > 50_000 i/s  (TODO: calibrate on target hardware)
+#   - String with match:        > 20_000 i/s  (pattern gsub triggers once)
+#   - EAV hash (100 rows):      > 300 i/s     (TODO: calibrate)
+#
+# Note: benchmark-ips must be installed (it is a dev dependency of this gem).
+# These benchmarks are NOT part of the test suite and are never run in CI.
+
+require 'bundler/setup'
+require 'benchmark/ips'
+
+# Load the component under bench without booting Rails.
+require_relative '../lib/woods/console/credential_index'
+require_relative '../lib/woods/console/credential_scanner'
+
+scanner = Woods::Console::CredentialScanner.new
+
+# ── Inputs ───────────────────────────────────────────────────────────────────
+
+SHORT_CLEAN = 'hello@example.com'.freeze
+
+LONG_CLEAN = ('Lorem ipsum dolor sit amet, consectetur adipiscing elit. ' * 100).freeze
+
+# A Stripe secret key — triggers stripe_secret_key pattern.
+STRING_WITH_MATCH = 'payment token: sk_test_4eC39HqLyjWDarjtT1zdp7dc and more text after'.freeze
+
+# Simulate a console_data_snapshot rows payload: 100 rows, each a hash with
+# string key column name and a clean string value. Realistic column names
+# drawn from a typical ActiveRecord model (no credentials).
+EAV_ROWS = Array.new(100) do |i|
+  {
+    'id'         => (1000 + i).to_s,
+    'email'      => "user#{i}@example.com",
+    'name'       => "User #{i}",
+    'created_at' => "2024-01-#{(i % 28) + 1}",
+    'status'     => %w[active inactive pending][i % 3]
+  }
+end.freeze
+
+Benchmark.ips do |x|
+  x.config(warmup: 2, time: 5)
+
+  x.report('short clean string') do
+    scanner.scan(SHORT_CLEAN)
+  end
+
+  x.report('long clean string (5.5KB)') do
+    scanner.scan(LONG_CLEAN)
+  end
+
+  x.report('string with Stripe key match') do
+    scanner.scan(STRING_WITH_MATCH)
+  end
+
+  x.report('EAV hash 100 rows (5 columns each)') do
+    scanner.scan(EAV_ROWS)
+  end
+
+  x.compare!
+end

--- a/bench/sql_validator_bench.rb
+++ b/bench/sql_validator_bench.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+# Benchmark: Woods::Console::SqlValidator
+#
+# What this measures:
+#   SqlValidator#validate! is called once per console_sql tool invocation —
+#   the hot path is a clean SELECT that passes all checks. The bench also
+#   covers rejection paths so we can see the relative cost of each guard.
+#
+#   1. Simple SELECT (passes all checks) — the common case; measures the
+#      full validation pipeline on a minimal clean query.
+#   2. Complex SELECT with CTEs and subqueries — a realistic analytics query
+#      a developer might send; exercises the multi-check pipeline on a longer
+#      string.
+#   3. Forbidden prefix rejection (INSERT) — hits check_forbidden_keywords!
+#      on the first check and raises immediately.
+#   4. Body keyword rejection (UNION) — passes the prefix check, then hits
+#      check_body_forbidden_keywords!.
+#   5. Comment-hidden keyword (SELECT --; DELETE) — exercises the
+#      check_forbidden_keywords_in_body! strip-then-scan path.
+#
+# How to run:
+#   bundle exec ruby bench/sql_validator_bench.rb
+#
+# What "good" looks like:
+#   - Simple SELECT:   > 100_000 i/s  (frozen constants + fast match? exit)
+#   - Complex SELECT:  > 30_000 i/s   (TODO: calibrate)
+#   - Rejections:      roughly comparable to their passing counterparts —
+#                      early exits should be faster than full-pass validation
+#
+# Note: benchmark-ips must be installed (it is a dev dependency of this gem).
+# These benchmarks are NOT part of the test suite and are never run in CI.
+
+require 'bundler/setup'
+require 'benchmark/ips'
+
+require_relative '../lib/woods/console/sql_validator'
+
+validator = Woods::Console::SqlValidator.new
+
+# ── Inputs ───────────────────────────────────────────────────────────────────
+
+SIMPLE_SELECT = 'SELECT id, email, created_at FROM users WHERE id = 42'.freeze
+
+COMPLEX_SELECT = <<~SQL.freeze
+  WITH recent_orders AS (
+    SELECT user_id, COUNT(*) AS order_count, SUM(total_cents) AS total
+    FROM orders
+    WHERE created_at > NOW() - INTERVAL '30 days'
+    GROUP BY user_id
+  ),
+  high_value AS (
+    SELECT user_id FROM recent_orders WHERE total > 10000
+  )
+  SELECT u.id, u.email, ro.order_count, ro.total
+  FROM users u
+  JOIN recent_orders ro ON ro.user_id = u.id
+  WHERE u.id IN (SELECT user_id FROM high_value)
+  ORDER BY ro.total DESC
+  LIMIT 100
+SQL
+
+INSERT_SQL = 'INSERT INTO users (email) VALUES (\'attacker@evil.com\')'.freeze
+
+UNION_SQL = 'SELECT id FROM users UNION SELECT id FROM admins'.freeze
+
+COMMENT_HIDDEN_SQL = "SELECT 1 --;\nDELETE FROM users".freeze
+
+Benchmark.ips do |x|
+  x.config(warmup: 2, time: 5)
+
+  x.report('simple SELECT (passes)') do
+    validator.validate!(SIMPLE_SELECT)
+  rescue Woods::Console::SqlValidationError
+    nil
+  end
+
+  x.report('complex SELECT with CTEs (passes)') do
+    validator.validate!(COMPLEX_SELECT)
+  rescue Woods::Console::SqlValidationError
+    nil
+  end
+
+  x.report('INSERT rejection (prefix check)') do
+    validator.validate!(INSERT_SQL)
+  rescue Woods::Console::SqlValidationError
+    nil
+  end
+
+  x.report('UNION rejection (body keyword check)') do
+    validator.validate!(UNION_SQL)
+  rescue Woods::Console::SqlValidationError
+    nil
+  end
+
+  x.report('comment-hidden DELETE rejection') do
+    validator.validate!(COMMENT_HIDDEN_SQL)
+  rescue Woods::Console::SqlValidationError
+    nil
+  end
+
+  x.compare!
+end

--- a/bench/table_gate_bench.rb
+++ b/bench/table_gate_bench.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+# Benchmark: Woods::Console::TableGate
+#
+# What this measures:
+#   TableGate is called on every console_sql, console_query, console_joins,
+#   and console_association_count invocation. The gate's hot path is a clean
+#   query that touches no blocked tables. The bench covers:
+#
+#   1. check_sql! — simple SELECT, no blocked tables — measures strip_noise +
+#      regex scan over a short query. The common case.
+#   2. check_sql! — complex multi-join SELECT, no blocked tables — exercises
+#      the FROM_CLAUSE + JOIN_REFERENCE scan over a longer string.
+#   3. check_sql! — query that hits a blocked table — measures how quickly
+#      the gate raises TableGateError.
+#   4. check_model! — model name lookup (hash read + check_table!) — fast
+#      path for model-based tools.
+#   5. check_joins! — resolves two association names through the reflection
+#      map — the console_query joins path.
+#   6. inactive gate (no blocked tables) — TableGate#active? short-circuit —
+#      should be near-zero overhead.
+#
+# How to run:
+#   bundle exec ruby bench/table_gate_bench.rb
+#
+# What "good" looks like:
+#   - Simple SQL, no match:    > 20_000 i/s  (strip_noise + scan on short string)
+#   - Complex SQL, no match:   > 5_000 i/s   (TODO: calibrate)
+#   - check_model!:            > 200_000 i/s (hash lookup only)
+#   - Inactive gate:           > 1_000_000 i/s (single boolean check)
+#
+# Note: benchmark-ips must be installed (it is a dev dependency of this gem).
+# These benchmarks are NOT part of the test suite and are never run in CI.
+
+require 'bundler/setup'
+require 'benchmark/ips'
+
+require_relative '../lib/woods/console/table_gate'
+
+# ── Gate configurations ───────────────────────────────────────────────────────
+
+MODEL_TABLES = {
+  'User'          => 'users',
+  'Order'         => 'orders',
+  'Product'       => 'products',
+  'Authorization' => 'authorizations',
+  'AuditLog'      => 'audit_logs'
+}.freeze
+
+MODEL_REFLECTIONS = {
+  'User' => {
+    'orders'         => 'orders',
+    'authorizations' => 'authorizations',
+    'audit_logs'     => 'audit_logs'
+  },
+  'Order' => {
+    'user'     => 'users',
+    'products' => 'products'
+  }
+}.freeze
+
+# Active gate: authorizations and audit_logs are blocked.
+ACTIVE_GATE = Woods::Console::TableGate.new(
+  blocked_tables:    %w[authorizations audit_logs],
+  model_tables:      MODEL_TABLES,
+  model_reflections: MODEL_REFLECTIONS
+)
+
+# Inactive gate: no blocked tables — represents an unconfigured or opt-out host.
+INACTIVE_GATE = Woods::Console::TableGate.new(
+  blocked_tables:    [],
+  model_tables:      MODEL_TABLES,
+  model_reflections: MODEL_REFLECTIONS
+)
+
+# ── SQL inputs ────────────────────────────────────────────────────────────────
+
+SIMPLE_SQL = 'SELECT id, email FROM users WHERE status = \'active\''.freeze
+
+COMPLEX_SQL = <<~SQL.freeze
+  SELECT u.id, u.email, o.id AS order_id, o.total_cents, p.name AS product_name
+  FROM users u
+  JOIN orders o ON o.user_id = u.id
+  JOIN order_items oi ON oi.order_id = o.id
+  JOIN products p ON p.id = oi.product_id
+  WHERE u.created_at > '2024-01-01'
+    AND o.status = 'completed'
+  ORDER BY o.created_at DESC
+  LIMIT 50
+SQL
+
+BLOCKED_SQL = 'SELECT * FROM authorizations WHERE user_id = 1'.freeze
+
+Benchmark.ips do |x|
+  x.config(warmup: 2, time: 5)
+
+  x.report('check_sql! simple SELECT (no blocked table)') do
+    ACTIVE_GATE.check_sql!(SIMPLE_SQL)
+  rescue Woods::Console::TableGateError
+    nil
+  end
+
+  x.report('check_sql! complex multi-join SELECT (no blocked table)') do
+    ACTIVE_GATE.check_sql!(COMPLEX_SQL)
+  rescue Woods::Console::TableGateError
+    nil
+  end
+
+  x.report('check_sql! hits blocked table (raises)') do
+    ACTIVE_GATE.check_sql!(BLOCKED_SQL)
+  rescue Woods::Console::TableGateError
+    nil
+  end
+
+  x.report('check_model! clean model (hash lookup)') do
+    ACTIVE_GATE.check_model!('User')
+  rescue Woods::Console::TableGateError
+    nil
+  end
+
+  x.report('check_joins! two associations (one blocked)') do
+    ACTIVE_GATE.check_joins!('User', %w[orders authorizations])
+  rescue Woods::Console::TableGateError
+    nil
+  end
+
+  x.report('inactive gate — check_sql! short-circuit') do
+    INACTIVE_GATE.check_sql!(SIMPLE_SQL)
+  rescue Woods::Console::TableGateError
+    nil
+  end
+
+  x.compare!
+end

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,18 @@ What's next: see [COVERAGE_GAP_ANALYSIS.md](COVERAGE_GAP_ANALYSIS.md) for remain
 
 Historical design documents from the build phase are in [design/](design/) (see [design/README.md](design/README.md)).
 
+## Benchmarks
+
+The `bench/` directory contains opt-in benchmarks for console-layer components. Run any bench individually:
+
+```bash
+bundle exec ruby bench/credential_scanner_bench.rb
+bundle exec ruby bench/sql_validator_bench.rb
+bundle exec ruby bench/table_gate_bench.rb
+```
+
+These benchmarks are **not part of the test suite** and are never run in CI. They exist so performance claims can be proven or disproven without scaffolding from scratch. Each file documents what it measures, how to run it, and rough IPS targets at the top.
+
 ## Planned Documentation
 
 | Document | Scope |


### PR DESCRIPTION
## Summary

- Adds `bench/` with three standalone IPS benchmarks: `credential_scanner_bench.rb`, `sql_validator_bench.rb`, `table_gate_bench.rb`
- Each file covers realistic input shapes drawn from the server call sites (short/long clean strings, strings with matches, EAV hash rows, multi-join SQL, rejection paths)
- `benchmark-ips ~> 2.0` added to Gemfile dev group (not gemspec, matching project convention)
- `bench/**/*` excluded from rubocop `AllCops`
- `docs/README.md` gains a Benchmarks section documenting `bundle exec ruby bench/<name>.rb` and that benches are NOT part of the test suite

## Test plan

- [ ] `bundle exec ruby bench/credential_scanner_bench.rb` — prints IPS comparison table
- [ ] `bundle exec ruby bench/sql_validator_bench.rb` — prints IPS comparison table
- [ ] `bundle exec ruby bench/table_gate_bench.rb` — prints IPS comparison table
- [ ] `bundle exec rake spec` — 3759 examples, 0 failures (unchanged)
- [ ] `bundle exec rubocop` — no offenses