### PR TITLE
feat(console): log skipped models at debug level during introspection

### DIFF
--- a/lib/woods/console/rack_middleware.rb
+++ b/lib/woods/console/rack_middleware.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'woods/observability/structured_logger'
 
 module Woods
   module Console
@@ -171,7 +172,13 @@ module Woods
           registry[model.name] = model.column_names
           tables[model.name] = model.table_name
           reflections[model.name] = reflections_for(model)
-        rescue StandardError
+        rescue StandardError => e
+          structured_logger.debug(
+            'console.model_introspection.skipped',
+            model: model.name,
+            error_class: e.class.name,
+            error_message: e.message
+          )
           next
         end
 
@@ -187,6 +194,10 @@ module Woods
         rescue StandardError
           next
         end
+      end
+
+      def structured_logger
+        @structured_logger ||= Woods::Observability::StructuredLogger.new
       end
     end
   end

--- a/spec/console/rack_middleware_spec.rb
+++ b/spec/console/rack_middleware_spec.rb
@@ -5,6 +5,7 @@ require 'woods'
 require 'woods/console/rack_middleware'
 require 'woods/console/safe_context'
 require 'woods/console/model_validator'
+require 'woods/observability/structured_logger'
 
 # Stub Server so we don't pull in the full MCP transport stack.
 unless defined?(Woods::Console::Server)
@@ -60,6 +61,64 @@ RSpec.describe Woods::Console::RackMiddleware do
 
       expect(Woods::Console::SafeContext).to have_received(:new)
         .with(hash_including(pool: pool))
+    end
+  end
+
+  describe '#build_model_introspection' do
+    let(:logger) { instance_double(Woods::Observability::StructuredLogger) }
+    let(:bad_model) do
+      m = class_double('BadModel')
+      allow(m).to receive(:name).and_return('BadModel')
+      allow(m).to receive(:abstract_class?).and_return(false)
+      allow(m).to receive(:table_exists?).and_return(true)
+      allow(m).to receive(:column_names).and_raise(StandardError, 'column boom')
+      m
+    end
+    let(:good_model) do
+      m = class_double('GoodModel')
+      allow(m).to receive(:name).and_return('GoodModel')
+      allow(m).to receive(:abstract_class?).and_return(false)
+      allow(m).to receive(:table_exists?).and_return(true)
+      allow(m).to receive(:column_names).and_return(['id'])
+      allow(m).to receive(:table_name).and_return('good_models')
+      allow(m).to receive(:reflect_on_all_associations).and_return([])
+      m
+    end
+
+    before do
+      allow(ar_base).to receive(:descendants).and_return([bad_model, good_model])
+      middleware.instance_variable_set(:@structured_logger, logger)
+      allow(logger).to receive(:debug)
+    end
+
+    it 'logs a debug event when a model raises during introspection' do
+      middleware.send(:build_model_introspection)
+
+      expect(logger).to have_received(:debug).with(
+        'console.model_introspection.skipped',
+        hash_including(model: 'BadModel', error_class: 'StandardError')
+      )
+    end
+
+    it 'includes the error message in the debug payload' do
+      middleware.send(:build_model_introspection)
+
+      expect(logger).to have_received(:debug).with(
+        'console.model_introspection.skipped',
+        hash_including(error_message: 'column boom')
+      )
+    end
+
+    it 'still includes the good model in the introspection result' do
+      result = middleware.send(:build_model_introspection)
+
+      expect(result[:registry]).to include('GoodModel')
+    end
+
+    it 'excludes the bad model from the introspection result' do
+      result = middleware.send(:build_model_introspection)
+
+      expect(result[:registry]).not_to include('BadModel')
     end
   end
 end


### PR DESCRIPTION
## Summary

Resolves backlog task **WOODS-CONSOLE-INTROSPECT-DEBUG**.

`RackMiddleware#build_model_introspection` previously swallowed `StandardError` from reflection calls silently — operators couldn't tell why their introspection set was smaller than expected (abstract classes, gems that register STI classes that don't load, broken associations, etc.).

- Adds a `Woods::Observability::StructuredLogger` debug-level call in the rescue block.
- Event name: `console.model_introspection.skipped` (follows existing dot-namespace convention — `console.credential_scan.hits`, `console.table_gate.rejected`).
- Payload: `model:` (class constant name), `error_class:`, `error_message:`.
- Control flow unchanged — the model still skips and introspection continues for other models. Production log volume controlled by debug-level gating.

### Files

- `lib/woods/console/rack_middleware.rb` — +~5 lines for the debug call + memoized `structured_logger` method
- `spec/console/rack_middleware_spec.rb` — 4 new examples covering the skip event

## Test plan

- [x] `bundle exec rspec spec/console/rack_middleware_spec.rb` → 7 examples, 0 failures
- [x] `bundle exec rubocop lib/woods/console/rack_middleware.rb spec/console/rack_middleware_spec.rb` → clean
- [ ] CI green