### PR TITLE
audit: quick-win bundle (P0 safe defaults, CI hardening, CVE bumps, docs, specs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,30 @@ jobs:
       - name: Run linter
         run: bundle exec rubocop
 
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@4c56a21280b36d862b5fc31348f463d60bdc55d5 # v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+      - name: Run tests with coverage
+        run: COVERAGE=true bundle exec rake spec
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@4c56a21280b36d862b5fc31348f463d60bdc55d5 # v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+      - name: Check for dependency vulnerabilities
+        run: bundle exec bundle-audit check --update
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,8 @@ Woods is a Ruby gem that extracts structured data from Rails applications via ru
 }
 ```
 
+> Use `woods-mcp-start` on Claude Code for automatic restart after crashes. Use `woods-mcp` on Cursor, Windsurf, or other MCP clients.
+
 **Console Server** (optional, requires live Rails):
 
 ```json
@@ -77,5 +79,5 @@ Run `bundle exec rake woods:extract` (or `docker compose exec app bundle exec ra
 - **Navigation edges** (`link_to`, `redirect_to`, `form_action`) trace UI user journeys. View templates produce `link_to` edges; controllers produce `redirect_to` edges; forms produce `form_action` edges.
 - **`search` accepts a `types` filter** to scope queries by unit type: `["model"]`, `["controller", "route"]`, etc.
 - **Graph analysis tools** (`graph_analysis` with `analysis:` set to `"orphans"`, `"hubs"`, `"cycles"`, `"bridges"`, or `"dead_ends"`) are the right tool for dead code detection and architecture analysis — not `search`.
-- **Console Server runs every query in a rolled-back transaction.** Writes appear to succeed but are silently discarded. SQL validation also blocks DML/DDL at the string level before any database interaction.
+- **Console Server safety model.** Every query runs in a rolled-back transaction — writes appear to succeed but are silently discarded. SQL validation blocks DML/DDL at the string level before any database interaction. Tier 4 tools additionally require confirmation and are recorded in an audit log. See [docs/CONSOLE_MCP_SETUP.md — Safety Model](docs/CONSOLE_MCP_SETUP.md#safety-model) for the full five-layer breakdown.
 - **Some unit types require full extraction to update** (routes, middleware, engines, state machines, events, factories). Incremental mode skips these.

--- a/Gemfile
+++ b/Gemfile
@@ -7,15 +7,17 @@ gemspec
 
 group :development, :test do
   gem 'benchmark-ips', '~> 2.0'
+  gem 'bundler', '>= 2.0'
+  gem 'bundler-audit', '~> 0.9'
   gem 'debug', '>= 1.0.0'
   # activesupport for specs that don't need full Rails
   gem 'activesupport'
-  gem 'bundler', '>= 2.0'
   gem 'rake', '~> 13.0'
   gem 'rspec', '~> 3.12'
   gem 'rubocop', '~> 1.50'
   gem 'rubocop-rails', '~> 2.19'
   gem 'rubocop-rspec', '~> 3.9'
+  gem 'simplecov', '~> 0.22', require: false
   gem 'sqlite3', '>= 1.4'
   # Optional: only needed for flow analysis (AST parsing)
   gem 'parser', '~> 3.3'

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,14 +49,7 @@ Extracted data is written to `tmp/woods/` by default. This directory contains yo
 
 ### Console Server
 
-The Console MCP Server provides live database access. It includes multiple safety layers:
-
-- **SafeContext** wraps all operations in a rolled-back transaction
-- **SqlValidator** rejects DML/DDL statements before execution
-- **Confirmation** gates guard destructive operations
-- **AuditLogger** records all operations to JSONL
-
-Despite these safeguards, the Console Server should only be used in development/staging environments, never in production.
+The Console MCP Server provides live database access through a five-layer defense-in-depth stack (feature gate, blocked tables, credential scanner, column redaction, and SqlValidator + rolled-back transactions). Tier 4 tools additionally require confirmation and are recorded in an audit log. Despite these safeguards, the Console Server should only be used in development/staging environments, never in production. See [docs/CONSOLE_MCP_SETUP.md — Safety Model](docs/CONSOLE_MCP_SETUP.md#safety-model) for the full breakdown.
 
 ### MCP Transport
 

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -70,7 +70,7 @@ The Index Server reads from `tmp/woods/` and does not require Rails.
 }
 ```
 
-`woods-mcp-start` is a self-healing wrapper that validates `manifest.json` before starting and auto-restarts on failure. Use it for Claude Code.
+> Use `woods-mcp-start` on Claude Code for automatic restart after crashes. Use `woods-mcp` on Cursor, Windsurf, or other MCP clients.
 
 **Cursor** — add to `.cursor/mcp.json`:
 

--- a/docs/CONSOLE_MCP_SETUP.md
+++ b/docs/CONSOLE_MCP_SETUP.md
@@ -608,6 +608,23 @@ The Console MCP ships with a five-layer defense-in-depth stack. Each layer is in
 
 Layers 0–3 are configured via `Woods.configure`. Layer 4 is always on and has no knobs. Observability hooks — `console.table_gate.rejected` for Layer 1, `console.credential_scan.hits` for Layer 2 — emit structured log lines via `Woods::Observability::StructuredLogger` so operators can audit enforcement without scraping MCP wire traffic.
 
+### Confirmation Gates
+
+Tier 4 tools (`console_eval`, `console_sql`, `console_query`) and any state-mutating Tier 2/3 operations (e.g., `console_update_setting`, retrying a job via `console_job_find`) require explicit confirmation before the executor runs. `Woods::Console::Confirmation` evaluates the request against the configured mode (`:auto_approve` for programmatic use, `:callback` for custom policies) and raises `ConfirmationDeniedError` if the check fails. The confirmation outcome — tool name, params, and granted/denied status — is recorded in the audit log.
+
+### Audit Log
+
+`Woods::Console::AuditLogger` appends a JSONL entry for every Tier 4 tool invocation. Each line records the tool name, parameters, confirmation status, result summary, and a UTC timestamp. The log path is configured when building the server:
+
+```ruby
+Woods::Console::Server.build_embedded(
+  audit_log_path: Rails.root.join('log/console_audit.jsonl'),
+  # ...
+)
+```
+
+This log is separate from the structured observability log lines (Layer 1/2 hooks) — it captures the full parameter set of every privileged call, giving operators an out-of-band audit trail independent of MCP wire traffic.
+
 ### Rolled-Back Transactions
 
 Every tool invocation runs inside a database transaction that is **always rolled back**:

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -158,6 +158,8 @@ Configure in your AI tool's MCP settings:
 }
 ```
 
+> Use `woods-mcp-start` on Claude Code for automatic restart after crashes. Use `woods-mcp` on Cursor, Windsurf, or other MCP clients.
+
 ### Console Server (live Rails queries)
 
 ```bash

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -31,7 +31,11 @@ Then run the install generator:
 bundle exec rails generate woods:install
 ```
 
-This creates `config/initializers/woods.rb` with default configuration.
+This creates `config/initializers/woods.rb` with annotated default configuration, and a migration for Woods tables (`woods_units`, `woods_edges`, `woods_embeddings`). Run migrations after the generator:
+
+```bash
+bundle exec rails db:migrate
+```
 
 > **Important:** Woods requires a booted Rails environment for extraction. It uses runtime introspection (`ActiveRecord::Base.descendants`, `Rails.application.routes`, reflection APIs) to produce accurate output. It cannot extract from source files alone.
 

--- a/docs/backlog.json
+++ b/docs/backlog.json
@@ -35,7 +35,7 @@
     "severity": "high",
     "category": "code-bug",
     "layer": "config",
-    "files": ["lib/codebase_index.rb"],
+    "files": ["lib/woods.rb"],
     "description": "Default extractors config only lists :models, :controllers, :services, :components. Missing: :jobs, :mailers, :graphql, :rails_source.",
     "status": "resolved"
   },

--- a/lib/generators/woods/install_generator.rb
+++ b/lib/generators/woods/install_generator.rb
@@ -5,20 +5,29 @@ require 'rails/generators/active_record'
 
 module Woods
   module Generators
-    # Rails generator that creates a migration for Woods tables.
+    # Rails generator that installs Woods into a Rails application.
     #
     # Usage:
     #   rails generate woods:install
     #
-    # Creates a migration with woods_units, woods_edges, and
-    # woods_embeddings tables. Works with PostgreSQL, MySQL, and SQLite.
+    # Creates:
+    #   config/initializers/woods.rb        — annotated configuration file
+    #   db/migrate/<ts>_create_woods_tables.rb — migration for Woods tables
+    #
+    # The migration creates woods_units, woods_edges, and woods_embeddings
+    # tables. Works with PostgreSQL, MySQL, and SQLite.
     #
     class InstallGenerator < Rails::Generators::Base
       include ActiveRecord::Generators::Migration
 
       source_root File.expand_path('templates', __dir__)
 
-      desc 'Creates a migration for Woods tables (units, edges, embeddings)'
+      desc 'Creates a Woods initializer and migration for Woods tables'
+
+      # @return [void]
+      def create_initializer_file
+        template 'woods.rb.tt', 'config/initializers/woods.rb'
+      end
 
       # @return [void]
       def create_migration_file

--- a/lib/generators/woods/templates/woods.rb.tt
+++ b/lib/generators/woods/templates/woods.rb.tt
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+# Woods configuration
+# Full reference: https://github.com/bigcartel/woods/blob/main/docs/CONFIGURATION_REFERENCE.md
+#
+# Quick-start presets (uncomment one instead of the full block below):
+#   Woods.configure_with_preset(:local)       # in-memory + Ollama, no external services
+#   Woods.configure_with_preset(:postgresql)  # pgvector + OpenAI (PostgreSQL required)
+#   Woods.configure_with_preset(:production)  # Qdrant + OpenAI (production-scale)
+#
+# Presets accept a block for overrides:
+#   Woods.configure_with_preset(:local) { |c| c.max_context_tokens = 16_000 }
+
+Woods.configure do |config|
+  # ── Core ────────────────────────────────────────────────────────────────
+
+  # Directory where extracted JSON is written.
+  # Default: Rails.root.join('tmp/woods')
+  config.output_dir = Rails.root.join('tmp/woods')
+
+  # Maximum tokens returned in a retrieval context window.
+  # config.max_context_tokens = 8_000
+
+  # Minimum vector similarity score (0.0–1.0) for retrieval results.
+  # config.similarity_threshold = 0.7
+
+  # Output format for retrieval: :claude, :markdown, :plain, :json
+  # config.context_format = :markdown
+
+  # Pretty-print extracted JSON (disable in CI to save disk space).
+  # config.pretty_json = true
+
+  # ── Extractors ──────────────────────────────────────────────────────────
+
+  # Enabled extractors. Default set covers the most common Rails layers.
+  # See CONFIGURATION_REFERENCE.md for the full list of available symbols.
+  # config.extractors = %i[
+  #   models controllers services components view_components
+  #   jobs mailers graphql serializers managers policies validators
+  #   rails_source
+  # ]
+
+  # Include Rails / gem source in the index (increases extraction time).
+  # config.include_framework_sources = true
+
+  # Enable parallel extraction (experimental — may conflict with some apps).
+  # config.concurrent_extraction = false
+
+  # ── Embedding ───────────────────────────────────────────────────────────
+
+  # Embedding provider: :openai or :ollama
+  # config.embedding_provider = :openai
+  # config.embedding_model    = 'text-embedding-3-small'
+  # config.embedding_options  = { api_key: ENV['OPENAI_API_KEY'] }
+
+  # Ollama (local, no API key needed):
+  # config.embedding_provider = :ollama
+  # config.embedding_model    = 'nomic-embed-text'
+  # config.embedding_options  = {
+  #   base_url: ENV.fetch('OLLAMA_URL', 'http://localhost:11434')
+  # }
+
+  # ── Storage ─────────────────────────────────────────────────────────────
+
+  # Vector store: :in_memory, :pgvector (PostgreSQL), :qdrant
+  # config.vector_store = :in_memory
+
+  # pgvector — run `rails generate woods:pgvector && rails db:migrate` first.
+  # config.vector_store         = :pgvector
+  # config.vector_store_options = {
+  #   connection: ActiveRecord::Base.connection,
+  #   dimensions: 1_536
+  # }
+
+  # Qdrant:
+  # config.vector_store         = :qdrant
+  # config.vector_store_options = {
+  #   url:        ENV.fetch('QDRANT_URL', 'http://localhost:6333'),
+  #   collection: 'woods',
+  #   dimensions: 1_536
+  # }
+
+  # Metadata store: :in_memory, :sqlite
+  # config.metadata_store = :in_memory
+  # config.metadata_store_options = {
+  #   database: Rails.root.join('tmp/woods/metadata.sqlite3').to_s
+  # }
+
+  # ── Pipeline ────────────────────────────────────────────────────────────
+
+  # Pre-compute per-action request flow maps during extraction (slow).
+  # config.precompute_flows = false
+
+  # Extract link_to / redirect_to / form_action navigation edges.
+  # config.extract_navigation_edges = true
+
+  # Temporal snapshots — requires migrations 004+005.
+  # config.enable_snapshots = false
+
+  # ── Console MCP ─────────────────────────────────────────────────────────
+  #
+  # The Console MCP server lets AI tools query your live Rails app.
+  # It is DISABLED by default. Enable only after reviewing the security
+  # documentation in docs/CONSOLE_MCP_SETUP.md.
+  #
+  # Defense layers (all active by default when the server is on):
+  #   Layer 1 — SqlValidator: rejects DML/DDL before any DB interaction.
+  #   Layer 2 — SafeContext: wraps every request in a rolled-back transaction;
+  #              writes are silently discarded even if Layer 1 is bypassed.
+  #   Layer 3 — Column redaction: credential columns are replaced with
+  #              [REDACTED] in every tool response.
+
+  # config.console_mcp_enabled = false
+  # config.console_mcp_path    = '/mcp/console'
+
+  # Credential-column redaction (Layer 3).
+  # Starts from a safe default list (passwords, tokens, secrets).
+  # Extend: Woods::DEFAULT_CONSOLE_REDACTED_COLUMNS + %w[my_secret_col]
+  # Override entirely to remove a default:
+  # config.console_redacted_columns = %w[password token api_key]
+
+  # Key-value pairs where the value should be redacted (e.g., env var names).
+  # config.console_redacted_key_values = []
+
+  # Tables completely blocked from queries.
+  # config.console_blocked_tables = []
+
+  # Disable specific scanner patterns (rare — prefer blocked_tables).
+  # config.console_disabled_scanner_patterns = []
+
+  # Allow the AI console to execute Ruby eval (off by default; very dangerous).
+  # config.console_unsafe_eval_enabled = false
+
+  # Expose SQL/query read tools inside embedded console (adds read-only DB
+  # access via the rake task or Docker exec path; SqlValidator still applies).
+  # config.console_embedded_read_tools = false
+
+  # ── Caching ─────────────────────────────────────────────────────────────
+
+  # Cache embedding and retrieval responses to reduce API cost.
+  # config.cache_enabled = false
+  # config.cache_store   = :redis   # :redis, :solid_cache, :memory
+  # config.cache_options = { redis: Redis.new(url: ENV['REDIS_URL']) }
+
+  # ── Notion Export ───────────────────────────────────────────────────────
+
+  # config.notion_api_token   = ENV['NOTION_API_TOKEN']
+  # config.notion_database_ids = {
+  #   data_models: 'your-database-id',
+  #   columns:     'your-database-id'
+  # }
+end

--- a/lib/woods.rb
+++ b/lib/woods.rb
@@ -81,6 +81,40 @@ module Woods
     secret
   ].freeze
 
+  # Console MCP secure defaults — Layer 1 table-level blocking.
+  #
+  # Tables named here are rejected outright before any SQL reaches the
+  # database. This list targets authentication and credential storage
+  # tables that carry secrets or session state across all major auth
+  # stacks (Devise, Doorkeeper, Rodauth, has_secure_password, Sorcery,
+  # OmniAuth, and hand-rolled token systems).
+  #
+  # Intentionally omitted to avoid over-blocking benign apps:
+  #   - `users` / `accounts` — many apps expose safe columns from these
+  #     tables and operators should decide explicitly.
+  #   - PII-heavy but auth-unrelated tables (`payments`, `addresses`) —
+  #     org-specific compliance concern, not a universal default.
+  #
+  # To keep the defaults and add more tables:
+  #   Woods.configure { |c| c.console_blocked_tables =
+  #     Woods::DEFAULT_CONSOLE_BLOCKED_TABLES + %w[extra_table] }
+  #
+  # To replace the defaults entirely (including removing entries):
+  #   Woods.configure { |c| c.console_blocked_tables = %w[only_this] }
+  #
+  # To disable Layer 1 (gate becomes inactive; other layers still apply):
+  #   Woods.configure { |c| c.console_blocked_tables = [] }
+  DEFAULT_CONSOLE_BLOCKED_TABLES = %w[
+    sessions
+    api_keys
+    credentials
+    oauth_applications
+    oauth_access_tokens
+    oauth_refresh_tokens
+    identities
+    active_storage_blobs
+  ].freeze
+
   # ════════════════════════════════════════════════════════════════════════
   # Configuration
   # ════════════════════════════════════════════════════════════════════════
@@ -126,7 +160,7 @@ module Woods
       @console_redacted_columns = DEFAULT_CONSOLE_REDACTED_COLUMNS.dup
       @console_redacted_key_values = []
       @console_embedded_read_tools = false
-      @console_blocked_tables = []
+      @console_blocked_tables = DEFAULT_CONSOLE_BLOCKED_TABLES.dup
       @console_disabled_scanner_patterns = []
       @console_credential_defense_enabled = true
       @console_credential_rotation_warning = true

--- a/lib/woods/console/rack_middleware.rb
+++ b/lib/woods/console/rack_middleware.rb
@@ -115,6 +115,8 @@ module Woods
         @mutex.synchronize do
           return @transport if @transport
 
+          check_blocked_tables_config!
+
           require 'woods/console/server'
           Rails.application.eager_load!
 
@@ -123,6 +125,31 @@ module Woods
           server.transport = @transport
           @transport
         end
+      end
+
+      # Emit a prominent warning (or raise in production) when the Console MCP
+      # is enabled but no tables are blocked. An empty block list means Layer 1
+      # of the defense stack is fully inactive — every table in the database is
+      # reachable via console_sql, console_query, and the model tools.
+      #
+      # Remediation:
+      #   Woods.configure { |c| c.console_blocked_tables =
+      #     Woods::DEFAULT_CONSOLE_BLOCKED_TABLES + %w[your_sensitive_table] }
+      #
+      # @raise [Woods::ConfigurationError] in production environments
+      def check_blocked_tables_config!
+        return unless Woods.configuration.console_blocked_tables.empty?
+
+        message =
+          '[Woods Console] console_blocked_tables is empty — Layer 1 (table gate) is INACTIVE. ' \
+          'All tables are reachable via the Console MCP. ' \
+          'Set console_blocked_tables in your Woods initializer to restrict access. ' \
+          'Example: Woods.configure { |c| c.console_blocked_tables = ' \
+          'Woods::DEFAULT_CONSOLE_BLOCKED_TABLES + %w[your_table] }'
+
+        raise Woods::ConfigurationError, message if defined?(Rails) && Rails.env.production?
+
+        warn message
       end
 
       # Build the embedded MCP server. SafeContext is given the writing

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe Woods::Configuration do
       expect(config.console_redacted_key_values).to eq([])
     end
 
-    it 'sets console_blocked_tables to empty array' do
-      expect(config.console_blocked_tables).to eq([])
+    it 'sets console_blocked_tables to DEFAULT_CONSOLE_BLOCKED_TABLES' do
+      expect(config.console_blocked_tables).to eq(Woods::DEFAULT_CONSOLE_BLOCKED_TABLES)
     end
 
     it 'sets console_disabled_scanner_patterns to empty array' do

--- a/spec/console/rack_middleware_spec.rb
+++ b/spec/console/rack_middleware_spec.rb
@@ -121,4 +121,63 @@ RSpec.describe Woods::Console::RackMiddleware do
       expect(result[:registry]).not_to include('BadModel')
     end
   end
+
+  describe '#check_blocked_tables_config!' do
+    subject(:middleware) { described_class.new(->(_env) { [200, {}, []] }) }
+
+    context 'when console_blocked_tables is non-empty' do
+      before do
+        allow(Woods.configuration).to receive(:console_blocked_tables)
+          .and_return(%w[sessions])
+      end
+
+      it 'does nothing' do
+        expect { middleware.send(:check_blocked_tables_config!) }.not_to raise_error
+      end
+    end
+
+    context 'when console_blocked_tables is empty in a non-production environment' do
+      before do
+        allow(Woods.configuration).to receive(:console_blocked_tables).and_return([])
+
+        rails_env = double('env', production?: false)
+        rails_double = class_double('Rails').as_stubbed_const
+        allow(rails_double).to receive(:env).and_return(rails_env)
+      end
+
+      it 'emits a warn instead of raising' do
+        expect { middleware.send(:check_blocked_tables_config!) }.not_to raise_error
+      end
+
+      it 'includes the remediation hint in the warning' do
+        warning = nil
+        allow(middleware).to receive(:warn) { |msg| warning = msg }
+
+        middleware.send(:check_blocked_tables_config!)
+
+        expect(warning).to include('console_blocked_tables')
+        expect(warning).to include('DEFAULT_CONSOLE_BLOCKED_TABLES')
+      end
+    end
+
+    context 'when console_blocked_tables is empty in production' do
+      before do
+        allow(Woods.configuration).to receive(:console_blocked_tables).and_return([])
+
+        rails_env = double('env', production?: true)
+        rails_double = class_double('Rails').as_stubbed_const
+        allow(rails_double).to receive(:env).and_return(rails_env)
+      end
+
+      it 'raises Woods::ConfigurationError' do
+        expect { middleware.send(:check_blocked_tables_config!) }
+          .to raise_error(Woods::ConfigurationError, /console_blocked_tables/)
+      end
+
+      it 'includes the remediation hint in the error message' do
+        expect { middleware.send(:check_blocked_tables_config!) }
+          .to raise_error(Woods::ConfigurationError, /DEFAULT_CONSOLE_BLOCKED_TABLES/)
+      end
+    end
+  end
 end

--- a/spec/console/redactor_spec.rb
+++ b/spec/console/redactor_spec.rb
@@ -1,0 +1,305 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'woods/console/redactor'
+
+RSpec.describe Woods::Console::Redactor do
+  # Normalize a single EAV pattern (symbol keys → string keys).
+  def normalize_kv_pattern(pat)
+    {
+      'key_column' => pat[:key_column].to_s,
+      'value_column' => pat[:value_column].to_s,
+      'sensitive_keys' => Array(pat[:sensitive_keys]).map(&:to_s)
+    }
+  end
+
+  # Apply EAV rules to an already column-redacted hash.
+  def apply_kv_rules(hash, kvs)
+    kvs.each do |rule|
+      kc = rule['key_column']
+      vc = rule['value_column']
+      next unless hash.key?(kc) && hash.key?(vc)
+      next unless rule['sensitive_keys'].include?(hash[kc].to_s)
+
+      hash[vc] = '[REDACTED]'
+    end
+    hash
+  end
+
+  # Minimal stand-in for SafeContext. Exposes redacted_columns /
+  # redacted_key_values and stubs #redact with the same logic SafeContext uses.
+  def build_ctx(redacted_columns: [], redacted_key_values: [])
+    cols = Array(redacted_columns).map(&:to_s)
+    kvs  = Array(redacted_key_values).map { |p| normalize_kv_pattern(p) }
+
+    double('SafeContext',
+           redacted_columns: cols,
+           redacted_key_values: kvs).tap do |ctx|
+      allow(ctx).to receive(:redact) do |hash|
+        str_hash = hash.transform_keys(&:to_s)
+        column_redacted = str_hash.each_with_object({}) do |(k, v), out|
+          out[k] = cols.include?(k) ? '[REDACTED]' : v
+        end
+        apply_kv_rules(column_redacted, kvs)
+      end
+    end
+  end
+
+  describe '.apply' do
+    context 'with a plain Hash result (no envelope keys)' do
+      let(:ctx) { build_ctx(redacted_columns: ['password']) }
+
+      it 'redacts the matched column and leaves others intact' do
+        result = described_class.apply({ 'password' => 'hunter2', 'email' => 'x@y.z' }, ctx)
+        expect(result['password']).to eq('[REDACTED]')
+        expect(result['email']).to eq('x@y.z')
+      end
+
+      it 'converts symbol keys to string keys before redacting' do
+        result = described_class.apply({ password: 'hunter2', email: 'x@y.z' }, ctx)
+        expect(result['password']).to eq('[REDACTED]')
+        expect(result['email']).to eq('x@y.z')
+      end
+
+      it 'leaves a non-redacted column unchanged' do
+        ctx_clean = build_ctx(redacted_columns: ['secret'])
+        result = described_class.apply({ 'email' => 'x@y.z', 'name' => 'Alice' }, ctx_clean)
+        expect(result['email']).to eq('x@y.z')
+        expect(result['name']).to eq('Alice')
+      end
+
+      it 'returns the original value when no columns are redacted' do
+        ctx_empty = build_ctx
+        result = described_class.apply({ 'password' => 'hunter2' }, ctx_empty)
+        expect(result['password']).to eq('hunter2')
+      end
+    end
+
+    context 'with an Array of Hashes' do
+      let(:ctx) { build_ctx(redacted_columns: ['password']) }
+
+      it 'redacts each Hash element in the array' do
+        rows = [
+          { 'password' => 'abc', 'id' => 1 },
+          { 'password' => 'def', 'id' => 2 }
+        ]
+        result = described_class.apply(rows, ctx)
+        expect(result.map { |r| r['password'] }).to eq(%w[[REDACTED] [REDACTED]])
+        expect(result.map { |r| r['id'] }).to eq([1, 2])
+      end
+
+      it 'leaves non-Hash elements in an Array untouched' do
+        result = described_class.apply([1, 'plain', nil], ctx)
+        expect(result).to eq([1, 'plain', nil])
+      end
+    end
+
+    context 'with a scalar result' do
+      let(:ctx) { build_ctx(redacted_columns: ['password']) }
+
+      it 'returns the scalar unchanged' do
+        expect(described_class.apply(42, ctx)).to eq(42)
+        expect(described_class.apply(nil, ctx)).to be_nil
+        expect(described_class.apply('string', ctx)).to eq('string')
+      end
+    end
+  end
+
+  describe '.apply — envelope shapes' do
+    context '{record: Hash} shape (find)' do
+      let(:ctx) { build_ctx(redacted_columns: ['password']) }
+
+      it 'redacts inside the record value' do
+        result = described_class.apply(
+          { 'record' => { 'password' => 'hunter2', 'email' => 'x@y.z' } },
+          ctx
+        )
+        expect(result['record']['password']).to eq('[REDACTED]')
+        expect(result['record']['email']).to eq('x@y.z')
+      end
+
+      it 'passes through a non-Hash record value unchanged' do
+        result = described_class.apply({ 'record' => 'not_a_hash' }, ctx)
+        expect(result['record']).to eq('not_a_hash')
+      end
+    end
+
+    context '{records: [Hash]} shape (sample, recent)' do
+      let(:ctx) { build_ctx(redacted_columns: ['password']) }
+
+      it 'redacts each record in the array' do
+        result = described_class.apply(
+          { 'records' => [
+            { 'password' => 'abc', 'id' => 1 },
+            { 'password' => 'xyz', 'id' => 2 }
+          ] },
+          ctx
+        )
+        expect(result['records'].map { |r| r['password'] }).to all(eq('[REDACTED]'))
+      end
+
+      it 'leaves non-Hash entries in records array untouched' do
+        result = described_class.apply({ 'records' => [nil, 'bare'] }, ctx)
+        expect(result['records']).to eq([nil, 'bare'])
+      end
+    end
+
+    context '{columns:, rows:} shape (sql, query)' do
+      let(:ctx) { build_ctx(redacted_columns: ['password']) }
+
+      it 'redacts positional cells where the column is in redacted_columns' do
+        result = described_class.apply(
+          { 'columns' => %w[id email password],
+            'rows' => [[1, 'x@y.z', 'hunter2'], [2, 'a@b.c', 'secret']] },
+          ctx
+        )
+        expect(result['rows'][0]).to eq([1, 'x@y.z', '[REDACTED]'])
+        expect(result['rows'][1]).to eq([2, 'a@b.c', '[REDACTED]'])
+      end
+
+      it 'leaves rows untouched when no column names are in redacted_columns' do
+        ctx_other = build_ctx(redacted_columns: ['ssn'])
+        result = described_class.apply(
+          { 'columns' => %w[id email], 'rows' => [[1, 'x@y.z']] },
+          ctx_other
+        )
+        expect(result['rows'][0]).to eq([1, 'x@y.z'])
+      end
+
+      it 'passes envelope keys that are not data (e.g. total_count) through unchanged' do
+        result = described_class.apply(
+          { 'columns' => %w[id password], 'rows' => [[1, 'hunter2']], 'total_count' => 99 },
+          ctx
+        )
+        expect(result['total_count']).to eq(99)
+        expect(result['rows'][0]).to eq([1, '[REDACTED]'])
+      end
+    end
+
+    context '{columns:, values:} shape (pluck)' do
+      let(:ctx) { build_ctx(redacted_columns: ['password']) }
+
+      it 'redacts multi-column pluck rows (nested arrays)' do
+        result = described_class.apply(
+          { 'columns' => %w[id password],
+            'values' => [[1, 'hunter2'], [2, 'secret']] },
+          ctx
+        )
+        expect(result['values'][0]).to eq([1, '[REDACTED]'])
+        expect(result['values'][1]).to eq([2, '[REDACTED]'])
+      end
+
+      it 'redacts a single-column pluck (flat scalar array)' do
+        result = described_class.apply(
+          { 'columns' => %w[password],
+            'values' => %w[hunter2 secret] },
+          ctx
+        )
+        expect(result['values']).to eq(%w[[REDACTED] [REDACTED]])
+      end
+
+      it 'does not redact scalars in a flat array when the column is not redacted' do
+        ctx_other = build_ctx(redacted_columns: ['ssn'])
+        result = described_class.apply(
+          { 'columns' => %w[email],
+            'values' => %w[x@y.z a@b.c] },
+          ctx_other
+        )
+        expect(result['values']).to eq(%w[x@y.z a@b.c])
+      end
+    end
+
+    context '{associations: Hash} shape (data_snapshot)' do
+      let(:ctx) { build_ctx(redacted_columns: ['password']) }
+
+      it 'redacts records in each association array' do
+        result = described_class.apply(
+          { 'record' => { 'id' => 1, 'password' => 'hunter2' },
+            'associations' => {
+              'orders' => [{ 'id' => 10, 'password' => 'p1' }],
+              'comments' => [{ 'id' => 20, 'password' => 'p2' }]
+            } },
+          ctx
+        )
+        expect(result['associations']['orders'][0]['password']).to eq('[REDACTED]')
+        expect(result['associations']['comments'][0]['password']).to eq('[REDACTED]')
+      end
+
+      it 'passes through a non-Hash associations value unchanged' do
+        result = described_class.apply({ 'associations' => 'not_a_hash' }, ctx)
+        expect(result['associations']).to eq('not_a_hash')
+      end
+    end
+  end
+
+  describe 'EAV (key-value) redaction' do
+    let(:kv_pattern) do
+      { key_column: 'key', value_column: 'value',
+        sensitive_keys: %w[stripe_access_token oauth_token] }
+    end
+    let(:ctx) { build_ctx(redacted_key_values: [kv_pattern]) }
+
+    context 'with {record: Hash} shape' do
+      it 'redacts the value when the key cell matches a sensitive key' do
+        result = described_class.apply(
+          { 'record' => { 'key' => 'stripe_access_token', 'value' => 'sk_live_123' } },
+          ctx
+        )
+        expect(result['record']['value']).to eq('[REDACTED]')
+      end
+
+      it 'leaves the value when the key cell does not match any sensitive key' do
+        result = described_class.apply(
+          { 'record' => { 'key' => 'theme', 'value' => 'dark' } },
+          ctx
+        )
+        expect(result['record']['value']).to eq('dark')
+      end
+    end
+
+    context 'with {columns:, rows:} shape' do
+      it 'redacts the value column when the key cell matches a sensitive key' do
+        result = described_class.apply(
+          { 'columns' => %w[id key value],
+            'rows' => [[1, 'oauth_token', 'tok_secret'], [2, 'theme', 'dark']] },
+          ctx
+        )
+        expect(result['rows'][0]).to eq([1, 'oauth_token', '[REDACTED]'])
+        expect(result['rows'][1]).to eq([2, 'theme', 'dark'])
+      end
+
+      it 'is a no-op when the columns header lacks the key or value column' do
+        result = described_class.apply(
+          { 'columns' => %w[id name],
+            'rows' => [[1, 'alice']] },
+          ctx
+        )
+        expect(result['rows'][0]).to eq([1, 'alice'])
+      end
+    end
+
+    context 'with {records: [Hash]} shape' do
+      it 'redacts sensitive EAV values across all records' do
+        result = described_class.apply(
+          { 'records' => [
+            { 'key' => 'stripe_access_token', 'value' => 'sk_live_abc' },
+            { 'key' => 'display_name',        'value' => 'Alice' }
+          ] },
+          ctx
+        )
+        expect(result['records'][0]['value']).to eq('[REDACTED]')
+        expect(result['records'][1]['value']).to eq('Alice')
+      end
+    end
+  end
+
+  describe 'DATA_ENVELOPE_KEYS constant' do
+    it 'includes record, records, rows, values, and associations' do
+      expect(described_class::DATA_ENVELOPE_KEYS).to include('record', 'records', 'rows', 'values', 'associations')
+    end
+
+    it 'is frozen' do
+      expect(described_class::DATA_ENVELOPE_KEYS).to be_frozen
+    end
+  end
+end

--- a/spec/console/table_gate_spec.rb
+++ b/spec/console/table_gate_spec.rb
@@ -1,9 +1,67 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'woods'
 require 'woods/console/table_gate'
 
 RSpec.describe Woods::Console::TableGate do
+  describe 'DEFAULT_CONSOLE_BLOCKED_TABLES' do
+    subject(:gate) do
+      described_class.new(
+        blocked_tables: Woods::DEFAULT_CONSOLE_BLOCKED_TABLES,
+        model_tables: {}
+      )
+    end
+
+    it 'is active (non-empty)' do
+      expect(gate).to be_active
+    end
+
+    it 'blocks sessions' do
+      expect { gate.check_sql!('SELECT * FROM sessions') }
+        .to raise_error(Woods::Console::TableGateError, /sessions/)
+    end
+
+    it 'blocks api_keys' do
+      expect { gate.check_sql!('SELECT * FROM api_keys') }
+        .to raise_error(Woods::Console::TableGateError, /api_keys/)
+    end
+
+    it 'blocks credentials' do
+      expect { gate.check_sql!('SELECT * FROM credentials') }
+        .to raise_error(Woods::Console::TableGateError, /credentials/)
+    end
+
+    it 'blocks oauth_applications' do
+      expect { gate.check_sql!('SELECT * FROM oauth_applications') }
+        .to raise_error(Woods::Console::TableGateError, /oauth_applications/)
+    end
+
+    it 'blocks oauth_access_tokens' do
+      expect { gate.check_sql!('SELECT * FROM oauth_access_tokens') }
+        .to raise_error(Woods::Console::TableGateError, /oauth_access_tokens/)
+    end
+
+    it 'blocks oauth_refresh_tokens' do
+      expect { gate.check_sql!('SELECT * FROM oauth_refresh_tokens') }
+        .to raise_error(Woods::Console::TableGateError, /oauth_refresh_tokens/)
+    end
+
+    it 'blocks identities' do
+      expect { gate.check_sql!('SELECT * FROM identities') }
+        .to raise_error(Woods::Console::TableGateError, /identities/)
+    end
+
+    it 'blocks active_storage_blobs' do
+      expect { gate.check_sql!('SELECT * FROM active_storage_blobs') }
+        .to raise_error(Woods::Console::TableGateError, /active_storage_blobs/)
+    end
+
+    it 'allows safe non-auth tables (e.g. products)' do
+      expect { gate.check_sql!('SELECT * FROM products') }.not_to raise_error
+    end
+  end
+
   describe '#check_sql!' do
     context 'when no tables are blocked' do
       let(:gate) { described_class.new(blocked_tables: [], model_tables: {}) }
@@ -13,6 +71,13 @@ RSpec.describe Woods::Console::TableGate do
       end
 
       it 'reports that the gate is inactive' do
+        expect(gate).not_to be_active
+      end
+
+      it 'remains entirely inactive even when DEFAULT_CONSOLE_BLOCKED_TABLES is non-empty' do
+        # Operators that explicitly set console_blocked_tables = [] intentionally
+        # disable Layer 1. The gate must honour that choice and stay inactive.
+        expect(Woods::DEFAULT_CONSOLE_BLOCKED_TABLES).not_to be_empty
         expect(gate).not_to be_active
       end
     end

--- a/spec/console/tool_specs_spec.rb
+++ b/spec/console/tool_specs_spec.rb
@@ -2,28 +2,20 @@
 
 require 'spec_helper'
 
-# tool_specs.rb is loaded as part of the console server — stub the minimal
-# constants it references at load time so we can exercise the data table
-# without booting a full Rails environment.
-module Woods
-  module Console
-    module Server
-      module Tools
-        module Tier1; end
-        module Tier2; end
-        module Tier3; end
-        module Tier4; end
-      end
-
-      # Tier 4 handlers reference these at spec-definition time via `begin` blocks.
-      # rubocop:disable Lint/EmptyClass
-      class EvalGuard; end
-      class SqlValidator; end
-      # rubocop:enable Lint/EmptyClass
-    end
-  end
-end
-
+# tool_specs.rb is a pure data table. Tier 4 `handler:` values use `begin`
+# blocks that instantiate EvalGuard / SqlValidator at require-time, and
+# Tier 1–3 lambdas reference `Tools::TierN` (resolved lexically from
+# `Woods::Console::Server`). Loading the real dependencies — rather than
+# stubbing them here — prevents spec-order pollution: empty stubs at
+# `Woods::Console::Server::Tools::Tier1` or `Server::SqlValidator` would
+# shadow the real constants for every later spec that exercises the
+# server through its tool lambdas.
+require 'woods/console/eval_guard'
+require 'woods/console/sql_validator'
+require 'woods/console/tools/tier1'
+require 'woods/console/tools/tier2'
+require 'woods/console/tools/tier3'
+require 'woods/console/tools/tier4'
 require 'woods/console/tool_specs'
 
 RSpec.describe Woods::Console::Server do

--- a/spec/console/tool_specs_spec.rb
+++ b/spec/console/tool_specs_spec.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# tool_specs.rb is loaded as part of the console server — stub the minimal
+# constants it references at load time so we can exercise the data table
+# without booting a full Rails environment.
+module Woods
+  module Console
+    module Server
+      module Tools
+        module Tier1; end
+        module Tier2; end
+        module Tier3; end
+        module Tier4; end
+      end
+
+      # Tier 4 handlers reference these at spec-definition time via `begin` blocks.
+      # rubocop:disable Lint/EmptyClass
+      class EvalGuard; end
+      class SqlValidator; end
+      # rubocop:enable Lint/EmptyClass
+    end
+  end
+end
+
+require 'woods/console/tool_specs'
+
+RSpec.describe Woods::Console::Server do
+  let(:all_specs) { described_class::TOOL_SPECS }
+
+  let(:valid_tiers) { (1..4).to_a }
+  let(:tier_constants) do
+    {
+      1 => described_class::TIER1_TOOLS,
+      2 => described_class::TIER2_TOOLS,
+      3 => described_class::TIER3_TOOLS,
+      4 => described_class::TIER4_TOOLS
+    }
+  end
+
+  # ── Catalogue completeness ─────────────────────────────────────────────────
+
+  describe 'TOOL_SPECS' do
+    it 'contains 31 entries' do
+      expect(all_specs.size).to eq(31)
+    end
+
+    it 'is frozen' do
+      expect(all_specs).to be_frozen
+    end
+  end
+
+  # ── Required fields on every ToolSpec ─────────────────────────────────────
+
+  describe 'each ToolSpec' do
+    it 'has a non-empty String name' do
+      expect(all_specs).to all(satisfy { |s| s.name.is_a?(String) && !s.name.empty? })
+    end
+
+    it 'has a non-empty String description' do
+      expect(all_specs).to all(satisfy { |s| s.description.is_a?(String) && !s.description.empty? })
+    end
+
+    it 'has a Hash properties value' do
+      expect(all_specs).to all(satisfy { |s| s.properties.is_a?(Hash) })
+    end
+
+    it 'has a valid tier (1–4)' do
+      expect(all_specs).to all(satisfy { |s| valid_tiers.include?(s.tier) })
+    end
+
+    it 'has a callable handler' do
+      expect(all_specs).to all(satisfy { |s| s.handler.respond_to?(:call) })
+    end
+
+    it 'has required that is nil or an Array of Strings' do
+      all_specs.each do |spec|
+        next if spec.required.nil?
+
+        expect(spec.required).to be_an(Array), "#{spec.name}: required must be nil or Array"
+        expect(spec.required).to all(be_a(String)), "#{spec.name}: required entries must be Strings"
+      end
+    end
+  end
+
+  # ── No duplicate names ────────────────────────────────────────────────────
+
+  describe 'TOOL_SPECS names' do
+    it 'are unique (no duplicates)' do
+      names = all_specs.map(&:name)
+      expect(names).to eq(names.uniq)
+    end
+
+    it 'all start with the console_ prefix' do
+      expect(all_specs).to all(satisfy { |s| s.name.start_with?('console_') })
+    end
+  end
+
+  # ── Tier catalogue cross-check ────────────────────────────────────────────
+
+  describe 'tier constants' do
+    it 'TIER1_TOOLS, TIER2_TOOLS, TIER3_TOOLS, TIER4_TOOLS are non-overlapping' do
+      all_names = [
+        described_class::TIER1_TOOLS,
+        described_class::TIER2_TOOLS,
+        described_class::TIER3_TOOLS,
+        described_class::TIER4_TOOLS
+      ].flatten
+      expect(all_names).to eq(all_names.uniq)
+    end
+
+    it 'each TOOL_SPEC name appears in exactly one tier constant (strip console_ prefix)' do
+      all_specs.each do |spec|
+        short_name = spec.name.delete_prefix('console_')
+        matching_tiers = tier_constants.select { |_, names| names.include?(short_name) }
+        msg = "#{spec.name}: expected in exactly one tier constant, found in #{matching_tiers.keys}"
+        expect(matching_tiers.size).to eq(1), msg
+      end
+    end
+
+    it 'every name in a tier constant maps to a TOOL_SPEC with that tier number' do
+      tier_constants.each do |tier_num, names|
+        names.each do |short_name|
+          full_name = "console_#{short_name}"
+          spec = all_specs.find { |s| s.name == full_name }
+          expect(spec).not_to be_nil, "No ToolSpec found for #{full_name}"
+          expect(spec.tier).to eq(tier_num),
+                               "#{full_name}: expected tier #{tier_num}, got #{spec.tier}"
+        end
+      end
+    end
+  end
+
+  # ── Properties schema validity ────────────────────────────────────────────
+
+  describe 'each ToolSpec property definition' do
+    it 'has a type field' do
+      all_specs.each do |spec|
+        spec.properties.each do |prop_name, defn|
+          expect(defn).to have_key(:type),
+                          "#{spec.name}.#{prop_name}: missing :type key"
+        end
+      end
+    end
+
+    it 'has a description field' do
+      all_specs.each do |spec|
+        spec.properties.each do |prop_name, defn|
+          expect(defn).to have_key(:description),
+                          "#{spec.name}.#{prop_name}: missing :description key"
+        end
+      end
+    end
+
+    it 'uses only allowed JSON Schema types' do
+      allowed_types = %w[string integer boolean object array number].freeze
+      all_specs.each do |spec|
+        spec.properties.each do |prop_name, defn|
+          expect(allowed_types).to include(defn[:type]),
+                                   "#{spec.name}.#{prop_name}: unexpected type '#{defn[:type]}'"
+        end
+      end
+    end
+  end
+
+  # ── required field cross-check ────────────────────────────────────────────
+
+  describe 'required fields' do
+    it 'each required field name exists as a property key' do
+      all_specs.each do |spec|
+        next unless spec.required
+
+        spec.required.each do |req|
+          expect(spec.properties).to have_key(req.to_sym).or(have_key(req)),
+                                     "#{spec.name}: required field '#{req}' not found in properties"
+        end
+      end
+    end
+  end
+
+  # ── Spot checks on specific tools ─────────────────────────────────────────
+
+  describe 'console_count' do
+    subject(:spec) { all_specs.find { |s| s.name == 'console_count' } }
+
+    it 'is tier 1' do
+      expect(spec.tier).to eq(1)
+    end
+
+    it 'requires model' do
+      expect(spec.required).to eq(['model'])
+    end
+
+    it 'defines a model property of type string' do
+      expect(spec.properties[:model][:type]).to eq('string')
+    end
+  end
+
+  describe 'console_sql' do
+    subject(:spec) { all_specs.find { |s| s.name == 'console_sql' } }
+
+    it 'is tier 4' do
+      expect(spec.tier).to eq(4)
+    end
+
+    it 'requires sql' do
+      expect(spec.required).to include('sql')
+    end
+  end
+
+  describe 'console_status' do
+    subject(:spec) { all_specs.find { |s| s.name == 'console_status' } }
+
+    it 'has no required fields' do
+      expect(spec.required).to be_nil
+    end
+
+    it 'has an empty properties Hash' do
+      expect(spec.properties).to eq({})
+    end
+  end
+end

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -41,6 +41,56 @@ RSpec.describe 'Install generator template' do
   end
 end
 
+RSpec.describe 'Install generator initializer template' do
+  let(:template_path) do
+    File.expand_path('../../lib/generators/woods/templates/woods.rb.tt', __dir__)
+  end
+
+  it 'template file exists' do
+    expect(File.exist?(template_path)).to be true
+  end
+
+  it 'template calls Woods.configure' do
+    content = File.read(template_path)
+    expect(content).to include('Woods.configure do |config|')
+  end
+
+  it 'template sets output_dir relative to Rails.root' do
+    content = File.read(template_path)
+    expect(content).to include('Rails.root.join')
+    expect(content).to include('tmp/woods')
+  end
+
+  it 'template mentions configure_with_preset idiom' do
+    content = File.read(template_path)
+    expect(content).to include('configure_with_preset')
+  end
+
+  it 'template covers console_mcp options' do
+    content = File.read(template_path)
+    expect(content).to include('console_mcp_enabled')
+    expect(content).to include('console_redacted_columns')
+  end
+
+  it 'template keeps console MCP disabled by default' do
+    content = File.read(template_path)
+    # The enable line must be commented out
+    expect(content).to match(/^\s*#\s*config\.console_mcp_enabled\s*=\s*false/)
+  end
+
+  it 'template mentions all three defense layers' do
+    content = File.read(template_path)
+    expect(content).to include('Layer 1')
+    expect(content).to include('Layer 2')
+    expect(content).to include('Layer 3')
+  end
+
+  it 'has frozen_string_literal comment' do
+    content = File.read(template_path)
+    expect(content).to start_with('# frozen_string_literal: true')
+  end
+end
+
 RSpec.describe 'Install generator class' do
   let(:generator_path) do
     File.expand_path('../../lib/generators/woods/install_generator.rb', __dir__)
@@ -54,5 +104,17 @@ RSpec.describe 'Install generator class' do
     content = File.read(generator_path)
     expect(content).to include('class InstallGenerator')
     expect(content).to include('module Generators')
+  end
+
+  it 'copies the initializer template' do
+    content = File.read(generator_path)
+    expect(content).to include("template 'woods.rb.tt'")
+    expect(content).to include('config/initializers/woods.rb')
+  end
+
+  it 'copies the migration template' do
+    content = File.read(generator_path)
+    expect(content).to include('migration_template')
+    expect(content).to include('create_woods_tables.rb.erb')
   end
 end

--- a/spec/mcp/bootstrapper_spec.rb
+++ b/spec/mcp/bootstrapper_spec.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+require 'woods'
+require 'woods/mcp/bootstrapper'
+
+RSpec.describe Woods::MCP::Bootstrapper do
+  describe '.resolve_index_dir' do
+    let(:fixture_dir) { File.expand_path('../fixtures/woods', __dir__) }
+
+    context 'when argv supplies a valid directory containing manifest.json' do
+      it 'returns the directory from argv[0]' do
+        result = described_class.resolve_index_dir([fixture_dir])
+        expect(result).to eq(fixture_dir)
+      end
+    end
+
+    context 'when argv is empty and WOODS_DIR env var is set' do
+      around do |example|
+        old = ENV.delete('WOODS_DIR')
+        ENV['WOODS_DIR'] = fixture_dir
+        example.run
+      ensure
+        old ? ENV['WOODS_DIR'] = old : ENV.delete('WOODS_DIR')
+      end
+
+      it 'returns the directory from WOODS_DIR' do
+        result = described_class.resolve_index_dir([])
+        expect(result).to eq(fixture_dir)
+      end
+    end
+
+    context 'resolution priority: argv[0] wins over WOODS_DIR' do
+      around do |example|
+        old = ENV.delete('WOODS_DIR')
+        ENV['WOODS_DIR'] = fixture_dir
+        example.run
+      ensure
+        old ? ENV['WOODS_DIR'] = old : ENV.delete('WOODS_DIR')
+      end
+
+      it 'uses argv[0] when both argv and WOODS_DIR are present' do
+        result = described_class.resolve_index_dir([fixture_dir])
+        expect(result).to eq(fixture_dir)
+      end
+    end
+
+    context 'when the directory does not exist' do
+      it 'exits with status 1' do
+        expect do
+          described_class.resolve_index_dir(['/definitely/not/a/real/woods/dir'])
+        end.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+      end
+
+      it 'emits a descriptive error to stderr' do
+        expect do
+          described_class.resolve_index_dir(['/definitely/not/a/real/woods/dir'])
+        end.to output(/Index directory does not exist/).to_stderr
+           .and raise_error(SystemExit)
+      end
+    end
+
+    context 'when the directory exists but lacks manifest.json' do
+      it 'exits with status 1' do
+        Dir.mktmpdir do |dir|
+          expect do
+            described_class.resolve_index_dir([dir])
+          end.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+        end
+      end
+
+      it 'mentions manifest.json in the error output' do
+        Dir.mktmpdir do |dir|
+          expect do
+            described_class.resolve_index_dir([dir])
+          end.to output(/manifest\.json/).to_stderr
+             .and raise_error(SystemExit)
+        end
+      end
+
+      it 'suggests running woods:extract' do
+        Dir.mktmpdir do |dir|
+          expect do
+            described_class.resolve_index_dir([dir])
+          end.to output(/woods:extract/).to_stderr
+             .and raise_error(SystemExit)
+        end
+      end
+    end
+
+    context 'when argv is empty and WOODS_DIR is unset (Dir.pwd fallback)' do
+      around do |example|
+        old = ENV.delete('WOODS_DIR')
+        example.run
+      ensure
+        old ? ENV['WOODS_DIR'] = old : ENV.delete('WOODS_DIR')
+      end
+
+      it 'exits when Dir.pwd has no manifest.json' do
+        # Gem root never has a manifest.json — safe to assume SystemExit here
+        unless File.exist?(File.join(Dir.pwd, 'manifest.json'))
+          expect do
+            described_class.resolve_index_dir([])
+          end.to raise_error(SystemExit)
+        end
+      end
+    end
+  end
+
+  describe '.build_snapshot_store' do
+    context 'when snapshots are disabled (no env var, no SQLite DB, config off)' do
+      around do |example|
+        old = ENV.delete('WOODS_SNAPSHOTS')
+        example.run
+      ensure
+        old ? ENV['WOODS_SNAPSHOTS'] = old : ENV.delete('WOODS_SNAPSHOTS')
+      end
+
+      it 'returns nil' do
+        Dir.mktmpdir do |dir|
+          allow(Woods.configuration).to receive(:enable_snapshots).and_return(false)
+          result = described_class.build_snapshot_store(dir)
+          expect(result).to be_nil
+        end
+      end
+    end
+
+    context 'when WOODS_SNAPSHOTS=true' do
+      around do |example|
+        old = ENV.delete('WOODS_SNAPSHOTS')
+        ENV['WOODS_SNAPSHOTS'] = 'true'
+        example.run
+      ensure
+        old ? ENV['WOODS_SNAPSHOTS'] = old : ENV.delete('WOODS_SNAPSHOTS')
+      end
+
+      it 'returns a snapshot store object rather than nil' do
+        Dir.mktmpdir do |dir|
+          result = described_class.build_snapshot_store(dir)
+          expect(result).not_to be_nil
+        end
+      end
+    end
+
+    context 'when a woods.sqlite3 file already exists in the index directory' do
+      around do |example|
+        old = ENV.delete('WOODS_SNAPSHOTS')
+        example.run
+      ensure
+        old ? ENV['WOODS_SNAPSHOTS'] = old : ENV.delete('WOODS_SNAPSHOTS')
+      end
+
+      it 'auto-enables and returns a store' do
+        Dir.mktmpdir do |dir|
+          FileUtils.touch(File.join(dir, 'woods.sqlite3'))
+          allow(Woods.configuration).to receive(:enable_snapshots).and_return(false)
+          result = described_class.build_snapshot_store(dir)
+          expect(result).not_to be_nil
+        end
+      end
+    end
+  end
+
+  describe '.ollama_reachable?' do
+    it 'returns false when nothing is listening on the configured port' do
+      old = ENV.delete('OLLAMA_BASE_URL')
+      ENV['OLLAMA_BASE_URL'] = 'http://127.0.0.1:19999'
+      result = described_class.ollama_reachable?
+      expect(result).to be false
+    ensure
+      old ? ENV['OLLAMA_BASE_URL'] = old : ENV.delete('OLLAMA_BASE_URL')
+    end
+
+    it 'returns false given a non-parseable URL (rescue StandardError path)' do
+      old = ENV.delete('OLLAMA_BASE_URL')
+      ENV['OLLAMA_BASE_URL'] = 'not_a_url'
+      result = described_class.ollama_reachable?
+      expect(result).to be false
+    ensure
+      old ? ENV['OLLAMA_BASE_URL'] = old : ENV.delete('OLLAMA_BASE_URL')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
+if ENV['COVERAGE']
+  require 'simplecov'
+  SimpleCov.start do
+    add_filter '/spec/'
+    minimum_coverage 88
+  end
+end
+
 require 'rspec'
 require 'active_support/core_ext/string/inflections'
 require 'woods/extracted_unit'

--- a/woods.gemspec
+++ b/woods.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Runtime dependencies
-  spec.add_dependency 'mcp', '~> 0.6'
+  spec.add_dependency 'mcp', '>= 0.9.2', '< 1.0'
   # `prism` ships in stdlib on Ruby 3.3+; the gem fills the gap for 3.0–3.2.
   # EvalGuard reuses the existing Woods::Ast::Parser, which already auto-detects
   # Prism vs the parser gem — this dep guarantees the Prism path on the lower


### PR DESCRIPTION
## Summary
Umbrella PR for the low-risk "quick-win" findings from the pre-release audit (`_project-resources/audits/next-release-audit.md`). Seven commits, all reviewable independently.

| # | Commit | What | Audit |
|---|---|---|---|
| 1 | `38bf034` | `woods:install` generator now emits a commented `config/initializers/woods.rb` (new `.tt` template, 144 lines). Spec grew 8→18 examples. | **P0-3** |
| 2 | `73a200c` | `DEFAULT_CONSOLE_BLOCKED_TABLES` shipped (8 tables: sessions, api_keys, credentials, oauth_*, identities, active_storage_blobs). `check_blocked_tables_config!` warns in dev / raises in production when the list is empty and console is enabled. **Closes the Layer 1 fail-open.** | **P0-2** |
| 3 | `b239690` | CI gains SimpleCov (88% floor, measured 90.08%) + `bundler-audit` job. | **P1-3** |
| 4 | `9e8a0b0` | Console safety model consolidated into `docs/CONSOLE_MCP_SETUP.md`; standardized MCP exe naming footnote across 3 docs; stale `lib/codebase_index.rb` reference in `docs/backlog.json` fixed. | **P1-5/6, P2-15** |
| 5 | `433c106` | +713 LOC / +64 new examples in `spec/console/redactor_spec.rb`, `spec/mcp/bootstrapper_spec.rb`, `spec/console/tool_specs_spec.rb`. | **P1-4** |
| 6 | `6133d03` | `mcp` gem bumped to `>= 0.9.2, < 1.0` closing **CVE-2026-33946 (HIGH)** — SSE stream hijacking. Full suite verified against `mcp 0.13.0`. Also resolves json and loofah advisories via lockfile regeneration in CI. | new (bundler-audit flagged) |
| 7 | `fe1b6f3` | Fix spec-order pollution from commit 5. `tool_specs_spec.rb` was defining empty stubs at `Woods::Console::Server::{Tools::Tier1..4,SqlValidator,EvalGuard}` that shadowed real constants for later specs (Ruby lexical lookup from inside `Woods::Console::Server` hit the stubs before climbing). Replaced with real `require`s. | follow-up |

## Test plan
- [x] `bundle exec rspec` — **3917 examples, 0 failures, 2 pending**
- [x] `bundle exec rubocop` — clean
- [x] `bundle exec bundler-audit check` — json, loofah resolved; mcp 0.9.2+ installed
- [x] `bundle exec ruby -Ilib -e "require 'woods/mcp/server'; require 'woods/console/server'"` — both servers load under mcp 0.13
- [ ] Verify CI job matrix (3.0–3.3) runs clean
- [ ] Verify SimpleCov coverage job passes 88% floor in CI
- [ ] Verify bundler-audit job runs clean in CI

## Out of scope (tracked in backlog for later PRs)
- P0-1 HTTP transport auth (needs design decision)
- P1-1 unified `woods mcp` entry point (~3 dev-days)
- P1-2 `docs/RETRIEVAL_GUIDE.md`
- P1-7/8/9 HTTP TLS/CORS, error `_meta`, `woods_status`
- All P2 items