### PR TITLE
feat(mcp): bearer auth for woods-mcp-http (P0-1)

### DIFF
--- a/docs/MCP_HTTP_TRANSPORT.md
+++ b/docs/MCP_HTTP_TRANSPORT.md
@@ -153,3 +153,41 @@ woods-mcp --http --port 8080  # HTTP on custom port
 - The MCP specification (2025-03-26) designates Streamable HTTP as the standard remote transport, replacing the earlier SSE-only transport
 - The next spec release (~June 2026) is expected to further formalize stateless transport patterns for horizontal scaling
 - The `mcp` gem tracks the spec closely; v0.6.0 already implements the full Streamable HTTP spec including stateless mode
+
+## Security
+
+The MCP gem does not authenticate at the transport layer, so `exe/woods-mcp-http` enforces authentication itself. The rules:
+
+| `HOST`                            | `WOODS_MCP_HTTP_TOKEN` set? | Result                                                      |
+|-----------------------------------|------------------------------|-------------------------------------------------------------|
+| `localhost` / `127.0.0.1` / `::1` | no                           | Boots with a warning; unauthenticated loopback access only  |
+| `localhost` / `127.0.0.1` / `::1` | yes                          | Boots; every request must present `Authorization: Bearer …` |
+| anything else                     | no                           | **Refuses to boot** — aborts with a pointer to this section |
+| anything else                     | yes                          | Boots; every request must present `Authorization: Bearer …` |
+
+This matches the posture used by other unauthenticated local servers (Redis `protected-mode`, Postgres `listen_addresses`): loopback works freely, non-loopback requires an explicit credential.
+
+### Generating a token
+
+```bash
+bundle exec rake woods:generate_token
+# prints a 64-char hex token to stdout
+```
+
+Any cryptographically random string works; `openssl rand -hex 32` is equivalent.
+
+### Running the server with a token
+
+```bash
+export WOODS_MCP_HTTP_TOKEN=$(bundle exec rake woods:generate_token 2>/dev/null)
+HOST=0.0.0.0 PORT=9292 bundle exec woods-mcp-http
+```
+
+Clients must send `Authorization: Bearer $WOODS_MCP_HTTP_TOKEN` on every request. Missing or mismatched tokens get `HTTP 401` with a `WWW-Authenticate: Bearer` header; comparison is constant-time (`Rack::Utils.secure_compare`).
+
+### Known limitations
+
+- **Plaintext tokens on the wire.** Bearer auth over HTTP leaks the token to anything on the network path. Terminate TLS at a reverse proxy (nginx, Caddy, Cloudflare) for any deployment beyond a single trusted host.
+- **No rotation primitive.** There is one static token. Rotating it requires restarting the server and updating clients. A rotation story is tracked separately and will likely arrive with a broader OAuth-shaped design.
+- **No per-client identity.** Every valid request is equally trusted; there are no scopes or audit trails. Treat the token as a shared secret for a trust boundary you already control.
+

--- a/exe/woods-mcp-http
+++ b/exe/woods-mcp-http
@@ -17,6 +17,7 @@ require_relative '../lib/woods/dependency_graph'
 require_relative '../lib/woods/graph_analyzer'
 require_relative '../lib/woods/mcp/server'
 require_relative '../lib/woods/mcp/bootstrapper'
+require_relative '../lib/woods/mcp/bearer_auth'
 require_relative '../lib/woods/embedding/text_preparer'
 require_relative '../lib/woods/embedding/indexer'
 
@@ -26,12 +27,24 @@ snapshot_store = Woods::MCP::Bootstrapper.build_snapshot_store(index_dir)
 
 port = (ENV['PORT'] || 9292).to_i
 host = ENV['HOST'] || 'localhost'
+token = ENV.fetch('WOODS_MCP_HTTP_TOKEN', nil)
+token = nil if token && token.empty?
+
+loopback = %w[localhost 127.0.0.1 ::1].include?(host)
+if !loopback && token.nil?
+  abort "[woods-mcp-http] Refusing to bind #{host} without WOODS_MCP_HTTP_TOKEN. " \
+        'Either set HOST=localhost, set WOODS_MCP_HTTP_TOKEN, or see docs/MCP_HTTP_TRANSPORT.md#security.'
+end
+if loopback && token.nil?
+  warn '[woods-mcp-http] WARNING: running on loopback without a token; local processes can reach this server.'
+end
 
 server = Woods::MCP::Server.build(index_dir: index_dir, retriever: retriever, snapshot_store: snapshot_store)
 transport = MCP::Server::Transports::StreamableHTTPTransport.new(server)
 server.transport = transport
 
-app = proc { |env| transport.handle_request(Rack::Request.new(env)) }
+inner = proc { |env| transport.handle_request(Rack::Request.new(env)) }
+app = token ? Woods::MCP::BearerAuth.new(inner, token: token) : inner
 
-warn "Woods MCP HTTP server starting on http://#{host}:#{port}"
+warn "Woods MCP HTTP server starting on http://#{host}:#{port} (auth: #{token ? 'bearer' : 'none'})"
 Rackup::Handler.default.run(app, Port: port, Host: host)

--- a/lib/tasks/woods.rake
+++ b/lib/tasks/woods.rake
@@ -672,4 +672,13 @@ namespace :woods do
 
   desc 'Relay findings to Unblocked (alias for unblocked_sync)'
   task relay: :unblocked_sync
+
+  desc 'Generate a random bearer token for woods-mcp-http (WOODS_MCP_HTTP_TOKEN)'
+  task :generate_token do
+    require 'securerandom'
+    token = SecureRandom.hex(32)
+    puts token
+    warn 'Set WOODS_MCP_HTTP_TOKEN to this value in the environment where woods-mcp-http runs,'
+    warn 'and send it as `Authorization: Bearer <token>` from clients.'
+  end
 end

--- a/lib/woods/mcp/bearer_auth.rb
+++ b/lib/woods/mcp/bearer_auth.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rack/utils'
+
+module Woods
+  module MCP
+    # Rack middleware that rejects requests lacking a matching bearer token.
+    #
+    # Uses Rack::Utils.secure_compare for constant-time comparison to avoid
+    # leaking token bytes via response-time side channels.
+    class BearerAuth
+      UNAUTHORIZED_BODY = { jsonrpc: '2.0', error: { code: -32_001, message: 'Unauthorized' }, id: nil }.to_json.freeze
+
+      def initialize(app, token:)
+        raise ArgumentError, 'token must be a non-empty string' if token.nil? || token.empty?
+
+        @app = app
+        @token = token.to_s
+      end
+
+      def call(env)
+        header = env['HTTP_AUTHORIZATION'].to_s
+        presented = header.start_with?('Bearer ') ? header.sub(/\ABearer /, '') : nil
+
+        if presented && Rack::Utils.secure_compare(@token, presented)
+          @app.call(env)
+        else
+          [401,
+           { 'content-type' => 'application/json', 'www-authenticate' => 'Bearer realm="woods-mcp-http"' },
+           [UNAUTHORIZED_BODY]]
+        end
+      end
+    end
+  end
+end

--- a/spec/mcp/bearer_auth_spec.rb
+++ b/spec/mcp/bearer_auth_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'woods/mcp/bearer_auth'
+
+RSpec.describe Woods::MCP::BearerAuth do
+  let(:inner_app) { ->(_env) { [200, { 'content-type' => 'text/plain' }, ['ok']] } }
+  let(:token) { 'sekret-token-abc123' }
+  let(:middleware) { described_class.new(inner_app, token: token) }
+
+  def call(auth_header)
+    env = {}
+    env['HTTP_AUTHORIZATION'] = auth_header if auth_header
+    middleware.call(env)
+  end
+
+  it 'forwards the request when the bearer token matches' do
+    status, _headers, body = call("Bearer #{token}")
+    expect(status).to eq(200)
+    expect(body).to eq(['ok'])
+  end
+
+  it 'returns 401 when the Authorization header is missing' do
+    status, headers, _body = call(nil)
+    expect(status).to eq(401)
+    expect(headers['www-authenticate']).to match(/Bearer/)
+  end
+
+  it 'returns 401 when the scheme is not Bearer' do
+    status, = call("Basic #{token}")
+    expect(status).to eq(401)
+  end
+
+  it 'returns 401 when the token is wrong' do
+    status, = call('Bearer wrong-token-abc123')
+    expect(status).to eq(401)
+  end
+
+  it 'returns 401 when the presented token length differs' do
+    status, = call('Bearer short')
+    expect(status).to eq(401)
+  end
+
+  it 'returns a JSON-RPC-shaped error body' do
+    _status, headers, body = call(nil)
+    expect(headers['content-type']).to eq('application/json')
+    parsed = JSON.parse(body.first)
+    expect(parsed['error']['message']).to eq('Unauthorized')
+  end
+
+  it 'raises when constructed with nil token' do
+    expect { described_class.new(inner_app, token: nil) }.to raise_error(ArgumentError)
+  end
+
+  it 'raises when constructed with empty token' do
+    expect { described_class.new(inner_app, token: '') }.to raise_error(ArgumentError)
+  end
+end


### PR DESCRIPTION
## Summary
- Closes **P0-1** from `next-release-audit.md`: `exe/woods-mcp-http` had no authentication and would happily bind non-loopback hosts.
- Adds `Woods::MCP::BearerAuth` Rack middleware using `Rack::Utils.secure_compare` for constant-time token comparison.
- `exe/woods-mcp-http` now refuses to bind non-loopback without `WOODS_MCP_HTTP_TOKEN`, warns on loopback when unset, and requires the token on every request (loopback included) when it is set.
- Adds `rake woods:generate_token` for discoverability and a security section in `docs/MCP_HTTP_TRANSPORT.md` covering the token matrix, TLS expectations, and rotation limitations.

## Behavior matrix

| HOST                | Token set? | Result                                             |
|---------------------|------------|----------------------------------------------------|
| loopback            | no         | boots with warning; unauthenticated loopback only  |
| loopback            | yes        | boots; every request needs `Authorization: Bearer` |
| non-loopback        | no         | **aborts** with pointer to docs                    |
| non-loopback        | yes        | boots; every request needs `Authorization: Bearer` |

## Test plan
- [x] `bundle exec rspec` — 3835 examples, 0 failures, 2 pending (tiktoken_ruby)
- [x] `bundle exec rubocop` — clean on changed files
- [x] New `spec/mcp/bearer_auth_spec.rb` covers match, missing header, wrong scheme, wrong token, length mismatch, JSON-RPC error body, and constructor validation (8 examples).
- [ ] Manual smoke: `HOST=0.0.0.0` aborts without token; `HOST=0.0.0.0 WOODS_MCP_HTTP_TOKEN=… curl` returns 401 without header and 200 with.

## Open items (deliberately out of scope)
- **TLS** is left to the operator via reverse proxy (tracked under P1-7).
- **Token rotation** is a single static token today; rotation will come with the broader OAuth-shaped design.