### PR TITLE
feat(mcp): OriginGuard + TLS reverse-proxy docs (P1-7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ bin/context7
 .grove/state.json
 .grove/state.json.bak
 .grove/.envrc
+.claude/worktrees/

--- a/docs/MCP_HTTP_TRANSPORT.md
+++ b/docs/MCP_HTTP_TRANSPORT.md
@@ -185,9 +185,62 @@ HOST=0.0.0.0 PORT=9292 bundle exec woods-mcp-http
 
 Clients must send `Authorization: Bearer $WOODS_MCP_HTTP_TOKEN` on every request. Missing or mismatched tokens get `HTTP 401` with a `WWW-Authenticate: Bearer` header; comparison is constant-time (`Rack::Utils.secure_compare`).
 
+### Browser origins (DNS rebinding defense)
+
+A second middleware, `Woods::MCP::OriginGuard`, rejects requests whose `Origin` header is outside an allow-list. Requests without an `Origin` header (curl, MCP stdio clients, server-to-server) pass through — bearer auth still gates them.
+
+| Scenario                         | `WOODS_MCP_HTTP_ALLOWED_ORIGINS`  | Origins accepted                                         |
+|----------------------------------|------------------------------------|----------------------------------------------------------|
+| default                          | unset                              | `http(s)://localhost`, `127.0.0.1`, `::1` (any port)     |
+| explicit list                    | `https://app.example.com`          | exactly `https://app.example.com` — loopback no longer allowed |
+| multiple origins                 | `https://a.example,https://b.example` | each listed origin                                    |
+
+`OPTIONS` preflights are answered with the matching `Access-Control-Allow-*` headers; successful responses carry `Access-Control-Allow-Origin`, `Access-Control-Expose-Headers: Mcp-Session-Id`, and `Vary: Origin`.
+
+### TLS termination
+
+The server speaks plain HTTP. Any deployment beyond a single trusted host should front it with a reverse proxy that handles TLS, HTTP/2, and connection limits.
+
+**Caddy** (automatic HTTPS via Let's Encrypt):
+
+```caddyfile
+mcp.example.com {
+  reverse_proxy 127.0.0.1:9292
+}
+```
+
+**nginx** (bring-your-own cert):
+
+```nginx
+server {
+  listen 443 ssl http2;
+  server_name mcp.example.com;
+
+  ssl_certificate     /etc/letsencrypt/live/mcp.example.com/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/mcp.example.com/privkey.pem;
+
+  location / {
+    proxy_pass http://127.0.0.1:9292;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+
+    # SSE streaming: disable buffering, raise timeouts
+    proxy_buffering off;
+    proxy_read_timeout 3600s;
+    proxy_send_timeout 3600s;
+  }
+}
+```
+
+Bind `woods-mcp-http` to `HOST=127.0.0.1` when a proxy handles the public surface; keep `WOODS_MCP_HTTP_TOKEN` set so the proxy-to-app hop still requires a bearer.
+
 ### Known limitations
 
 - **Plaintext tokens on the wire.** Bearer auth over HTTP leaks the token to anything on the network path. Terminate TLS at a reverse proxy (nginx, Caddy, Cloudflare) for any deployment beyond a single trusted host.
 - **No rotation primitive.** There is one static token. Rotating it requires restarting the server and updating clients. A rotation story is tracked separately and will likely arrive with a broader OAuth-shaped design.
 - **No per-client identity.** Every valid request is equally trusted; there are no scopes or audit trails. Treat the token as a shared secret for a trust boundary you already control.
+- **No in-process TLS.** TLS is a reverse-proxy concern — Caddy/nginx/Cloudflare handle certs, HSTS, and cipher policy better than a Rack-level implementation would.
 

--- a/exe/woods-mcp-http
+++ b/exe/woods-mcp-http
@@ -18,6 +18,7 @@ require_relative '../lib/woods/graph_analyzer'
 require_relative '../lib/woods/mcp/server'
 require_relative '../lib/woods/mcp/bootstrapper'
 require_relative '../lib/woods/mcp/bearer_auth'
+require_relative '../lib/woods/mcp/origin_guard'
 require_relative '../lib/woods/embedding/text_preparer'
 require_relative '../lib/woods/embedding/indexer'
 
@@ -43,8 +44,12 @@ server = Woods::MCP::Server.build(index_dir: index_dir, retriever: retriever, sn
 transport = MCP::Server::Transports::StreamableHTTPTransport.new(server)
 server.transport = transport
 
+allowed_origins = ENV.fetch('WOODS_MCP_HTTP_ALLOWED_ORIGINS', '').split(',').map(&:strip).reject(&:empty?)
+
 inner = proc { |env| transport.handle_request(Rack::Request.new(env)) }
 app = token ? Woods::MCP::BearerAuth.new(inner, token: token) : inner
+app = Woods::MCP::OriginGuard.new(app, allowed_origins: allowed_origins)
 
-warn "Woods MCP HTTP server starting on http://#{host}:#{port} (auth: #{token ? 'bearer' : 'none'})"
+origin_summary = allowed_origins.empty? ? 'loopback' : allowed_origins.join(',')
+warn "Woods MCP HTTP server starting on http://#{host}:#{port} (auth: #{token ? 'bearer' : 'none'}, origins: #{origin_summary})"
 Rackup::Handler.default.run(app, Port: port, Host: host)

--- a/exe/woods-mcp-http
+++ b/exe/woods-mcp-http
@@ -51,5 +51,6 @@ app = token ? Woods::MCP::BearerAuth.new(inner, token: token) : inner
 app = Woods::MCP::OriginGuard.new(app, allowed_origins: allowed_origins)
 
 origin_summary = allowed_origins.empty? ? 'loopback' : allowed_origins.join(',')
-warn "Woods MCP HTTP server starting on http://#{host}:#{port} (auth: #{token ? 'bearer' : 'none'}, origins: #{origin_summary})"
+auth_mode = token ? 'bearer' : 'none'
+warn "Woods MCP HTTP server starting on http://#{host}:#{port} (auth: #{auth_mode}, origins: #{origin_summary})"
 Rackup::Handler.default.run(app, Port: port, Host: host)

--- a/lib/woods/mcp/origin_guard.rb
+++ b/lib/woods/mcp/origin_guard.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Woods
+  module MCP
+    # Rack middleware that rejects browser-origin requests from unexpected sources.
+    #
+    # Defends against DNS rebinding and cross-site request forgery against a
+    # locally-bound MCP HTTP server. Defaults to loopback-only origins; operators
+    # can widen via WOODS_MCP_HTTP_ALLOWED_ORIGINS (comma-separated) or by passing
+    # :allowed_origins. Requests without an Origin header (curl, server-to-server,
+    # MCP stdio clients) are allowed through — bearer auth still gates them.
+    #
+    # Also answers CORS preflight (OPTIONS) with the matching allow-list.
+    class OriginGuard
+      DEFAULT_ALLOWED = %w[
+        http://localhost http://127.0.0.1 http://[::1]
+        https://localhost https://127.0.0.1 https://[::1]
+      ].freeze
+
+      ALLOWED_METHODS = 'GET, POST, DELETE, OPTIONS'
+      ALLOWED_HEADERS = 'Authorization, Content-Type, Mcp-Session-Id'
+
+      def initialize(app, allowed_origins: nil)
+        @app = app
+        @allowed = Array(allowed_origins).compact.reject(&:empty?).map { |o| normalize(o) }
+        @allowed = DEFAULT_ALLOWED.dup if @allowed.empty?
+      end
+
+      def call(env)
+        origin = env['HTTP_ORIGIN']
+        method = env['REQUEST_METHOD']
+
+        return forbidden(origin) if origin && !origin_allowed?(origin)
+
+        return preflight(origin) if method == 'OPTIONS'
+
+        status, headers, body = @app.call(env)
+        headers = cors_headers(origin).merge(headers) if origin && origin_allowed?(origin)
+        [status, headers, body]
+      end
+
+      private
+
+      def normalize(origin)
+        origin.to_s.sub(%r{/\z}, '').downcase
+      end
+
+      def origin_allowed?(origin)
+        @allowed.include?(normalize(origin)) || @allowed.include?(normalize(origin).sub(/:\d+\z/, ''))
+      end
+
+      def preflight(origin)
+        headers = origin && origin_allowed?(origin) ? cors_headers(origin) : {}
+        [204, headers, []]
+      end
+
+      def cors_headers(origin)
+        {
+          'access-control-allow-origin' => origin,
+          'access-control-allow-methods' => ALLOWED_METHODS,
+          'access-control-allow-headers' => ALLOWED_HEADERS,
+          'access-control-expose-headers' => 'Mcp-Session-Id',
+          'vary' => 'Origin'
+        }
+      end
+
+      def forbidden(origin)
+        body = { jsonrpc: '2.0', error: { code: -32_002, message: "Origin not allowed: #{origin}" }, id: nil }.to_json
+        [403, { 'content-type' => 'application/json' }, [body]]
+      end
+    end
+  end
+end

--- a/spec/mcp/origin_guard_spec.rb
+++ b/spec/mcp/origin_guard_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'woods/mcp/origin_guard'
+
+RSpec.describe Woods::MCP::OriginGuard do
+  let(:inner_app) { ->(_env) { [200, { 'content-type' => 'text/plain' }, ['ok']] } }
+
+  def call(middleware, origin: nil, method: 'POST')
+    env = { 'REQUEST_METHOD' => method }
+    env['HTTP_ORIGIN'] = origin if origin
+    middleware.call(env)
+  end
+
+  describe 'default (loopback-only) policy' do
+    subject(:middleware) { described_class.new(inner_app) }
+
+    it 'allows requests with no Origin header (curl, server-to-server)' do
+      status, = call(middleware, origin: nil)
+      expect(status).to eq(200)
+    end
+
+    it 'allows http://localhost' do
+      expect(call(middleware, origin: 'http://localhost').first).to eq(200)
+    end
+
+    it 'allows http://localhost:5173 (matches host regardless of port)' do
+      expect(call(middleware, origin: 'http://localhost:5173').first).to eq(200)
+    end
+
+    it 'allows http://127.0.0.1' do
+      expect(call(middleware, origin: 'http://127.0.0.1').first).to eq(200)
+    end
+
+    it 'rejects http://evil.example.com' do
+      status, _headers, body = call(middleware, origin: 'http://evil.example.com')
+      expect(status).to eq(403)
+      parsed = JSON.parse(body.first)
+      expect(parsed['error']['message']).to match(/Origin not allowed/)
+    end
+
+    it 'adds CORS headers to allowed responses' do
+      _status, headers, = call(middleware, origin: 'http://localhost')
+      expect(headers['access-control-allow-origin']).to eq('http://localhost')
+      expect(headers['vary']).to eq('Origin')
+    end
+
+    it 'answers OPTIONS preflight with 204 for allowed origins' do
+      status, headers, = call(middleware, origin: 'http://localhost', method: 'OPTIONS')
+      expect(status).to eq(204)
+      expect(headers['access-control-allow-methods']).to include('POST')
+    end
+  end
+
+  describe 'explicit allow-list' do
+    subject(:middleware) { described_class.new(inner_app, allowed_origins: ['https://app.example.com']) }
+
+    it 'allows configured origin' do
+      expect(call(middleware, origin: 'https://app.example.com').first).to eq(200)
+    end
+
+    it 'rejects loopback when a custom allow-list is set' do
+      expect(call(middleware, origin: 'http://localhost').first).to eq(403)
+    end
+
+    it 'rejects other origins' do
+      expect(call(middleware, origin: 'https://other.example.com').first).to eq(403)
+    end
+
+    it 'is case-insensitive' do
+      expect(call(middleware, origin: 'https://APP.example.com').first).to eq(200)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Closes **P1-7** from `next-release-audit.md`: layers Origin/CORS defense on top of #52's bearer auth and documents the TLS reverse-proxy pattern.
- Adds \`Woods::MCP::OriginGuard\` — rejects browser-origin requests outside an allow-list. Loopback-only by default; override with \`WOODS_MCP_HTTP_ALLOWED_ORIGINS\`. Requests without an \`Origin\` header (curl, server-to-server, MCP stdio) pass through so bearer auth keeps gating them.
- Answers \`OPTIONS\` preflight with matching \`Access-Control-Allow-*\` headers; sets \`Vary: Origin\` and exposes \`Mcp-Session-Id\`.
- \`docs/MCP_HTTP_TRANSPORT.md\` gains an Origin allow-list matrix, Caddy + nginx examples (including SSE-friendly timeouts), and a note that in-process TLS is intentionally out of scope.

## Behavior matrix (origins)
| `WOODS_MCP_HTTP_ALLOWED_ORIGINS` | Accepted                                                     |
|----------------------------------|--------------------------------------------------------------|
| unset                            | \`http(s)://localhost\`, \`127.0.0.1\`, \`::1\` (any port)   |
| \`https://app.example.com\`      | exactly that origin — loopback is no longer allowed          |
| comma-separated list             | each listed origin                                           |

## Test plan
- [x] \`bundle exec rspec\` — 3936 examples, 0 failures, 2 pending (tiktoken)
- [x] \`bundle exec rubocop\` — clean on changed files
- [x] \`spec/mcp/origin_guard_spec.rb\` (11 examples) covers: no-Origin allow, loopback allow, disallowed origin 403, CORS headers on allowed responses, OPTIONS preflight, explicit allow-list narrowing, case-insensitivity.
- [ ] Manual smoke: curl with \`-H 'Origin: http://evil.example'\` returns 403; \`-H 'Origin: http://localhost'\` returns 200 with CORS headers; OPTIONS returns 204.