### PR TITLE
feat(mcp): woods_status diagnostic tool (P1)

### DIFF
--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -235,6 +235,7 @@ Use `framework` to search the Rails/gem source installed in the app — not docu
 
 | Tool | Key Parameters | Description |
 |------|---------------|-------------|
+| `woods_status` | _(none)_ | Diagnose whether the server is ready. Returns extraction metadata (last run, unit counts, git SHA, staleness seconds), retriever/embedding configuration, and feature flags. **Call first on cold connect.** |
 | `lookup` | `identifier`, `include_source`, `sections` | Full unit by exact identifier. `sections` filters which fields to return. |
 | `search` | `query`, `types`, `fields`, `limit` | Regex search across identifiers, source, or metadata. Returns `{ results: [...], note?, partial? }` — `note` flags broad patterns (>50% of a directory matched), `partial` means the phase-2 scan cap (`WOODS_SEARCH_MAX_SCAN`, default 500) was hit. Invalid regex falls back to literal match. Follow up with `lookup`. |
 | `dependencies` | `identifier`, `depth`, `types`, `via` | Forward dependency tree (BFS). What a unit depends on. |

--- a/lib/woods/mcp/server.rb
+++ b/lib/woods/mcp/server.rb
@@ -2,6 +2,7 @@
 
 require 'logger'
 require 'mcp'
+require 'time'
 require 'set'
 require_relative 'index_reader'
 require_relative 'tool_response_renderer'
@@ -73,6 +74,7 @@ module Woods
           define_feedback_tools(server, feedback_store, respond)
           define_snapshot_tools(server, snapshot_store, respond)
           define_notion_sync_tool(server, reader, index_dir, respond)
+          define_woods_status_tool(server, reader, retriever, index_dir, respond)
           register_resource_handler(server, reader)
 
           server
@@ -984,6 +986,91 @@ module Woods
               mime_type: 'application/json'
             )
           ]
+        end
+
+        def define_woods_status_tool(server, reader, retriever, index_dir, respond)
+          server.define_tool(
+            name: 'woods_status',
+            description: 'Diagnose whether the Woods index and server are healthy. Returns extraction metadata ' \
+                         '(last run, unit counts, git SHA, staleness in seconds), retriever/embedding configuration, ' \
+                         'feature flags, and a ready flag. Call this first on cold connect to learn what the server knows.',
+            input_schema: { type: 'object', properties: {} }
+          ) do |server_context:|
+            _ = server_context
+            status = Woods::MCP::Server.build_status(reader: reader, retriever: retriever, index_dir: index_dir)
+            respond.call(JSON.pretty_generate(status))
+          end
+        end
+
+        public
+
+        # Build the woods_status payload. Exposed at module level so specs (and future
+        # console/unified-server entry points) can assemble the same shape without
+        # reaching through the MCP::Server internals.
+        def build_status(reader:, retriever:, index_dir:)
+          manifest = safe_manifest(reader)
+          extracted_at = manifest && manifest['extracted_at']
+          staleness = staleness_seconds(extracted_at)
+          config = Woods.configuration
+
+          {
+            ready: manifest && !manifest['counts'].to_h.empty?,
+            server: {
+              name: 'woods',
+              version: Woods::VERSION,
+              index_dir: index_dir.to_s
+            },
+            index: {
+              extracted_at: extracted_at,
+              staleness_seconds: staleness,
+              rails_version: manifest && manifest['rails_version'],
+              ruby_version: manifest && manifest['ruby_version'],
+              total_units: manifest && manifest['total_units'],
+              counts: (manifest && manifest['counts']) || {},
+              git_sha: manifest && manifest['git_sha'],
+              git_branch: manifest && manifest['git_branch'],
+              gemfile_lock_sha: manifest && manifest['gemfile_lock_sha'],
+              schema_sha: manifest && manifest['schema_sha']
+            },
+            retriever: {
+              configured: !retriever.nil?,
+              class: retriever&.class&.name
+            },
+            features: {
+              embedding_model: config.respond_to?(:embedding_model) ? config.embedding_model : nil,
+              embedding_provider: config.respond_to?(:embedding_provider) ? presence(config.embedding_provider) : nil,
+              vector_store: config.respond_to?(:vector_store) ? presence(config.vector_store) : nil,
+              session_tracer_enabled: config.respond_to?(:session_tracer_enabled) ? config.session_tracer_enabled : false,
+              snapshots_enabled: config.respond_to?(:enable_snapshots) ? config.enable_snapshots : false,
+              notion_configured: config.respond_to?(:notion_api_token) && !presence(config.notion_api_token).nil?,
+              console_mcp_enabled: config.respond_to?(:console_mcp_enabled) ? config.console_mcp_enabled : false
+            }
+          }
+        end
+
+        private
+
+        # Return a Hash of manifest content, or nil if unreadable.
+        def safe_manifest(reader)
+          reader.manifest
+        rescue StandardError
+          nil
+        end
+
+        # Seconds since extraction. Returns nil if timestamp is missing or unparsable.
+        def staleness_seconds(iso8601)
+          return nil if iso8601.nil? || iso8601.empty?
+
+          (Time.now - Time.parse(iso8601)).to_i
+        rescue ArgumentError
+          nil
+        end
+
+        def presence(value)
+          return nil if value.nil?
+          return nil if value.respond_to?(:empty?) && value.empty?
+
+          value.to_s
         end
 
         def register_resource_handler(server, reader)

--- a/spec/mcp/server_spec.rb
+++ b/spec/mcp/server_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe Woods::MCP::Server do
       expect(server).to be_a(MCP::Server)
     end
 
-    it 'registers 28 tools' do
+    it 'registers 29 tools' do
       tools = server.instance_variable_get(:@tools)
-      expect(tools.size).to eq(28)
+      expect(tools.size).to eq(29)
     end
 
     it 'registers expected tool names' do
@@ -32,7 +32,8 @@ RSpec.describe Woods::MCP::Server do
         'retrieval_explain', 'retrieval_suggest',
         'list_snapshots', 'snapshot_diff',
         'unit_history', 'snapshot_detail',
-        'notion_sync'
+        'notion_sync',
+        'woods_status'
       )
     end
 

--- a/spec/mcp/woods_status_spec.rb
+++ b/spec/mcp/woods_status_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'woods'
+require 'woods/mcp/server'
+require 'woods/mcp/index_reader'
+
+RSpec.describe 'woods_status tool' do
+  let(:fixture_dir) { File.expand_path('../fixtures/woods', __dir__) }
+  let(:reader) { Woods::MCP::IndexReader.new(fixture_dir) }
+
+  describe 'Woods::MCP::Server.build_status' do
+    subject(:status) { Woods::MCP::Server.build_status(reader: reader, retriever: nil, index_dir: fixture_dir) }
+
+    it 'reports server identity with the current gem version' do
+      expect(status[:server]).to include(name: 'woods', version: Woods::VERSION, index_dir: fixture_dir.to_s)
+    end
+
+    it 'surfaces extraction metadata from the manifest' do
+      expect(status[:index]).to include(
+        extracted_at: '2026-01-15T12:00:00Z',
+        rails_version: '8.1.2',
+        ruby_version: '4.0.1'
+      )
+      expect(status[:index][:counts]).to include('models' => 2, 'controllers' => 1)
+    end
+
+    it 'computes staleness as a non-negative integer of seconds' do
+      expect(status[:index][:staleness_seconds]).to be_a(Integer)
+      expect(status[:index][:staleness_seconds]).to be >= 0
+    end
+
+    it 'reports ready=true when the index has units' do
+      expect(status[:ready]).to be(true)
+    end
+
+    it 'reports retriever.configured=false when no retriever is passed' do
+      expect(status[:retriever]).to include(configured: false, class: nil)
+    end
+
+    it 'reports retriever.configured=true when a retriever is present' do
+      fake = Class.new.new
+      s = Woods::MCP::Server.build_status(reader: reader, retriever: fake, index_dir: fixture_dir)
+      expect(s[:retriever][:configured]).to be(true)
+    end
+
+    it 'exposes feature flags from Woods.configuration' do
+      expect(status[:features]).to include(
+        :embedding_model, :session_tracer_enabled, :snapshots_enabled,
+        :notion_configured, :console_mcp_enabled
+      )
+    end
+  end
+
+  describe 'missing-manifest resilience' do
+    it 'returns ready=false and empty index metadata when manifest is unreadable' do
+      broken_reader = Class.new do
+        def manifest
+          raise StandardError, 'boom'
+        end
+      end.new
+
+      status = Woods::MCP::Server.build_status(reader: broken_reader, retriever: nil, index_dir: '/nope')
+      expect(status[:ready]).to be_falsey
+      expect(status[:index][:extracted_at]).to be_nil
+      expect(status[:index][:counts]).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Closes a P1 from `next-release-audit.md` (A2, §6.1): neither MCP server exposed a health/diagnostic tool, so an agent cold-connecting couldn't learn "extraction has not run," "retriever not configured," or the index's git SHA without an out-of-band check.
- Adds `woods_status` to the index server (total: 29 tools). Payload covers:
  - `server`: name, gem version, index_dir
  - `index`: extracted_at, **staleness_seconds**, rails/ruby versions, per-type unit counts, git SHA/branch, gemfile_lock/schema digests
  - `retriever`: configured flag + class name
  - `features`: embedding model/provider, vector store, session tracer, snapshots, notion, console MCP
  - `ready`: true when a non-empty manifest is on disk
- Assembly logic exposed at `Woods::MCP::Server.build_status` so the console server and future unified-server entry point emit the same shape without re-probing.
- Agent guide tool table now lists \`woods_status\` at the top with a "call first on cold connect" note.

## Test plan
- [x] `bundle exec rspec` — 3933 examples, 0 failures, 2 pending
- [x] `bundle exec rubocop` — clean on changed files
- [x] New `spec/mcp/woods_status_spec.rb` covers: server identity, manifest surfacing, staleness is a non-negative integer, ready flag, retriever-present variant, feature flags exposed, and missing-manifest resilience (StandardError from reader → `ready: false`, empty index hash).
- [x] Updated `spec/mcp/server_spec.rb` tool count (28 → 29) + name list.