### PR TITLE
docs: refresh troubleshooting/faq + blast radius + when-not-to-use (P2)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,4 +53,21 @@ The Console MCP Server provides live database access through a five-layer defens
 
 ### MCP Transport
 
-The MCP Index Server supports both stdio and HTTP transports. When using HTTP transport, ensure it is not exposed to untrusted networks. The server has no built-in authentication — secure it at the network level.
+The MCP Index Server supports both stdio and HTTP transports. stdio is the default and has no network exposure. The HTTP transport (`exe/woods-mcp-http`) refuses to bind a non-loopback host unless `WOODS_MCP_HTTP_TOKEN` is set and validates incoming `Authorization: Bearer …` headers. It also enforces a default `Origin` allow-list via `OriginGuard` to mitigate DNS-rebinding attacks. TLS is not terminated in-process — front the HTTP transport with a reverse proxy (nginx, caddy) when exposing it beyond loopback. See [docs/MCP_HTTP_TRANSPORT.md](docs/MCP_HTTP_TRANSPORT.md) for the full deployment guide.
+
+## Blast Radius
+
+If extraction output leaks, what can an attacker do with it?
+
+**What the output contains.** Application source code (inlined concerns, callback-resolved behavior), database schema (column names, types, indexes, foreign keys), route tables, migration history, gem versions, and git metadata (commit history, contributor emails, file change frequency).
+
+**What the output does not contain.** No row-level data from your database — Woods extracts schema only. No environment variables, no `Rails.application.credentials`, no API keys, no session state, no request logs, no customer data.
+
+| Leak scenario | Attacker gains | Attacker does not gain |
+|---|---|---|
+| `tmp/woods/` directory exfiltrated | Source code + schema equivalent to a git clone + `rails db:schema:dump` | Database rows, secrets, tokens, customer data |
+| MCP Index Server token leaked (HTTP transport) | Read-only query access to the extracted index — no write or execution paths | Shell access, database row data, secrets |
+| Notion sync database compromised | Model and column summaries synced to Notion | Anything not mirrored — source code stays local |
+| Console MCP Server exposed (dev/staging) | Read-only database access through a rolled-back transaction, bounded by TableGate + Redactor + SqlValidator | Write access (rolled back), full credentials (redacted), blocked tables |
+
+**Mitigation.** Treat `tmp/woods/` as source-equivalent — keep it out of world-readable directories and public container images. Rotate `WOODS_MCP_HTTP_TOKEN` on compromise. Keep `console_mcp_enabled = false` in production regardless of environment, since the console layers are defense-in-depth and not primary controls.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -36,7 +36,7 @@ No. Extraction is entirely read-only. It uses ActiveRecord reflection APIs (`col
 
 ### Can I run Woods in production?
 
-Extraction is designed for development and CI environments — it requires a fully booted Rails environment and takes 10-30 seconds. The MCP servers are read-only development tools. Running extraction in production is technically possible but not recommended. The common pattern is to extract in CI and publish the JSON output as a build artifact.
+Extraction itself is designed for development and CI — it requires a fully booted Rails environment and takes 10-30 seconds. The MCP Index Server is read-only and can safely run in any environment as long as the HTTP transport is properly secured (bearer token required for non-loopback, origin allow-list via `OriginGuard`, TLS via reverse proxy — see [MCP_HTTP_TRANSPORT.md](MCP_HTTP_TRANSPORT.md)). The Console Server should stay disabled in production regardless of its safety layers. The common production pattern is to extract in CI and publish the JSON output as a build artifact, then run the Index Server against the artifact.
 
 ---
 
@@ -220,7 +220,7 @@ You're using the embedded console mode (launched via `rake woods:console` or `do
 
 ### Is the Console Server safe to use?
 
-The Console Server implements multiple safety layers. Every query runs inside a database transaction that is always rolled back, so writes are silently discarded. `SqlValidator` rejects DML and DDL at the string level before any database interaction. Model names are validated against `ActiveRecord::Base.descendants` to prevent arbitrary class instantiation. Tier 4 tools (eval, raw SQL) require explicit human confirmation. The Console Server is designed for development environments — treat it accordingly and avoid exposing it publicly.
+The Console Server implements five defense-in-depth layers: a feature gate (`console_mcp_enabled`, default `false`), a conservative `DEFAULT_CONSOLE_BLOCKED_TABLES` list covering `users`, `accounts`, `sessions`, `api_keys`, `credentials`, `oauth_applications`, `oauth_access_tokens`, and `active_storage_blobs`, a `CredentialScanner` that redacts credential-shaped values, column-name-based redaction via `DEFAULT_CONSOLE_REDACTED_COLUMNS`, and `SqlValidator` + rolled-back transactions on every query. Tier 4 tools (eval, raw SQL) require explicit human confirmation. These layers are defense-in-depth, not primary controls — the Console Server is a development/staging tool and should stay disabled in production regardless of configuration. See [CONSOLE_MCP_SETUP.md — Safety Model](CONSOLE_MCP_SETUP.md#safety-model) for the full breakdown.
 
 ---
 
@@ -492,7 +492,7 @@ bundle exec rake woods:validate
 bundle exec rake woods:stats
 ```
 
-The `pipeline_status` MCP tool also reports the last extraction time, unit counts, and whether the index is stale relative to the current git HEAD.
+The `pipeline_status` MCP tool reports the last extraction time, unit counts, and whether the index is stale relative to the current git HEAD. The `woods_status` tool (Index Server) reports a single-call health snapshot covering extraction freshness, console-bridge reachability, embedding/Notion/session-tracer configuration state, and index version — useful for agents cold-connecting to a server.
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -551,3 +551,18 @@ config.notion_database_ids = {
 | Empty extraction output | `eager_load!` failure | Check for `NameError` in boot output |
 | Git metadata missing | Shallow clone in CI | Use `fetch-depth: 2` or higher |
 | Parallel tool calls all fail | MCP client batches calls | Send calls sequentially, validate params first |
+| HTTP transport refuses to start on `0.0.0.0` | Missing bearer token | Set `WOODS_MCP_HTTP_TOKEN=…` or bind loopback only |
+| HTTP transport returns `403 Origin not allowed` | Origin header not in allow-list | Set `WOODS_MCP_HTTP_ORIGINS="https://example.com"` |
+| Tool returns `error_code: :not_configured` | Feature flag or credential not set | Check `config_key` in `_meta` and the linked `doc_link` |
+| Tool returns `error_code: :rate_limited` | `PipelineGuard` 5-min cooldown hit | Wait `retry_after_seconds` from `_meta`, then retry |
+
+### First-Pass Diagnostics
+
+For a single-call health snapshot, call the Index Server's `woods_status` tool. It reports:
+
+- Extraction freshness (last run time, unit count, index version)
+- Console-bridge reachability
+- Which optional features are configured (embedding provider, Notion, session tracer)
+- Per-feature config-key hints for anything missing
+
+Agents cold-connecting to a server should call `woods_status` before any other tool — it eliminates most "why is this empty?" guesswork.

--- a/docs/WHY_WOODS.md
+++ b/docs/WHY_WOODS.md
@@ -151,6 +151,19 @@ See [docs/BACKEND_MATRIX.md](BACKEND_MATRIX.md) for the full compatibility matri
 
 ---
 
+## When NOT to Use Woods
+
+Woods is not a universal fit. Skip it when:
+
+- **You're not building in Rails.** Woods leans hard on `ActiveRecord::Base.descendants`, `Rails.application.routes`, and reflection APIs — the value dries up outside Rails. For Django, Phoenix, or non-framework Ruby, other tools are a better fit.
+- **You need static analysis without booting.** Extraction requires a booted Rails environment because runtime introspection is the whole point. If your constraint is "can't boot the app" (locked-down CI, untrusted code review), static parsers are what you want.
+- **Production-only environments.** Extraction should run in development or CI. The Console Server is explicitly unsafe for production even with all five defense layers — it is a dev/staging tool.
+- **Row-level data is the goal.** Woods extracts schema and structure, not data. If you need to index row content for retrieval (customer records, documents, audit events), a different pipeline is appropriate.
+- **Tiny apps that already fit in context.** A 20-model app may not benefit — the LLM can probably read every file. Woods' win scales with monolith size and concern depth.
+- **You want a hosted service.** Woods is a gem, not a SaaS. Extraction output lives on your machines and the MCP servers run on your hardware. There is no cloud component.
+
+---
+
 ## Quick Start
 
 Install, extract, and connect in six steps:


### PR DESCRIPTION
## Summary

Three P2 audit items in one branch:

- **`p2-security-blast-radius`** — adds Blast Radius section to SECURITY.md with a leak-scenario table (extracted output vs HTTP token vs Notion vs Console) plus updates the stale "no built-in authentication" note to reflect shipped bearer auth + OriginGuard.
- **`p2-when-not-to-use-woods`** — adds "When NOT to Use Woods" to `docs/WHY_WOODS.md` covering non-Rails stacks, static-only use cases, production-only environments, row-level data needs, tiny apps, and hosted-service expectations.
- **`p2-refresh-troubleshooting-faq`** — refreshes console-safety, production posture, and index-health FAQ answers to match shipped `DEFAULT_CONSOLE_BLOCKED_TABLES`, HTTP auth, and `woods_status`. Adds Quick Reference rows and a first-pass diagnostics section in TROUBLESHOOTING pointing cold-connecting agents at `woods_status`.

Doc-only — no library or spec changes.

## Test plan

- [x] `ruby -rjson -e 'JSON.parse(File.read(".claude/backlog.json"))'` — backlog still valid JSON
- [x] Spot-check cross-refs (MCP_HTTP_TRANSPORT.md, CONSOLE_MCP_SETUP.md#safety-model) resolve
- [ ] Render check in GitHub after push