### PR TITLE
test: CircuitBreaker + DependencyGraph cyclic + incremental filter specs (P2)

### DIFF
--- a/spec/dependency_graph_cyclic_spec.rb
+++ b/spec/dependency_graph_cyclic_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+
+RSpec.describe Woods::DependencyGraph, 'cyclic graph behavior' do
+  let(:graph) { described_class.new }
+
+  def make_unit(type:, identifier:, file_path: nil, dependencies: [])
+    unit = Woods::ExtractedUnit.new(
+      type: type,
+      identifier: identifier,
+      file_path: file_path || "/app/#{identifier.downcase}.rb"
+    )
+    unit.dependencies = dependencies
+    unit
+  end
+
+  # Helper: build the A → B → A cycle
+  def register_ab_cycle
+    graph.register(make_unit(
+                     type: :model, identifier: 'A',
+                     dependencies: [{ type: :model, target: 'B', via: :belongs_to }]
+                   ))
+    graph.register(make_unit(
+                     type: :model, identifier: 'B',
+                     dependencies: [{ type: :model, target: 'A', via: :belongs_to }]
+                   ))
+  end
+
+  describe '#dependencies_of on a cyclic graph' do
+    before { register_ab_cycle }
+
+    it 'returns direct dependencies for a node involved in a cycle' do
+      expect(graph.dependencies_of('A')).to contain_exactly('B')
+      expect(graph.dependencies_of('B')).to contain_exactly('A')
+    end
+
+    it 'filters by via label within a cycle' do
+      expect(graph.dependencies_of('A', via: :belongs_to)).to eq(['B'])
+      expect(graph.dependencies_of('A', via: :code_reference)).to be_empty
+    end
+  end
+
+  describe '#dependents_of on a cyclic graph' do
+    before { register_ab_cycle }
+
+    it 'returns correct direct dependents in a mutual dependency' do
+      expect(graph.dependents_of('A')).to contain_exactly('B')
+      expect(graph.dependents_of('B')).to contain_exactly('A')
+    end
+
+    it 'filters dependents by via label' do
+      expect(graph.dependents_of('A', via: :belongs_to)).to contain_exactly('B')
+      expect(graph.dependents_of('A', via: :redirect_to)).to be_empty
+    end
+  end
+
+  describe '#affected_by on a cyclic graph' do
+    before do
+      graph.register(make_unit(
+                       type: :model, identifier: 'A',
+                       file_path: 'app/models/a.rb',
+                       dependencies: [{ type: :model, target: 'B', via: :belongs_to }]
+                     ))
+      graph.register(make_unit(
+                       type: :model, identifier: 'B',
+                       file_path: 'app/models/b.rb',
+                       dependencies: [{ type: :model, target: 'A', via: :belongs_to }]
+                     ))
+    end
+
+    it 'terminates and does not infinite-loop on a cycle' do
+      # Should complete without raising SystemStackError or hanging
+      result = nil
+      expect { result = graph.affected_by(['app/models/a.rb']) }.not_to raise_error
+      expect(result).to be_an(Array)
+    end
+
+    it 'returns both nodes of the cycle as affected' do
+      affected = graph.affected_by(['app/models/a.rb'])
+      expect(affected).to include('A', 'B')
+    end
+
+    it 'visited tracking prevents duplicate queue entries' do
+      # Build a 3-node cycle A → B → C → A
+      graph.register(make_unit(
+                       type: :model, identifier: 'C',
+                       file_path: 'app/models/c.rb',
+                       dependencies: [{ type: :model, target: 'A', via: :belongs_to }]
+                     ))
+
+      affected = graph.affected_by(['app/models/a.rb'])
+      # Each node appears exactly once
+      expect(affected.uniq).to eq(affected)
+      expect(affected).to include('A', 'B', 'C')
+    end
+  end
+
+  describe '#pagerank on a cyclic graph' do
+    before { register_ab_cycle }
+
+    it 'converges without raising (no NaN or Infinity scores)' do
+      scores = nil
+      expect { scores = graph.pagerank }.not_to raise_error
+
+      scores.each_value do |v|
+        expect(v).to be_finite
+        expect(v).not_to be_nan
+      end
+    end
+
+    it 'produces stable values (running twice gives the same result)' do
+      run1 = graph.pagerank
+      run2 = graph.pagerank
+      expect(run1).to eq(run2)
+    end
+
+    it 'scores sum approximately to 1.0 on a cyclic graph' do
+      total = graph.pagerank.values.sum
+      expect(total).to be_within(0.01).of(1.0)
+    end
+
+    it 'assigns equal scores to symmetric nodes in a mutual cycle' do
+      scores = graph.pagerank
+      # A and B are symmetric — each depends on the other exactly once
+      expect(scores['A']).to be_within(0.001).of(scores['B'])
+    end
+  end
+end

--- a/spec/extractors/incremental_filtering_spec.rb
+++ b/spec/extractors/incremental_filtering_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pathname'
+require 'tmpdir'
+require 'fileutils'
+require 'woods/extractor'
+
+# Verify that incremental re-extraction (re_extract_unit) silently skips unit
+# types that cannot be re-extracted from a single file. Per CLAUDE.md:
+#   "route, middleware, engine, scheduled_job" — no per-file extraction method
+#   StateMachineExtractor and FactoryExtractor — return arrays, not registered in FILE_BASED
+#   EventExtractor — two-pass, no single-file extraction method
+#
+# These types are in TYPE_TO_EXTRACTOR_KEY and EXTRACTORS but are absent from
+# both FILE_BASED and CLASS_BASED, so re_extract_unit returns nil and skips them.
+#
+# Types that DO have single-file support (FILE_BASED or CLASS_BASED) should
+# reach the extractor dispatch — verified here with a lightweight double.
+
+# Unit types that have no single-file extraction path and must be skipped
+# during incremental re-extraction.
+INCREMENTAL_UNSUPPORTED_TYPES = %i[
+  route middleware engine scheduled_job state_machine factory event rails_source
+].freeze
+
+RSpec.describe Woods::Extractor, '#re_extract_unit filtering' do
+  let(:tmpdir) { Dir.mktmpdir('woods_incremental_test') }
+  let(:rails_root) { Pathname.new(tmpdir) }
+  let(:extractor) { described_class.new(output_dir: File.join(tmpdir, 'output')) }
+
+  before do
+    stub_const('Rails', double('Rails'))
+    allow(Rails).to receive(:root).and_return(rails_root)
+    allow(Rails).to receive(:logger).and_return(double('Logger').as_null_object)
+    # RailsSourceExtractor#initialize calls Rails.version at construction time
+    allow(Rails).to receive(:version).and_return('7.2.0')
+  end
+
+  after { FileUtils.rm_rf(tmpdir) }
+
+  # Build a minimal registered graph node for a given type and unit_id.
+  def register_node(type, unit_id, file_path: nil)
+    fp = file_path || File.join(tmpdir, "#{unit_id.downcase}.rb")
+    FileUtils.touch(fp) unless File.exist?(fp)
+
+    graph = extractor.dependency_graph
+    graph.instance_variable_get(:@nodes)[unit_id] = {
+      type: type,
+      file_path: fp,
+      namespace: nil
+    }
+    graph.instance_variable_get(:@edges)[unit_id] = []
+    fp
+  end
+
+  describe 'unsupported types are silently skipped' do
+    INCREMENTAL_UNSUPPORTED_TYPES.each do |type|
+      it "returns nil and does not raise for type :#{type}" do
+        unit_id = "Sample#{type.to_s.camelize}"
+        register_node(type, unit_id)
+
+        result = nil
+        expect { result = extractor.send(:re_extract_unit, unit_id) }.not_to raise_error
+        # nil return means no unit was produced — the type was silently skipped
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe 'FILE_BASED types reach the extractor dispatch' do
+    it 'calls the file-based extractor method for a :service unit' do
+      # Stub EXTRACTORS so we can intercept the call without a real Rails app
+      fake_extractor_instance = double('ServiceExtractor')
+      fake_extractor_class    = double('ServiceExtractorClass', new: fake_extractor_instance)
+
+      stub_const('Woods::Extractor::EXTRACTORS', {
+                   services: fake_extractor_class
+                 })
+
+      allow(fake_extractor_instance).to receive(:extract_service_file).and_return(nil)
+
+      register_node(:service, 'UserService')
+
+      extractor.send(:re_extract_unit, 'UserService')
+
+      expect(fake_extractor_instance).to have_received(:extract_service_file)
+    end
+
+    it 'calls the file-based extractor method for a :concern unit' do
+      fake_extractor_instance = double('ConcernExtractor')
+      fake_extractor_class    = double('ConcernExtractorClass', new: fake_extractor_instance)
+
+      stub_const('Woods::Extractor::EXTRACTORS', {
+                   concerns: fake_extractor_class
+                 })
+
+      allow(fake_extractor_instance).to receive(:extract_concern_file).and_return(nil)
+
+      register_node(:concern, 'Auditable')
+
+      extractor.send(:re_extract_unit, 'Auditable')
+
+      expect(fake_extractor_instance).to have_received(:extract_concern_file)
+    end
+  end
+
+  describe 'GraphQL types reach the extractor dispatch' do
+    it 'calls extract_graphql_file for :graphql_type units' do
+      fake_extractor_instance = double('GraphQLExtractor')
+      fake_extractor_class    = double('GraphQLExtractorClass', new: fake_extractor_instance)
+
+      stub_const('Woods::Extractor::EXTRACTORS', {
+                   graphql: fake_extractor_class
+                 })
+
+      allow(fake_extractor_instance).to receive(:extract_graphql_file).and_return(nil)
+
+      register_node(:graphql_type, 'UserType')
+
+      extractor.send(:re_extract_unit, 'UserType')
+
+      expect(fake_extractor_instance).to have_received(:extract_graphql_file)
+    end
+  end
+
+  describe 'framework-prefixed units are skipped before type dispatch' do
+    it 'skips units with rails/ prefix regardless of type' do
+      result = extractor.send(:re_extract_unit, 'rails/active_record')
+      expect(result).to be_nil
+    end
+
+    it 'skips units with gems/ prefix regardless of type' do
+      result = extractor.send(:re_extract_unit, 'gems/devise')
+      expect(result).to be_nil
+    end
+  end
+end

--- a/spec/resilience/circuit_breaker_cyclic_spec.rb
+++ b/spec/resilience/circuit_breaker_cyclic_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'woods'
+require 'woods/resilience/circuit_breaker'
+
+RSpec.describe Woods::Resilience::CircuitBreaker, 'cyclic / re-entrant scenarios' do
+  # State transitions remain correct when the same call path cycles back
+  # through the same breaker (e.g., A calls B calls A).
+  # CLAUDE.md: "state is per-instance, not global"
+
+  describe 'state transitions remain correct under re-entrant calls' do
+    subject(:breaker) { described_class.new(threshold: 3, reset_timeout: 0.05) }
+
+    it 'state is per-instance — two independent breakers track failures separately' do
+      breaker_a = described_class.new(threshold: 2, reset_timeout: 60)
+      breaker_b = described_class.new(threshold: 2, reset_timeout: 60)
+
+      # Exhaust breaker_a
+      2.times { breaker_a.call { raise StandardError, 'fail' } rescue nil } # rubocop:disable Style/RescueModifier
+
+      expect(breaker_a.state).to eq(:open)
+      expect(breaker_b.state).to eq(:closed)
+    end
+
+    it 'failures are counted per instance — exhausting one does not affect another' do
+      shared_threshold = 3
+      breaker_a = described_class.new(threshold: shared_threshold, reset_timeout: 60)
+      breaker_b = described_class.new(threshold: shared_threshold, reset_timeout: 60)
+
+      # Fail breaker_a to threshold
+      shared_threshold.times { breaker_a.call { raise StandardError } rescue nil } # rubocop:disable Style/RescueModifier
+
+      # breaker_b should still allow calls
+      expect { breaker_b.call { 42 } }.not_to raise_error
+      expect(breaker_b.state).to eq(:closed)
+    end
+
+    it 'closed → open → half_open → closed cycle works correctly' do
+      # Drive to :open
+      3.times { breaker.call { raise StandardError, 'fail' } rescue nil } # rubocop:disable Style/RescueModifier
+      expect(breaker.state).to eq(:open)
+
+      # Simulate timeout elapsed — half_open probe succeeds → closed
+      allow(Time).to receive(:now).and_return(Time.now + 1.0)
+      breaker.call { 'recovered' }
+
+      expect(breaker.state).to eq(:closed)
+    end
+
+    it 'half_open probe failure returns to :open with a fresh cooldown' do
+      # Drive to :open
+      3.times { breaker.call { raise StandardError } rescue nil } # rubocop:disable Style/RescueModifier
+
+      frozen_now = Time.now
+      allow(Time).to receive(:now).and_return(frozen_now + 1.0)
+
+      # half_open probe fails
+      breaker.call { raise StandardError, 'still broken' } rescue nil # rubocop:disable Style/RescueModifier
+      expect(breaker.state).to eq(:open)
+
+      # Fresh cooldown: calls within the new window are rejected
+      expect { breaker.call { 'attempt' } }.to raise_error(Woods::Resilience::CircuitOpenError)
+    end
+
+    it 'a cyclic call path does not corrupt failure counts' do
+      # Simulate A → B → A by re-entering the same breaker from within its own block.
+      # The breaker uses a non-reentrant Mutex; the outer block executes outside the mutex,
+      # so re-entering via an inner call uses a separate phase-2 execution — this should work
+      # without deadlock, and failures count correctly.
+      inner_call_count = 0
+
+      breaker = described_class.new(threshold: 5, reset_timeout: 60)
+
+      # First outer call succeeds, triggering an inner call that also succeeds
+      breaker.call do
+        inner_call_count += 1
+        breaker.call { inner_call_count += 1 } # re-entrant — no deadlock expected
+      end
+
+      expect(inner_call_count).to eq(2)
+      expect(breaker.state).to eq(:closed)
+    end
+
+    it 'half_open succeeds then re-entering does not re-open the circuit' do
+      3.times { breaker.call { raise StandardError } rescue nil } # rubocop:disable Style/RescueModifier
+
+      allow(Time).to receive(:now).and_return(Time.now + 1.0)
+
+      # Successful half-open probe — resets state
+      breaker.call { 'probe ok' }
+      expect(breaker.state).to eq(:closed)
+
+      # A single subsequent failure should not open (threshold is 3, count was reset)
+      breaker.call { raise StandardError } rescue nil # rubocop:disable Style/RescueModifier
+      expect(breaker.state).to eq(:closed)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `spec/resilience/circuit_breaker_cyclic_spec.rb` — 6 examples verifying per-instance state isolation, closed→open→half_open→closed cycle, re-entrant call paths (closes `p2-spec-circuit-breaker-cyclic`)
- `spec/dependency_graph_cyclic_spec.rb` — 11 examples covering `#dependencies_of`, `#dependents_of`, `#affected_by` termination (no infinite loop), visited-tracking dedup, and PageRank convergence/symmetry on cyclic graphs (closes `p2-spec-dependency-graph-cyclic`)
- `spec/extractors/incremental_filtering_spec.rb` — 13 examples asserting that `re_extract_unit` silently skips `route`, `middleware`, `engine`, `scheduled_job`, `state_machine`, `factory`, `event`, and `rails_source` types; confirms FILE_BASED (`:service`, `:concern`) and GraphQL types reach their respective dispatch paths; framework-prefix skip verified (closes `p2-spec-incremental-unit-filtering`)

No library files were modified. No library bugs found.

## Test plan

- [x] Each spec file passes individually (`bundle exec rspec <file> --format documentation`)
- [x] Full suite: 3991 examples, 0 failures
- [x] `bundle exec rubocop -A` on all three files: no offenses