### PR TITLE
feat(retrieval): integrate pagerank into ranker importance signal (P2)

### DIFF
--- a/lib/woods/retrieval/ranker.rb
+++ b/lib/woods/retrieval/ranker.rb
@@ -35,8 +35,11 @@ module Woods
       RRF_K = 60
 
       # @param metadata_store [#find] Store that resolves identifiers to unit metadata
-      def initialize(metadata_store:)
+      # @param graph_store [#pagerank, nil] Optional graph store exposing PageRank scores.
+      #   When present, PageRank rank-percentile replaces the bucketed importance signal.
+      def initialize(metadata_store:, graph_store: nil)
         @metadata_store = metadata_store
+        @graph_store = graph_store
       end
 
       # Rank candidates by weighted signal scoring with diversity adjustment.
@@ -133,7 +136,7 @@ module Woods
               semantic: candidate.score.to_f,
               keyword: keyword_score(candidate),
               recency: recency_score(unit),
-              importance: importance_score(unit),
+              importance: importance_score(unit, candidate.identifier),
               type_match: type_match_score(unit, classification),
               diversity: 1.0 # Adjusted after initial sort
             }
@@ -184,9 +187,18 @@ module Woods
 
       # Importance score based on PageRank / structural importance.
       #
+      # Prefers live PageRank from the graph store (rank-percentile 0.0–1.0) when
+      # available. Falls back to bucketed importance metadata (`:high`/`:medium`/`:low`)
+      # when there is no graph store, the PageRank map is empty, or the identifier
+      # is not yet indexed (e.g., a new unit since the last extraction).
+      #
       # @param unit [Hash, nil] Unit metadata from store
+      # @param identifier [String] Candidate identifier (matched against PageRank keys)
       # @return [Float] 0.0 to 1.0
-      def importance_score(unit)
+      def importance_score(unit, identifier)
+        pagerank = pagerank_importance_map[identifier]
+        return pagerank if pagerank
+
         return 0.5 unless unit
 
         importance = dig_metadata(unit, :importance)
@@ -196,6 +208,35 @@ module Woods
         when 'low' then 0.3
         else 0.5
         end
+      end
+
+      # Lazily-computed rank-percentile map derived from the graph store's PageRank.
+      #
+      # Top-ranked identifier gets 1.0, bottom-ranked gets 1/n. Identifiers absent
+      # from PageRank (new units, ephemeral candidates) return nil and fall back
+      # to the bucketed importance signal.
+      #
+      # @return [Hash{String => Float}]
+      def pagerank_importance_map
+        @pagerank_importance_map ||= compute_pagerank_importance_map
+      end
+
+      # Compute rank-percentile scores from the graph store's PageRank hash.
+      #
+      # @return [Hash{String => Float}] Empty hash when no graph store or no scores.
+      def compute_pagerank_importance_map
+        return {} unless @graph_store.respond_to?(:pagerank)
+
+        scores = @graph_store.pagerank
+        return {} if scores.nil? || scores.empty?
+
+        ranked = scores.sort_by { |_id, score| -score }
+        total = ranked.size.to_f
+        ranked.each_with_index.to_h do |(identifier, _score), rank|
+          [identifier, 1.0 - (rank / total)]
+        end
+      rescue StandardError
+        {}
       end
 
       # Type match score — bonus when result type matches query target_type.

--- a/lib/woods/retriever.rb
+++ b/lib/woods/retriever.rb
@@ -59,7 +59,7 @@ module Woods
         graph_store: graph_store,
         embedding_provider: embedding_provider
       )
-      @ranker = Retrieval::Ranker.new(metadata_store: metadata_store)
+      @ranker = Retrieval::Ranker.new(metadata_store: metadata_store, graph_store: graph_store)
       @assembler = Retrieval::ContextAssembler.new(metadata_store: metadata_store)
     end
 

--- a/spec/retrieval/ranker_spec.rb
+++ b/spec/retrieval/ranker_spec.rb
@@ -5,6 +5,7 @@ require 'woods/retrieval/search_executor'
 require 'woods/retrieval/query_classifier'
 require 'woods/retrieval/ranker'
 require 'woods/storage/metadata_store'
+require 'woods/storage/graph_store'
 
 RSpec.describe Woods::Retrieval::Ranker do
   let(:metadata_store) { instance_double(Woods::Storage::MetadataStore::Interface) }
@@ -184,6 +185,112 @@ RSpec.describe Woods::Retrieval::Ranker do
       trivial = candidate(identifier: 'Trivial', score: 0.5)
 
       result = ranker.rank([trivial, important], classification: classification)
+
+      expect(result.first.identifier).to eq('Important')
+    end
+  end
+
+  describe 'pagerank importance integration' do
+    let(:graph_store) { instance_double(Woods::Storage::GraphStore::Interface) }
+    let(:ranker) { described_class.new(metadata_store: metadata_store, graph_store: graph_store) }
+
+    it 'prefers high-pagerank candidates over low-pagerank ones' do
+      allow(graph_store).to receive(:pagerank).and_return(
+        'Hot' => 0.9, 'Warm' => 0.1, 'Cold' => 0.001
+      )
+      allow(metadata_store).to receive(:find).and_return(nil)
+
+      candidates = %w[Cold Warm Hot].map { |id| candidate(identifier: id, score: 0.5) }
+
+      result = ranker.rank(candidates, classification: classification)
+
+      expect(result.map(&:identifier)).to eq(%w[Hot Warm Cold])
+    end
+
+    it 'uses rank-percentile rather than raw pagerank values' do
+      # Raw values span 4 orders of magnitude, but percentile compresses
+      # ranking into 1.0 (top) down to 1/n (bottom) — order is what matters.
+      allow(graph_store).to receive(:pagerank).and_return(
+        'Top' => 0.9, 'Mid' => 0.0005, 'Bottom' => 0.00001
+      )
+      allow(metadata_store).to receive(:find).and_return(nil)
+
+      candidates = %w[Bottom Mid Top].map { |id| candidate(identifier: id, score: 0.5) }
+
+      result = ranker.rank(candidates, classification: classification)
+
+      expect(result.map(&:identifier)).to eq(%w[Top Mid Bottom])
+    end
+
+    it 'falls back to bucketed metadata importance for identifiers absent from pagerank' do
+      # Known is the lowest-ranked unit in a 5-node graph (percentile ≈ 0.2)
+      allow(graph_store).to receive(:pagerank).and_return(
+        'A' => 0.9, 'B' => 0.7, 'C' => 0.5, 'D' => 0.3, 'Known' => 0.01
+      )
+      allow(metadata_store).to receive(:find).with('Known').and_return(nil)
+      allow(metadata_store).to receive(:find).with('NewUnit')
+                                             .and_return({ metadata: { importance: :high } })
+
+      known = candidate(identifier: 'Known', score: 0.5)
+      # NewUnit isn't in the graph yet, but its bucketed importance is :high (=> 1.0)
+      new_unit = candidate(identifier: 'NewUnit', score: 0.5)
+
+      result = ranker.rank([known, new_unit], classification: classification)
+
+      expect(result.first.identifier).to eq('NewUnit')
+    end
+
+    it 'falls back entirely when graph store returns an empty pagerank hash' do
+      allow(graph_store).to receive(:pagerank).and_return({})
+      allow(metadata_store).to receive(:find).with('Important')
+                                             .and_return({ metadata: { importance: :high } })
+      allow(metadata_store).to receive(:find).with('Trivial')
+                                             .and_return({ metadata: { importance: :low } })
+
+      candidates = [
+        candidate(identifier: 'Trivial', score: 0.5),
+        candidate(identifier: 'Important', score: 0.5)
+      ]
+
+      result = ranker.rank(candidates, classification: classification)
+
+      expect(result.first.identifier).to eq('Important')
+    end
+
+    it 'swallows graph store errors and falls back to bucketed importance' do
+      allow(graph_store).to receive(:pagerank).and_raise(StandardError, 'graph unavailable')
+      allow(metadata_store).to receive(:find).with('Important')
+                                             .and_return({ metadata: { importance: :high } })
+
+      candidates = [candidate(identifier: 'Important', score: 0.5)]
+
+      expect { ranker.rank(candidates, classification: classification) }.not_to raise_error
+    end
+
+    it 'computes pagerank map once even across multiple rank() calls' do
+      allow(graph_store).to receive(:pagerank).and_return('A' => 0.9, 'B' => 0.1).once
+      allow(metadata_store).to receive(:find).and_return(nil)
+
+      2.times do
+        ranker.rank([candidate(identifier: 'A', score: 0.5)], classification: classification)
+      end
+    end
+  end
+
+  describe 'ranker without graph_store (backwards compat)' do
+    it 'falls back to bucketed metadata importance' do
+      allow(metadata_store).to receive(:find).with('Important')
+                                             .and_return({ metadata: { importance: :high } })
+      allow(metadata_store).to receive(:find).with('Trivial')
+                                             .and_return({ metadata: { importance: :low } })
+
+      ranker_without_graph = described_class.new(metadata_store: metadata_store)
+      candidates = [
+        candidate(identifier: 'Trivial', score: 0.5),
+        candidate(identifier: 'Important', score: 0.5)
+      ]
+
+      result = ranker_without_graph.rank(candidates, classification: classification)
 
       expect(result.first.identifier).to eq('Important')
     end


### PR DESCRIPTION
## Summary

Replaces the bucketed metadata importance signal with live rank-percentile scoring derived from the dependency graph's PageRank.

- **Before:** `importance_score` mapped metadata `:high`/`:medium`/`:low` → `1.0`/`0.6`/`0.3`, defaulting to `0.5`. PageRank already gets computed at extraction time and written to \`dependency_graph.json\`, but retrieval never read it.
- **After:** When a \`graph_store\` is wired into the Ranker, it lazily derives a rank-percentile map from \`graph_store.pagerank\`. Top-ranked unit → \`1.0\`, bottom → \`1/n\`. Identifiers not in the graph (new/ephemeral units) still fall through to the bucketed metadata signal, so behavior degrades gracefully on partial data.

Graph-store errors are swallowed so a misconfigured graph never breaks ranking.

\`Retriever\` passes its existing \`graph_store\` argument to \`Ranker.new\`. Direct Ranker consumers that omit \`graph_store:\` are unchanged (backwards-compatible).

Addresses P2 backlog item \`p2-pagerank-ranker-integration\` from the v1.0 pre-release audit.

## Test plan
- [x] New ranker specs: high pagerank beats low, rank-percentile ignores raw magnitude, fallback for identifiers absent from pagerank, fallback on empty/raising graph store, pagerank computed once across multiple \`rank()\` calls, backwards-compat path without graph_store
- [x] Full suite: \`bundle exec rake spec\` — 3998 examples, 0 failures (2 unrelated pending)
- [x] Rubocop clean on changed files