### PR TITLE
perf(mcp): warm index reader cache on server build (P2)

### DIFF
--- a/lib/woods/mcp/index_reader.rb
+++ b/lib/woods/mcp/index_reader.rb
@@ -52,6 +52,34 @@ module Woods
         @identifier_map = nil
       end
 
+      # Pre-populate cached state so the first MCP tool call doesn't pay
+      # for disk reads + JSON parsing.
+      #
+      # Touches every lazy accessor: manifest, summary, dependency_graph,
+      # graph_analysis, and the identifier_map (which reads all _index.json
+      # files). Each step is individually rescued so a missing optional
+      # artefact (e.g. graph_analysis.json) never blocks the rest.
+      #
+      # Safe to call multiple times — lazy accessors short-circuit on the
+      # memoized value.
+      #
+      # @return [Hash] Per-step outcome: `{step => true | Exception}`
+      def warmup!
+        steps = {
+          manifest: -> { manifest },
+          summary: -> { summary },
+          dependency_graph: -> { dependency_graph },
+          graph_analysis: -> { graph_analysis },
+          identifier_map: -> { identifier_map }
+        }
+        steps.each_with_object({}) do |(step, runner), result|
+          runner.call
+          result[step] = true
+        rescue StandardError => e
+          result[step] = e
+        end
+      end
+
       # Clear all cached state so the next access re-reads from disk.
       #
       # @return [void]

--- a/lib/woods/mcp/server.rb
+++ b/lib/woods/mcp/server.rb
@@ -28,10 +28,14 @@ module Woods
         # @param retriever [Woods::Retriever, nil] Optional retriever for semantic search
         # @param operator [Hash, nil] Optional operator config with :status_reporter, :error_escalator, :pipeline_guard, :pipeline_lock
         # @param feedback_store [Woods::Feedback::Store, nil] Optional feedback store
+        # @param warmup [Boolean] Pre-populate the index reader's caches during build,
+        #   shifting first-tool-call latency to startup. Default: true. Pass false for
+        #   tests or when startup time matters more than first-query latency.
         # @return [MCP::Server] Configured server ready for transport
         def build(index_dir:, retriever: nil, operator: nil, feedback_store: nil, snapshot_store: nil,
-                  response_format: nil)
+                  response_format: nil, warmup: true)
           reader = IndexReader.new(index_dir)
+          reader.warmup! if warmup
           config = Woods.configuration
           format = response_format || (config.respond_to?(:context_format) ? config.context_format : nil) || :markdown
           renderer = ToolResponseRenderer.for(format)

--- a/spec/mcp/index_reader_spec.rb
+++ b/spec/mcp/index_reader_spec.rb
@@ -69,6 +69,51 @@ RSpec.describe Woods::MCP::IndexReader do
     end
   end
 
+  describe '#warmup!' do
+    it 'reports success for every step when artefacts are present' do
+      result = reader.warmup!
+
+      expect(result).to eq(
+        manifest: true,
+        summary: true,
+        dependency_graph: true,
+        graph_analysis: true,
+        identifier_map: true
+      )
+    end
+
+    it 'populates caches so subsequent accessors do not re-read from disk' do
+      reader.warmup!
+
+      # After warmup, calling a lazy accessor should not parse JSON again.
+      # Prove this by spying on File.read: subsequent calls hit zero reads.
+      allow(File).to receive(:read).and_call_original
+      reader.manifest
+      reader.dependency_graph
+      reader.graph_analysis
+
+      expect(File).not_to have_received(:read)
+    end
+
+    it 'is idempotent — second call reuses the memoized values' do
+      first_graph = reader.warmup! && reader.dependency_graph
+      second_graph = reader.warmup! && reader.dependency_graph
+
+      expect(first_graph).to equal(second_graph)
+    end
+
+    it 'records per-step exceptions without aborting the rest' do
+      # Force one step to raise. graph_analysis.json is optional and easy to target.
+      allow(reader).to receive(:graph_analysis).and_raise(StandardError, 'boom')
+
+      result = reader.warmup!
+
+      expect(result[:graph_analysis]).to be_a(StandardError)
+      expect(result[:manifest]).to be(true)
+      expect(result[:identifier_map]).to be(true)
+    end
+  end
+
   describe '#find_unit' do
     it 'returns full unit data for a valid identifier' do
       unit = reader.find_unit('Post')

--- a/spec/mcp/server_spec.rb
+++ b/spec/mcp/server_spec.rb
@@ -58,6 +58,27 @@ RSpec.describe Woods::MCP::Server do
       uris = templates.map(&:uri_template)
       expect(uris).to contain_exactly('codebase://unit/{identifier}', 'codebase://type/{type}')
     end
+
+    it 'warms the index reader cache by default' do
+      reader = Woods::MCP::IndexReader.new(fixture_dir)
+      allow(Woods::MCP::IndexReader).to receive(:new).and_return(reader)
+
+      described_class.build(index_dir: fixture_dir, response_format: :json)
+
+      # After build, the manifest is already memoized — reading it should not
+      # call File.read on manifest.json.
+      allow(File).to receive(:read).and_call_original
+      reader.manifest
+      expect(File).not_to have_received(:read)
+    end
+
+    it 'skips warmup when warmup: false' do
+      reader = Woods::MCP::IndexReader.new(fixture_dir)
+      allow(Woods::MCP::IndexReader).to receive(:new).and_return(reader)
+      expect(reader).not_to receive(:warmup!)
+
+      described_class.build(index_dir: fixture_dir, response_format: :json, warmup: false)
+    end
   end
 
   describe 'tool: lookup' do


### PR DESCRIPTION
## Summary

\`IndexReader\` lazy-loads five pieces of state the first time each is requested: \`manifest.json\`, \`SUMMARY.md\`, \`dependency_graph.json\`, \`graph_analysis.json\`, and the identifier map (which reads all 34 \`_index.json\` files). For stdio MCP servers, that means the first tool call pays disk + JSON parse cost — an observable first-query latency spike every time an agent connects.

- **\`IndexReader#warmup!\`** — touches all five accessors with per-step \`rescue\`, returning \`{step => true | Exception}\`. Missing optional artefacts (old extractions without \`graph_analysis.json\`) no longer block the rest.
- **\`MCP::Server.build(..., warmup: true)\`** — default \`true\`, pre-warms the reader right after instantiation. Callers that need the old lazy behavior (tests, cold-start benchmarks) can pass \`warmup: false\`.

Idempotent: second \`warmup!\` call is a no-op because the lazy accessors short-circuit on memoized state.

Addresses P2 backlog item \`p2-cache-warmup-mcp-boot\` from the v1.0 pre-release audit.

## Test plan
- [x] New IndexReader specs: every step succeeds on the fixture, caches stay warm (no further File.read after warmup), idempotent across repeat calls, per-step exceptions don't abort the rest
- [x] New Server.build specs: default build warms the reader, \`warmup: false\` skips it
- [x] Full suite: \`bundle exec rake spec\` — 4004 examples, 0 failures (2 unrelated pending)
- [x] Rubocop clean on changed files