### PR TITLE
test: replace mock-centric patterns with observable stubs (3 specs)

### DIFF
--- a/spec/console/dispatch_pipeline_spec.rb
+++ b/spec/console/dispatch_pipeline_spec.rb
@@ -28,6 +28,26 @@ RSpec.describe Woods::Console::DispatchPipeline do
     end
   end
 
+  # Hand-rolled recording logger. Each log call is captured as a data tuple so
+  # specs can assert on observable log output without RSpec message spies.
+  let(:recording_logger_class) do
+    Class.new do
+      attr_reader :events
+
+      def initialize
+        @events = []
+      end
+
+      def warn(event, payload = {})
+        @events << { level: :warn, event: event, payload: payload }
+      end
+
+      def info(event, payload = {})
+        @events << { level: :info, event: event, payload: payload }
+      end
+    end
+  end
+
   let(:ok_result) { { 'ok' => true, 'result' => { 'record' => { 'id' => 1 } } } }
   let(:error_result) { { 'ok' => false, 'error_type' => 'RuntimeError', 'error' => 'boom' } }
 
@@ -79,13 +99,14 @@ RSpec.describe Woods::Console::DispatchPipeline do
       scanner = Woods::Console::CredentialScanner.new
       response_ctx = Woods::Console::ResponseContext.build(credential_scanner: scanner)
       conn = conn_mgr.new('ok' => true, 'result' => 'token: sk_live_abcdefghijklmnopqrstuvwx')
-      logger = spy('logger')
+      logger = recording_logger_class.new
       pipeline = build_pipeline(conn: conn, ctx: response_ctx, logger: logger)
 
       response = pipeline.call({})
 
       expect(response.content.first[:text]).to include('[REDACTED')
-      expect(logger).to have_received(:warn).with('console.credential_scan.hits', anything)
+      credential_events = logger.events.select { |e| e[:event] == 'console.credential_scan.hits' }
+      expect(credential_events).not_to be_empty
     end
 
     it 'renders via the renderer when provided' do
@@ -114,14 +135,15 @@ RSpec.describe Woods::Console::DispatchPipeline do
       gate = Woods::Console::TableGate.new(blocked_tables: %w[users], model_tables: {})
       response_ctx = Woods::Console::ResponseContext.build(table_gate: gate)
       conn = conn_mgr.new(ok_result)
-      logger = spy('logger')
+      logger = recording_logger_class.new
       pipeline = build_pipeline(conn: conn, ctx: response_ctx, logger: logger)
 
       response = pipeline.call({ sql: 'SELECT * FROM users' })
 
       expect(response.error?).to be(true)
       expect(response.content.first[:text]).to include('users')
-      expect(logger).to have_received(:warn).with('console.table_gate.rejected', anything)
+      rejection_events = logger.events.select { |e| e[:event] == 'console.table_gate.rejected' }
+      expect(rejection_events).not_to be_empty
       expect(conn.calls).to be_empty
     end
 

--- a/spec/embedding/indexer_spec.rb
+++ b/spec/embedding/indexer_spec.rb
@@ -6,19 +6,36 @@ require 'woods'
 require 'woods/embedding/indexer'
 require 'woods/embedding/text_preparer'
 require 'woods/embedding/provider'
+require 'woods/storage/vector_store'
 
 RSpec.describe Woods::Embedding::Indexer do
+  # A small stub provider that returns deterministic vectors. Uses a real class
+  # so the indexer exercises actual call paths instead of RSpec's message
+  # tracking.
+  let(:stub_provider_class) do
+    Class.new do
+      attr_reader :embed_batch_calls
+
+      def initialize(vector: [0.1, 0.2])
+        @vector = vector
+        @embed_batch_calls = 0
+      end
+
+      def embed(_text)
+        @vector
+      end
+
+      def embed_batch(texts)
+        @embed_batch_calls += 1
+        Array.new(texts.length) { @vector }
+      end
+    end
+  end
+
   let(:output_dir) { '/tmp/claude/indexer_test' }
-
-  let(:provider) do
-    instance_double('Provider', embed: [0.1, 0.2], embed_batch: [[0.1, 0.2], [0.3, 0.4]])
-  end
-
+  let(:provider) { stub_provider_class.new }
   let(:text_preparer) { Woods::Embedding::TextPreparer.new }
-
-  let(:vector_store) do
-    instance_double('VectorStore', store: nil, store_batch: nil, delete: nil, count: 0)
-  end
+  let(:vector_store) { Woods::Storage::VectorStore::InMemory.new }
 
   let(:indexer) do
     described_class.new(
@@ -58,7 +75,6 @@ RSpec.describe Woods::Embedding::Indexer do
 
   before do
     FileUtils.mkdir_p(output_dir)
-    # Clean up any previous test files
     Dir.glob(File.join(output_dir, '*.json')).each { |f| File.delete(f) }
   end
 
@@ -78,21 +94,18 @@ RSpec.describe Woods::Embedding::Indexer do
       expect(stats[:errors]).to eq(0)
     end
 
-    it 'calls embed_batch on the provider' do
+    it 'stores the embedded vector in the vector store' do
       indexer.index_all
-      expect(provider).to have_received(:embed_batch)
+
+      expect(vector_store.count).to eq(1)
+      results = vector_store.search([0.1, 0.2], limit: 1)
+      expect(results.first.id).to eq('User')
+      expect(results.first.metadata).to include(type: 'model', identifier: 'User')
     end
 
-    it 'stores vectors in the vector store via batch' do
+    it 'writes a checkpoint file keyed by identifier and source hash' do
       indexer.index_all
-      expect(vector_store).to have_received(:store_batch).with(
-        [hash_including(id: 'User', vector: [0.1, 0.2],
-                        metadata: hash_including(type: 'model', identifier: 'User'))]
-      )
-    end
 
-    it 'writes a checkpoint file' do
-      indexer.index_all
       checkpoint = JSON.parse(File.read(File.join(output_dir, 'checkpoint.json')))
       expect(checkpoint['User']).to eq('abc123')
     end
@@ -102,9 +115,11 @@ RSpec.describe Woods::Embedding::Indexer do
         File.write(File.join(output_dir, 'payment_service.json'), JSON.generate(second_unit_data))
       end
 
-      it 'processes all units' do
+      it 'stores a vector for each unit' do
         stats = indexer.index_all
+
         expect(stats[:processed]).to eq(2)
+        expect(vector_store.count).to eq(2)
       end
     end
 
@@ -120,7 +135,6 @@ RSpec.describe Woods::Embedding::Indexer do
 
       before do
         File.write(File.join(output_dir, 'user.json'), JSON.generate(chunked_data))
-        allow(provider).to receive(:embed_batch).and_return([[0.1, 0.2], [0.3, 0.4]])
       end
 
       it 'creates one embedding per chunk' do
@@ -128,12 +142,11 @@ RSpec.describe Woods::Embedding::Indexer do
         expect(stats[:processed]).to eq(2)
       end
 
-      it 'stores each chunk with a chunk suffix ID via batch' do
+      it 'stores each chunk under a chunk-suffixed id' do
         indexer.index_all
-        expect(vector_store).to have_received(:store_batch) do |entries|
-          ids = entries.map { |e| e[:id] }
-          expect(ids).to include('User#chunk_0', 'User#chunk_1')
-        end
+
+        stored_ids = vector_store.search([0.1, 0.2], limit: 10).map(&:id)
+        expect(stored_ids).to contain_exactly('User#chunk_0', 'User#chunk_1')
       end
     end
 
@@ -179,15 +192,13 @@ RSpec.describe Woods::Embedding::Indexer do
         File.write(File.join(output_dir, 'checkpoint.json'), JSON.generate(checkpoint))
       end
 
-      it 'skips unchanged units' do
+      it 'skips unchanged units and does not embed them' do
         stats = indexer.index_incremental
+
         expect(stats[:processed]).to eq(0)
         expect(stats[:skipped]).to eq(1)
-      end
-
-      it 'does not call the provider' do
-        indexer.index_incremental
-        expect(provider).not_to have_received(:embed_batch)
+        expect(provider.embed_batch_calls).to eq(0)
+        expect(vector_store.count).to eq(0)
       end
     end
 
@@ -199,8 +210,10 @@ RSpec.describe Woods::Embedding::Indexer do
 
       it 'processes the changed unit' do
         stats = indexer.index_incremental
+
         expect(stats[:processed]).to eq(1)
         expect(stats[:skipped]).to eq(0)
+        expect(vector_store.count).to eq(1)
       end
     end
 
@@ -217,33 +230,57 @@ RSpec.describe Woods::Embedding::Indexer do
   end
 
   describe 'error handling' do
+    # Provider that always fails — a behavioural stub, not a mock spy.
+    let(:failing_provider_class) do
+      Class.new do
+        def initialize(message)
+          @message = message
+        end
+
+        def embed(_text)
+          raise StandardError, @message
+        end
+
+        def embed_batch(_texts)
+          raise StandardError, @message
+        end
+      end
+    end
+
     before do
       File.write(File.join(output_dir, 'user.json'), JSON.generate(unit_data))
-      allow(provider).to receive(:embed_batch).and_raise(StandardError, 'connection refused')
     end
 
     it 'raises Woods::Error on provider failure' do
-      expect { indexer.index_all }.to raise_error(
+      failing_indexer = described_class.new(
+        provider: failing_provider_class.new('connection refused'),
+        text_preparer: text_preparer,
+        vector_store: vector_store,
+        output_dir: output_dir,
+        batch_size: 2
+      )
+
+      expect { failing_indexer.index_all }.to raise_error(
         Woods::Error, /Embedding failed: connection refused/
       )
     end
 
-    it 'includes the error message in the raised exception' do
-      expect { indexer.index_all }.to raise_error(
-        Woods::Error, /connection refused/
-      )
-    end
-
     it 'increments error count in stats via embed_and_store' do
+      failing_indexer = described_class.new(
+        provider: failing_provider_class.new('network timeout'),
+        text_preparer: text_preparer,
+        vector_store: vector_store,
+        output_dir: output_dir,
+        batch_size: 2
+      )
+
       stats = { processed: 0, skipped: 0, errors: 0 }
       items = [{ id: 'User', text: 'class User; end', unit_data: unit_data,
                  source_hash: 'abc123', identifier: 'User' }]
       checkpoint = {}
 
-      allow(provider).to receive(:embed_batch).and_raise(StandardError, 'network timeout')
-
       expect do
-        indexer.send(:embed_and_store, items, checkpoint, stats)
+        failing_indexer.send(:embed_and_store, items, checkpoint, stats)
       end.to raise_error(Woods::Error, /network timeout/)
 
       expect(stats[:errors]).to eq(1)

--- a/spec/resilience/retryable_provider_spec.rb
+++ b/spec/resilience/retryable_provider_spec.rb
@@ -7,15 +7,54 @@ require 'woods/resilience/circuit_breaker'
 require 'woods/resilience/retryable_provider'
 
 RSpec.describe Woods::Resilience::RetryableProvider do
-  let(:mock_provider) do
-    instance_double(
-      Woods::Embedding::Provider::Ollama,
-      dimensions: 384,
-      model_name: 'test-model'
-    )
+  # Hand-rolled provider stub. Callers configure behavior by supplying
+  # sequences of results (values or exceptions); the stub replays them.
+  let(:recording_provider_class) do
+    Class.new do
+      attr_reader :embed_calls, :embed_batch_calls, :dimensions, :model_name
+
+      def initialize(embed_results: [], embed_batch_results: [], dimensions: 384, model_name: 'test-model')
+        @embed_results = embed_results.dup
+        @embed_batch_results = embed_batch_results.dup
+        @dimensions = dimensions
+        @model_name = model_name
+        @embed_calls = 0
+        @embed_batch_calls = 0
+      end
+
+      def embed(_text)
+        @embed_calls += 1
+        dispense(@embed_results)
+      end
+
+      def embed_batch(_texts)
+        @embed_batch_calls += 1
+        dispense(@embed_batch_results)
+      end
+
+      private
+
+      def dispense(queue)
+        result = queue.shift
+        raise result if result.is_a?(Exception)
+
+        result
+      end
+    end
   end
 
-  subject(:retryable) { described_class.new(provider: mock_provider, max_retries: 3) }
+  # Replace sleep with a recorder on a specific retryable instance. Returns the
+  # array that captures actual delay durations, so specs assert against real
+  # backoff values rather than message call history.
+  def record_sleep_on(retryable)
+    delays = []
+    retryable.define_singleton_method(:sleep) { |d| delays << d }
+    delays
+  end
+
+  let(:provider) { recording_provider_class.new(embed_results: [[0.1, 0.2, 0.3]]) }
+
+  subject(:retryable) { described_class.new(provider: provider, max_retries: 3) }
 
   describe '#dimensions' do
     it 'delegates to the wrapped provider' do
@@ -31,104 +70,121 @@ RSpec.describe Woods::Resilience::RetryableProvider do
 
   describe '#embed' do
     context 'when the provider succeeds immediately' do
-      before { allow(mock_provider).to receive(:embed).and_return([0.1, 0.2, 0.3]) }
-
-      it 'returns the embedding' do
+      it 'returns the embedding without retrying' do
         expect(retryable.embed('hello')).to eq([0.1, 0.2, 0.3])
+        expect(provider.embed_calls).to eq(1)
       end
     end
 
     context 'when the provider fails then succeeds' do
-      it 'retries and returns the result' do
-        call_count = 0
-        allow(mock_provider).to receive(:embed) do
-          call_count += 1
-          raise StandardError, 'transient error' if call_count < 3
+      let(:provider) do
+        recording_provider_class.new(
+          embed_results: [
+            StandardError.new('transient error'),
+            StandardError.new('transient error'),
+            [0.1, 0.2, 0.3]
+          ]
+        )
+      end
 
-          [0.1, 0.2, 0.3]
-        end
-
-        # Stub sleep to avoid actual delays
-        allow(retryable).to receive(:sleep)
+      it 'retries and eventually returns the embedding' do
+        record_sleep_on(retryable)
 
         expect(retryable.embed('hello')).to eq([0.1, 0.2, 0.3])
-        expect(call_count).to eq(3)
+        expect(provider.embed_calls).to eq(3)
       end
     end
 
     context 'when max retries are exceeded' do
-      before do
-        allow(mock_provider).to receive(:embed).and_raise(StandardError, 'persistent error')
-        allow(retryable).to receive(:sleep)
+      let(:provider) do
+        recording_provider_class.new(
+          embed_results: Array.new(10) { StandardError.new('persistent error') }
+        )
       end
 
       it 'raises the last error after exhausting retries' do
+        record_sleep_on(retryable)
+
         expect { retryable.embed('hello') }.to raise_error(StandardError, 'persistent error')
+      end
+
+      it 'attempts max_retries + 1 times in total' do
+        record_sleep_on(retryable)
+
+        begin
+          retryable.embed('hello')
+        rescue StandardError
+          # expected
+        end
+
+        expect(provider.embed_calls).to eq(4) # initial + 3 retries
       end
     end
 
     context 'with exponential backoff' do
-      before do
-        call_count = 0
-        allow(mock_provider).to receive(:embed) do
-          call_count += 1
-          raise StandardError, 'fail' if call_count < 3
-
-          [0.1]
-        end
+      let(:provider) do
+        recording_provider_class.new(
+          embed_results: [
+            StandardError.new('fail'),
+            StandardError.new('fail'),
+            [0.1]
+          ]
+        )
       end
 
-      it 'sleeps with exponential backoff between retries' do
-        allow(retryable).to receive(:sleep)
+      it 'sleeps with exponentially growing delays between retries' do
+        delays = record_sleep_on(retryable)
 
         retryable.embed('hello')
 
-        expect(retryable).to have_received(:sleep).with(0.2).ordered  # 2^1 * 0.1
-        expect(retryable).to have_received(:sleep).with(0.4).ordered  # 2^2 * 0.1
+        expect(delays).to eq([0.2, 0.4]) # 2^1 * 0.1, 2^2 * 0.1
       end
     end
   end
 
   describe '#embed_batch' do
     context 'when the provider succeeds immediately' do
-      before { allow(mock_provider).to receive(:embed_batch).and_return([[0.1], [0.2]]) }
+      let(:provider) { recording_provider_class.new(embed_batch_results: [[[0.1], [0.2]]]) }
 
       it 'returns the embeddings' do
         expect(retryable.embed_batch(%w[a b])).to eq([[0.1], [0.2]])
+        expect(provider.embed_batch_calls).to eq(1)
       end
     end
 
     context 'when the provider fails then succeeds' do
+      let(:provider) do
+        recording_provider_class.new(
+          embed_batch_results: [StandardError.new('transient'), [[0.1], [0.2]]]
+        )
+      end
+
       it 'retries and returns the result' do
-        call_count = 0
-        allow(mock_provider).to receive(:embed_batch) do
-          call_count += 1
-          raise StandardError, 'transient' if call_count < 2
-
-          [[0.1], [0.2]]
-        end
-
-        allow(retryable).to receive(:sleep)
+        record_sleep_on(retryable)
 
         expect(retryable.embed_batch(%w[a b])).to eq([[0.1], [0.2]])
-        expect(call_count).to eq(2)
+        expect(provider.embed_batch_calls).to eq(2)
       end
     end
   end
 
   describe 'circuit breaker integration' do
     let(:circuit_breaker) { Woods::Resilience::CircuitBreaker.new(threshold: 2, reset_timeout: 0.1) }
+    let(:provider) do
+      recording_provider_class.new(
+        embed_results: Array.new(10) { StandardError.new('fail') }
+      )
+    end
 
     subject(:retryable_with_cb) do
-      described_class.new(provider: mock_provider, max_retries: 3, circuit_breaker: circuit_breaker)
+      described_class.new(provider: provider, max_retries: 3, circuit_breaker: circuit_breaker)
     end
 
     context 'when circuit breaker is open' do
       before do
-        allow(mock_provider).to receive(:embed).and_raise(StandardError, 'fail')
-        allow(retryable_with_cb).to receive(:sleep)
+        record_sleep_on(retryable_with_cb)
 
-        # Trip the circuit breaker
+        # Trip the circuit breaker by exhausting retries once
         begin
           retryable_with_cb.embed('test')
         rescue StandardError
@@ -136,15 +192,19 @@ RSpec.describe Woods::Resilience::RetryableProvider do
         end
       end
 
-      it 'raises CircuitOpenError without retrying' do
+      it 'raises CircuitOpenError without invoking the provider' do
+        calls_before = provider.embed_calls
+
         expect do
           retryable_with_cb.embed('test')
         end.to raise_error(Woods::Resilience::CircuitOpenError)
+
+        expect(provider.embed_calls).to eq(calls_before)
       end
     end
 
     context 'when provider succeeds through circuit breaker' do
-      before { allow(mock_provider).to receive(:embed).and_return([0.5]) }
+      let(:provider) { recording_provider_class.new(embed_results: [[0.5]]) }
 
       it 'returns the result' do
         expect(retryable_with_cb.embed('hello')).to eq([0.5])


### PR DESCRIPTION
## Summary

Addresses the P2 audit item `p2-refactor-mock-centric-specs`. The audit flagged 5 spec files (~1098 lines). A file-by-file assessment found that only 3 of the 5 actually had mock-centric smells worth refactoring — the other two (`spec/console/response_context_spec.rb`, `spec/retrieval/search_executor_spec.rb`) were already observable and exercised real in-memory stores.

### What changed

- **`spec/embedding/indexer_spec.rb`** (259L): `instance_double('VectorStore')` → `Woods::Storage::VectorStore::InMemory`. Provider stays decoupled but as a stub class, not an `instance_double`. Assertions moved from `have_received(:store_batch).with(hash_including(...))` to `vector_store.count` / `.search(...)` — real state inspection.
- **`spec/resilience/retryable_provider_spec.rb`** (160L): `instance_double(Ollama)` + `have_received(:sleep).with(0.2).ordered` → `RecordingProvider` with result-queue semantics + `define_singleton_method(:sleep)` that captures durations into an array. Spec now asserts `delays == [0.2, 0.4]` against observable data.
- **`spec/console/dispatch_pipeline_spec.rb`** (177L): `spy('logger')` + `have_received(:warn).with('console.credential_scan.hits', anything)` → hand-rolled recording logger that captures each call as a data tuple. Assertions select events by name from an array.

### What didn't change and why

- **`response_context_spec.rb`** and **`search_executor_spec.rb`** were already observable (real stores, real value comparisons). No mock-centric pattern to remove — touching them would be churn.
- Tests that verify "X was not called" (e.g., skipped-unit path does not invoke the provider) kept a narrow counter assertion — this is a legitimate behavioural contract, just expressed through state rather than a mock spy.

### Why it matters

The mock-centric patterns were brittle: they asserted on call shapes (`have_received(:store_batch).with(...)`) rather than outcomes. A refactor that changes the call pattern without changing behaviour would break the spec. Moving to observable state (`vector_store.count`, captured log events, recorded sleep durations) lets the specs survive implementation refactors while still pinning down the actual behavioural contract.

## Test plan

- [x] Full suite passes: 4008 examples, 0 failures, 2 pending (pending = optional tiktoken_ruby benchmark)
- [x] The three touched files pass rubocop (no new offenses)
- [x] No production code changed — specs only