### PR TITLE
fix: require extracted_unit from standalone entry points

### DIFF
--- a/lib/woods/embedding/indexer.rb
+++ b/lib/woods/embedding/indexer.rb
@@ -3,6 +3,8 @@
 require 'json'
 require 'digest'
 
+require_relative '../extracted_unit'
+
 module Woods
   module Embedding
     # Orchestrates the indexing pipeline: reads extracted units, prepares text,

--- a/lib/woods/extractors/rails_source_extractor.rb
+++ b/lib/woods/extractors/rails_source_extractor.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../extracted_unit'
+
 module Woods
   module Extractors
     # RailsSourceExtractor indexes selected parts of the Rails framework

--- a/spec/load_order_spec.rb
+++ b/spec/load_order_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'open3'
+
+# Guards against "require X in isolation and a constant blows up" bugs.
+#
+# spec_helper eagerly requires woods/extracted_unit, so in-process tests can
+# never detect a missing sibling require. Each case shells out to a fresh
+# Ruby process to exercise the exact load order a user would hit by running
+# `bin/rails woods:embed` (or any other narrow entry point).
+# Files that reference Woods::ExtractedUnit directly. When required alone,
+# ExtractedUnit must already be defined — otherwise the caller gets
+# NameError the moment the referencing method runs.
+STANDALONE_EXTRACTED_UNIT_LOADERS = %w[
+  woods/embedding/indexer
+  woods/extractors/rails_source_extractor
+].freeze
+
+RSpec.describe 'Load order' do
+  STANDALONE_EXTRACTED_UNIT_LOADERS.each do |lib|
+    it "resolves Woods::ExtractedUnit after `require '#{lib}'` alone" do
+      stdout, status = Open3.capture2e(
+        'ruby', '-Ilib', "-r#{lib}",
+        '-e', 'exit(defined?(Woods::ExtractedUnit) ? 0 : 1)'
+      )
+      expect(status).to be_success, "ExtractedUnit undefined after requiring #{lib} in isolation:\n#{stdout}"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`bin/rails woods:embed` crashes with `NameError: uninitialized constant Woods::Embedding::Indexer::ExtractedUnit`. Root cause: `lib/woods/embedding/indexer.rb` references `Woods::ExtractedUnit` inside `build_unit`, but neither the file nor the `woods:embed` rake task ever requires `woods/extracted_unit`. It works through `woods:extract` only because `lib/woods/extractor.rb` eagerly requires it before loading any extractors.

An audit for the same pattern found a second instance — `lib/woods/extractors/rails_source_extractor.rb` does the same thing and has been latent because the testbed extracts zero framework sources by default, skipping the failure site.

Both fixes are identical one-line requires matching the convention already used in `lib/woods/ruby_analyzer/*.rb`.

## Broken entry points this addresses

- `woods:embed` — active (reported)
- `woods:embed_incremental` — same Indexer code path
- `woods:extract_framework` — latent (fires once `Woods.configuration.gem_configs` is populated)
- `exe/woods-mcp` / `exe/woods-mcp-http` — via the `pipeline_embed` MCP tool at `lib/woods/mcp/server.rb:735`, which instantiates `Woods::Embedding::Indexer`

## Regression test

`spec/load_order_spec.rb` shells out to a fresh Ruby process. In-process specs can't catch this class of bug because `spec_helper.rb:13` eagerly requires `woods/extracted_unit`, making the constant visible to every file regardless of its own requires. The spec is data-driven — add a lib path to `STANDALONE_EXTRACTED_UNIT_LOADERS` and the guard covers the new caller.

Sanity-checked by reverting each fix in turn; spec fails with the matching lib name, passes once restored.

## Test plan

- [x] `bundle exec rake spec` — 4010 examples, 0 failures
- [x] `bundle exec rubocop` on changed files — clean
- [x] `ruby -Ilib -rwoods/embedding/indexer -e 'puts defined?(Woods::ExtractedUnit)'` → `DEFINED`
- [x] `ruby -Ilib -rwoods/extractors/rails_source_extractor -e 'puts defined?(Woods::ExtractedUnit)'` → `DEFINED`
- [x] Revert-fix sanity: spec fails with accurate message, passes when restored
- [ ] After merge: verify in woods-testbed by running `bin/rails woods:embed` against a populated index