### PR TITLE
fix(embedding): filter non-unit JSON in Indexer#load_units

### DIFF
--- a/lib/woods/embedding/indexer.rb
+++ b/lib/woods/embedding/indexer.rb
@@ -39,7 +39,11 @@ module Woods
         Dir.glob(File.join(@output_dir, '**', '*.json')).filter_map do |path|
           next if File.basename(path) == 'checkpoint.json'
 
-          JSON.parse(File.read(path))
+          data = JSON.parse(File.read(path))
+          # Extraction output also contains index listings (_index.json arrays) and
+          # summary files (manifest.json, dependency_graph.json, graph_analysis.json)
+          # that live alongside per-unit JSON. Filter to the unit shape.
+          data if data.is_a?(Hash) && data.key?('type') && data.key?('identifier')
         rescue JSON::ParserError
           nil
         end

--- a/spec/embedding/indexer_spec.rb
+++ b/spec/embedding/indexer_spec.rb
@@ -171,6 +171,30 @@ RSpec.describe Woods::Embedding::Indexer do
         expect(stats[:processed]).to eq(1)
       end
     end
+
+    context 'when non-unit extraction output sits alongside unit files' do
+      # Real extraction output has _index.json listings (arrays) plus manifest /
+      # dependency_graph / graph_analysis summaries (hashes without a unit shape).
+      # Prior to the shape filter, these parsed into build_unit and crashed with
+      # TypeError: no implicit conversion of String into Integer.
+      before do
+        FileUtils.mkdir_p(File.join(output_dir, 'models'))
+        File.write(File.join(output_dir, 'models', '_index.json'),
+                   JSON.generate([{ 'identifier' => 'User', 'file_path' => 'app/models/user.rb' }]))
+        File.write(File.join(output_dir, 'manifest.json'),
+                   JSON.generate({ 'extracted_at' => '2026-04-22', 'unit_count' => 1 }))
+        File.write(File.join(output_dir, 'dependency_graph.json'),
+                   JSON.generate({ 'nodes' => [], 'edges' => [] }))
+        File.write(File.join(output_dir, 'graph_analysis.json'),
+                   JSON.generate({ 'orphans' => [], 'hubs' => [] }))
+      end
+
+      it 'processes only the unit file and ignores listings/summaries' do
+        stats = indexer.index_all
+        expect(stats[:processed]).to eq(1)
+        expect(stats[:errors]).to eq(0)
+      end
+    end
   end
 
   describe '#index_incremental' do


### PR DESCRIPTION
## Summary

- `bin/rails woods:embed` crashes immediately with `TypeError: no implicit conversion of String into Integer` against any populated `tmp/woods/` tree (reproduced from admin; shipped regression in 1.2.0).
- Root cause: `Indexer#load_units` globs every `*.json` under the output dir and hands each parsed blob to `build_unit`, which assumes a unit Hash. But extraction also writes per-directory `_index.json` listings (top-level arrays) and three summary files (`manifest.json`, `dependency_graph.json`, `graph_analysis.json` — Hashes without the unit shape). The Array case is what trips the TypeError at `data['type']`.
- Fix: filter `load_units` to `Hash`es carrying both `type` and `identifier` keys. Uses the shape rather than a filename blocklist so new non-unit files the extractor grows won't resurface this bug.
- Regression spec writes a mixed output dir (unit + `_index.json` array + `manifest`/`dependency_graph`/`graph_analysis` summaries) and asserts only the unit is processed.

## Verification

- Full suite: **4011 examples, 0 failures, 2 pending** (the 2 pending are pre-existing `tiktoken_ruby not installed` skips)
- Reproduced against the testbed's real extraction output: **291 units loaded, 0 non-unit shapes leaking through** with the fix applied

## Test plan

- [x] `bundle exec rspec spec/embedding/indexer_spec.rb` — new regression case passes
- [x] `bundle exec rspec` — full suite green
- [x] End-to-end against real `tmp/woods/` from woods-testbed rails-8.0 — no TypeError, correct unit count
- [ ] Reviewer repro: in any host app after `rake woods:extract`, run `rake woods:embed` with the fix and confirm no TypeError

## Impact

Unblocks embedding in every host app. Recommend cherry-picking to any vendored gem SHA in downstream apps that can't wait for 1.2.1.