### PR TITLE
fix(tasks): honour configured embedding provider in woods:embed

### DIFF
--- a/lib/tasks/woods.rake
+++ b/lib/tasks/woods.rake
@@ -354,33 +354,11 @@ namespace :woods do
   desc 'Embed all extracted units'
   task embed: :environment do
     require 'woods'
-    require 'woods/embedding/indexer'
-    require 'woods/embedding/text_preparer'
-    require 'woods/embedding/provider'
-    require 'woods/storage/vector_store'
+    require 'woods/tasks'
 
-    config = Woods.configuration
-    output_dir = ENV.fetch('WOODS_OUTPUT', config.output_dir)
-
-    provider = Woods::Embedding::Provider::Ollama.new
-    text_preparer = Woods::Embedding::TextPreparer.new
-    vector_store = Woods::Storage::VectorStore::InMemory.new
-
-    indexer = Woods::Embedding::Indexer.new(
-      provider: provider,
-      text_preparer: text_preparer,
-      vector_store: vector_store,
-      output_dir: output_dir
-    )
-
+    indexer = Woods::Tasks.build_embed_indexer
     puts 'Embedding all extracted units...'
-    stats = indexer.index_all
-
-    puts
-    puts 'Embedding complete!'
-    puts "  Processed: #{stats[:processed]}"
-    puts "  Skipped:   #{stats[:skipped]}"
-    puts "  Errors:    #{stats[:errors]}"
+    Woods::Tasks.print_embed_stats(indexer.index_all, mode: :full)
   end
 
   desc 'Nest the data — embed all units (alias for embed)'
@@ -389,33 +367,11 @@ namespace :woods do
   desc 'Embed changed units only (incremental)'
   task embed_incremental: :environment do
     require 'woods'
-    require 'woods/embedding/indexer'
-    require 'woods/embedding/text_preparer'
-    require 'woods/embedding/provider'
-    require 'woods/storage/vector_store'
+    require 'woods/tasks'
 
-    config = Woods.configuration
-    output_dir = ENV.fetch('WOODS_OUTPUT', config.output_dir)
-
-    provider = Woods::Embedding::Provider::Ollama.new
-    text_preparer = Woods::Embedding::TextPreparer.new
-    vector_store = Woods::Storage::VectorStore::InMemory.new
-
-    indexer = Woods::Embedding::Indexer.new(
-      provider: provider,
-      text_preparer: text_preparer,
-      vector_store: vector_store,
-      output_dir: output_dir
-    )
-
+    indexer = Woods::Tasks.build_embed_indexer
     puts 'Embedding changed units (incremental)...'
-    stats = indexer.index_incremental
-
-    puts
-    puts 'Incremental embedding complete!'
-    puts "  Processed: #{stats[:processed]}"
-    puts "  Skipped:   #{stats[:skipped]}"
-    puts "  Errors:    #{stats[:errors]}"
+    Woods::Tasks.print_embed_stats(indexer.index_incremental, mode: :incremental)
   end
 
   desc 'Hone the blade — incremental embedding (alias for embed_incremental)'

--- a/lib/woods/tasks.rb
+++ b/lib/woods/tasks.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative 'builder'
+require_relative 'embedding/indexer'
+require_relative 'embedding/text_preparer'
+
+module Woods
+  # Small helpers invoked from `lib/tasks/woods.rake`.
+  #
+  # Keeps rake task bodies to a couple of lines each so the real work lives in
+  # plain Ruby that can be unit-tested without Rake's global state.
+  module Tasks
+    module_function
+
+    # Build an {Embedding::Indexer} wired to the provider and stores described
+    # by {Woods.configuration}. Uses {Builder} so `config.embedding_provider`,
+    # `config.embedding_options`, and `config.vector_store(_options)` are all
+    # honoured — prior to this the rake tasks hardcoded Ollama + InMemory and
+    # silently ignored configuration, which was invisible until the provider
+    # tried to reach an unreachable default host.
+    #
+    # @return [Embedding::Indexer]
+    def build_embed_indexer
+      config = Woods.configuration
+      builder = Builder.new(config)
+
+      Embedding::Indexer.new(
+        provider: builder.build_embedding_provider,
+        text_preparer: Embedding::TextPreparer.new,
+        vector_store: builder.build_vector_store,
+        output_dir: ENV.fetch('WOODS_OUTPUT', config.output_dir)
+      )
+    end
+
+    # Print an indexer stats hash in the format the rake tasks have historically
+    # used. `mode:` only affects the header line.
+    #
+    # @param stats [Hash]
+    # @param mode [Symbol] :full or :incremental
+    def print_embed_stats(stats, mode:)
+      header = mode == :incremental ? 'Incremental embedding complete!' : 'Embedding complete!'
+      puts
+      puts header
+      puts "  Processed: #{stats[:processed]}"
+      puts "  Skipped:   #{stats[:skipped]}"
+      puts "  Errors:    #{stats[:errors]}"
+    end
+  end
+end

--- a/spec/tasks_spec.rb
+++ b/spec/tasks_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'woods'
+require 'woods/tasks'
+
+RSpec.describe Woods::Tasks do
+  describe '.build_embed_indexer' do
+    let(:fake_provider) { instance_double(Woods::Embedding::Provider::Ollama) }
+    let(:fake_vector_store) { instance_double(Woods::Storage::VectorStore::InMemory) }
+    let(:captured) { {} }
+
+    before do
+      allow_any_instance_of(Woods::Builder).to receive(:build_embedding_provider).and_return(fake_provider)
+      allow_any_instance_of(Woods::Builder).to receive(:build_vector_store).and_return(fake_vector_store)
+
+      allow(Woods::Embedding::Indexer).to receive(:new).and_wrap_original do |original, **kwargs|
+        captured.merge!(kwargs)
+        original.call(**kwargs)
+      end
+    end
+
+    # Regression — the rake tasks used to hardcode Ollama.new / InMemory.new and
+    # ignored Woods.configuration entirely, so admin's host.docker.internal URL
+    # for a container-hosted app was discarded and the provider fell back to
+    # localhost:11434 inside the container.
+    it 'wires the indexer with the configured provider and vector store' do
+      described_class.build_embed_indexer
+
+      expect(captured[:provider]).to be(fake_provider)
+      expect(captured[:vector_store]).to be(fake_vector_store)
+      expect(captured[:text_preparer]).to be_a(Woods::Embedding::TextPreparer)
+    end
+
+    it 'uses config.output_dir by default' do
+      Woods.configure { |c| c.output_dir = '/tmp/woods-tasks-spec' }
+
+      described_class.build_embed_indexer
+
+      expect(captured[:output_dir]).to eq('/tmp/woods-tasks-spec')
+    end
+
+    it 'prefers WOODS_OUTPUT env var over config.output_dir' do
+      Woods.configure { |c| c.output_dir = '/tmp/config-output' }
+      ENV['WOODS_OUTPUT'] = '/tmp/env-output'
+
+      described_class.build_embed_indexer
+
+      expect(captured[:output_dir]).to eq('/tmp/env-output')
+    ensure
+      ENV.delete('WOODS_OUTPUT')
+    end
+  end
+
+  describe '.print_embed_stats' do
+    let(:stats) { { processed: 5, skipped: 2, errors: 0 } }
+
+    it 'prints a "complete" header in :full mode' do
+      expect { described_class.print_embed_stats(stats, mode: :full) }
+        .to output(/Embedding complete!/).to_stdout
+    end
+
+    it 'prints an "incremental" header in :incremental mode' do
+      expect { described_class.print_embed_stats(stats, mode: :incremental) }
+        .to output(/Incremental embedding complete!/).to_stdout
+    end
+
+    it 'prints the stats hash values' do
+      expect { described_class.print_embed_stats(stats, mode: :full) }
+        .to output(/Processed: 5.*Skipped:\s+2.*Errors:\s+0/m).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The `woods:embed` and `woods:embed_incremental` rake tasks hardcoded `Ollama.new` with no arguments and `InMemory.new` for the vector store, silently discarding every relevant configuration key:

- `config.embedding_provider`
- `config.embedding_options` (including `host:`)
- `config.embedding_model`
- `config.vector_store` / `config.vector_store_options`

For the admin host, this meant the carefully-configured `host: 'http://host.docker.internal:11434'` never reached the provider — the task ignored config and fell back to `DEFAULT_HOST = 'http://localhost:11434'`, which inside a container is the container itself. Agents saw `Errno::ECONNREFUSED` even when Ollama was running fine on the Mac host.

Route both task bodies through a small `Woods::Tasks` helper that wires the indexer via `Woods::Builder` — the same path `Retriever` already uses — so there's one source of truth for adapter selection.

## Why not a smaller fix

A 2-line patch inside the rake task (pass `**config.embedding_options` to `Ollama.new`) would fix admin but would still silently ignore `embedding_provider: :openai`, and rake task bodies aren't unit-testable. The helper is small (~30 lines) and makes the behaviour regression-testable.

## Test plan

- [x] `bundle exec rspec spec/tasks_spec.rb` — 6 examples, 0 failures
- [x] `bundle exec rspec spec/builder_spec.rb spec/embedding/ spec/tasks_spec.rb spec/load_order_spec.rb` — 115 examples, 0 failures
- [x] `bundle exec rubocop lib/tasks/woods.rake lib/woods/tasks.rb spec/tasks_spec.rb` — clean
- [ ] Once merged and admin bundles the new SHA: `bin/rails woods:embed` in `bc_admin` should reach Ollama at `host.docker.internal:11434` and not `localhost:11434`.

## Related / not included

There's a separate papercut where `CONFIGURATION_REFERENCE.md` and the auto-detect bootstrapper document the Ollama option as `base_url:` but the provider takes `host:`. That one's orthogonal (different code path, different users affected) — I'll file it as its own PR.