### PR TITLE
fix(embedding): pass options.num_ctx to Ollama /api/embed

### DIFF
--- a/lib/woods/embedding/provider.rb
+++ b/lib/woods/embedding/provider.rb
@@ -65,12 +65,22 @@ module Woods
 
         DEFAULT_MODEL = 'nomic-embed-text'
         DEFAULT_HOST = 'http://localhost:11434'
+        # Ollama caps embedding inputs at `num_ctx` tokens (default 2048),
+        # which truncates most real-world Rails units. nomic-embed-text
+        # supports up to 8192, matching the TextPreparer max_tokens default,
+        # so we lift the cap here to line the two up.
+        DEFAULT_NUM_CTX = 8192
 
         # @param model [String] Ollama model name (default: nomic-embed-text)
         # @param host [String] Ollama server URL (default: http://localhost:11434)
-        def initialize(model: DEFAULT_MODEL, host: DEFAULT_HOST)
+        # @param num_ctx [Integer, nil] Ollama context window in tokens. `nil`
+        #   uses Ollama's default (2048 for most embedding models — usually
+        #   too small). Defaults to 8192, which matches nomic-embed-text's
+        #   max and the TextPreparer default.
+        def initialize(model: DEFAULT_MODEL, host: DEFAULT_HOST, num_ctx: DEFAULT_NUM_CTX)
           @model = model
           @host = host
+          @num_ctx = num_ctx
           @uri = URI("#{host}/api/embed")
         end
 
@@ -80,7 +90,7 @@ module Woods
         # @return [Array<Float>] the embedding vector
         # @raise [Woods::Error] if the API returns an error
         def embed(text)
-          response = post_request({ model: @model, input: text })
+          response = post_request(build_body(text))
           response['embeddings'].first
         end
 
@@ -90,7 +100,7 @@ module Woods
         # @return [Array<Array<Float>>] array of embedding vectors
         # @raise [Woods::Error] if the API returns an error
         def embed_batch(texts)
-          response = post_request({ model: @model, input: texts })
+          response = post_request(build_body(texts))
           response['embeddings']
         end
 
@@ -111,6 +121,15 @@ module Woods
         end
 
         private
+
+        # Build the JSON body for an `/api/embed` call. Adds `options.num_ctx`
+        # when configured — without it, Ollama silently truncates to 2048
+        # tokens and returns 400 when the input exceeds that default.
+        def build_body(input)
+          body = { model: @model, input: input }
+          body[:options] = { num_ctx: @num_ctx } if @num_ctx
+          body
+        end
 
         # Send a POST request to the Ollama API.
         #

--- a/spec/embedding/provider_spec.rb
+++ b/spec/embedding/provider_spec.rb
@@ -155,5 +155,46 @@ RSpec.describe Woods::Embedding::Provider do
         end
       end
     end
+
+    describe 'context window (num_ctx)' do
+      before { allow(http_double).to receive(:request).and_return(success_response) }
+
+      # Regression — without `options.num_ctx`, Ollama caps embedding input at
+      # its 2048-token default and returns 400 ("the input length exceeds the
+      # context length") on most real-world Rails units. nomic-embed-text
+      # supports 8192, matching the TextPreparer default.
+      it 'defaults to sending options.num_ctx = 8192' do
+        provider.embed('text')
+        expect(http_double).to have_received(:request) do |req|
+          body = JSON.parse(req.body)
+          expect(body.dig('options', 'num_ctx')).to eq(8192)
+        end
+      end
+
+      it 'includes num_ctx in batch requests' do
+        allow(http_double).to receive(:request).and_return(batch_success_response)
+        provider.embed_batch(%w[a b])
+        expect(http_double).to have_received(:request) do |req|
+          body = JSON.parse(req.body)
+          expect(body.dig('options', 'num_ctx')).to eq(8192)
+        end
+      end
+
+      it 'honours a custom num_ctx' do
+        described_class.new(num_ctx: 4096).embed('text')
+        expect(http_double).to have_received(:request) do |req|
+          body = JSON.parse(req.body)
+          expect(body.dig('options', 'num_ctx')).to eq(4096)
+        end
+      end
+
+      it 'omits the options key entirely when num_ctx is nil' do
+        described_class.new(num_ctx: nil).embed('text')
+        expect(http_double).to have_received(:request) do |req|
+          body = JSON.parse(req.body)
+          expect(body).not_to have_key('options')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Ollama's `/api/embed` caps each input at `num_ctx` tokens, which defaults to **2048** — enough for a tiny snippet but nowhere near enough for most real-world Rails units. On admin's ~6.3k-unit extraction the embed task crashed immediately:

```
Woods::Error: Embedding failed: Ollama API error: 400
{"error":"the input length exceeds the context length"}
```

`nomic-embed-text` supports up to **8192** tokens, which happens to match `TextPreparer::DEFAULT_MAX_TOKENS`. Sending `options.num_ctx = 8192` lines the two up and lets Ollama accept anything the text preparer produces (including its already-truncated output).

## Changes

- `Embedding::Provider::Ollama.new` gains a `num_ctx:` kwarg (default `8192`, const `DEFAULT_NUM_CTX`).
- Both `#embed` and `#embed_batch` now include `options: { num_ctx: @num_ctx }` in the JSON body.
- Passing `num_ctx: nil` omits the `options` block entirely — useful for callers who want Ollama's server-side default.

## Test plan

- [x] `bundle exec rspec spec/embedding/provider_spec.rb` — 19 examples, 0 failures
- [x] `bundle exec rspec spec/embedding/ spec/builder_spec.rb spec/tasks_spec.rb` — 117 examples, 0 failures
- [x] `bundle exec rubocop lib/woods/embedding/provider.rb spec/embedding/provider_spec.rb` — clean
- [ ] After merge, `bin/rails woods:embed` inside `bc_admin` completes instead of crashing on the first oversize unit.

## Not in scope

Oversize units (> ~7.4k tokens — e.g., a huge model with many callbacks + inlined concerns) will still be **truncated** by `TextPreparer.enforce_token_limit`, not split. That trades retrieval quality on the tail for stability. If the quality tradeoff matters in practice, the follow-up is to wire `Woods::Chunking::SemanticChunker` into the extraction pipeline so those units become `Unit#chunk_0`, `Unit#chunk_1`, … — the `Indexer` already handles chunked units at `indexer.rb:86`.