### PR TITLE
fix(embedding): size Ollama requests to the model's native context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Ollama embedding no longer fails with `400 "the input length exceeds the context length"`.** Two issues compounded into a single runtime failure when indexing real Rails codebases against Ollama: (a) the provider hard-coded `num_ctx = 8192` for every model, but Ollama's `/api/embed` enforces each model's *native* context length regardless of `options.num_ctx` ([ollama/ollama#14186](https://github.com/ollama/ollama/issues/14186)) — `nomic-embed-text`'s native ceiling is 2048, and any request larger than that was rejected outright; (b) the indexer's "does this unit need chunking?" check was based on a chars/token estimate that under-counts dense Ruby source (CamelCase constants, callback DSLs, symbol-heavy code), so chunks that looked safe by char count still exceeded the token budget.
+
+### Added
+
+- **Per-model context-length registry (`Woods::Embedding::Provider::Ollama::MODEL_CONTEXT_LENGTHS`).** `num_ctx` is now auto-selected from the configured model name: `nomic-embed-text` → 2048, `bge-m3` → 8192, `snowflake-arctic-embed2` → 8192, `mxbai-embed-large` → 512, `snowflake-arctic-embed` → 512, `all-minilm` → 256. Unknown models fall back to 2048 (Ollama's embedding default). Explicit `num_ctx:` overrides continue to win when set. `Provider::Ollama#max_input_tokens` reports the selected value so the chunker can size inputs correctly.
+- **`Woods::Embedding::TokenCounter` — optional exact-token accounting via the `tokenizers` gem.** Loads the `bert-base-uncased` WordPiece tokenizer (the base every BERT-family embedding model uses) and re-verifies every chunk client-side. Catches the 10–20% gap between char-based estimates and Ollama's internal count on dense Ruby source. Falls back to a 1.5 chars/token ratio when the gem isn't installed, so Woods works unchanged without it — `gem 'tokenizers', '~> 0.5'` is recommended for any Ollama setup.
+- **Token-aware `Indexer#needs_chunking?`.** When a `TokenCounter` is present, the indexer consults it before deciding to chunk — a char-count-safe but token-count-over-budget unit now gets split instead of sent to Ollama and rejected.
+- **New `docs/EMBEDDING_MODELS.md`** — comparison of the five supported Ollama embedding models (context, dimensions, disk size), instructions for switching models (including the dimension-change re-index requirement), a walkthrough of the `num_ctx` regression and how Woods works around it, and the procedure for adding a new model to the context-length registry.
+
+### Changed
+
+- **Ollama embedding configuration — `base_url:` keyword corrected to `host:` in user docs.** `Woods::Embedding::Provider::Ollama#initialize` has always accepted `host:` (never `base_url:`), but several doc examples showed `base_url:` — following them would raise `ArgumentError` on boot. `CONFIGURATION_REFERENCE.md`, `TROUBLESHOOTING.md`, `FAQ.md`, `GETTING_STARTED.md`, and top-level `README.md` snippets are corrected. No code change — this is documentation catching up to long-standing code.
+- **`BACKEND_MATRIX.md`** — Ollama section expanded to a full model table with native context, dimensions, and disk weights for each supported model; adds a "Self-hosted + large units" selection-guidance row pointing to `bge-m3`.
+
 ### Security
 
 - **Console MCP re-enabled behind a five-layer defense-in-depth stack.** The feature was previously disabled at its entry points after an audit flagged a Stripe Connect credential leak via the `authorizations` EAV table. It now ships gated on a new `console_mcp_enabled` config flag (default `false`) and runs through five independent safety layers, so a single misconfigured layer cannot leak secrets:

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,5 @@ group :development, :test do
   # Ruby 3.0 we have to skip the declaration entirely or lock fails before
   # install runs. Pinned to 0.5.x — tokenizers 0.6 requires Ruby 3.2+,
   # which would break our 3.1 CI matrix row.
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1')
-    gem 'tokenizers', '~> 0.5.0'
-  end
+  gem 'tokenizers', '~> 0.5.0' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1')
 end

--- a/Gemfile
+++ b/Gemfile
@@ -22,4 +22,10 @@ group :development, :test do
   # Optional: only needed for flow analysis (AST parsing)
   gem 'parser', '~> 3.3'
   gem 'prism', '>= 0.24'
+  # Optional: exact token counting for the Ollama embedding path. Uses the
+  # `bert-base-uncased` WordPiece tokenizer that nomic-embed-text is built
+  # on, so we can size chunks to num_ctx without char-ratio guessing.
+  # Users running OpenAI don't need this. Users on Ollama install it in
+  # their own Gemfile to opt into exact sizing (see docs/CONFIGURATION_REFERENCE).
+  gem 'tokenizers', '~> 0.5'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,14 @@ group :development, :test do
   gem 'rubocop-rails', '~> 2.19'
   gem 'rubocop-rspec', '~> 3.9'
   gem 'simplecov', '~> 0.22', require: false
-  gem 'sqlite3', '>= 1.4'
+  # sqlite3 2.0+ requires RubyGems >= 3.3.22, which Ruby 3.0.7 doesn't ship
+  # (it's stuck on 3.2.33). Pin to the 1.x line on 3.0 so the matrix row
+  # can still resolve; everywhere else we get the latest.
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1')
+    gem 'sqlite3', '>= 1.4'
+  else
+    gem 'sqlite3', '>= 1.4', '< 2.0'
+  end
   # Optional: only needed for flow analysis (AST parsing)
   gem 'parser', '~> 3.3'
   gem 'prism', '>= 0.24'

--- a/Gemfile
+++ b/Gemfile
@@ -27,5 +27,11 @@ group :development, :test do
   # on, so we can size chunks to num_ctx without char-ratio guessing.
   # Users running OpenAI don't need this. Users on Ollama install it in
   # their own Gemfile to opt into exact sizing (see docs/CONFIGURATION_REFERENCE).
-  gem 'tokenizers', '~> 0.5'
+  # Gated to Ruby >= 3.1 — the gem itself requires 3.1+, and the TokenCounter
+  # falls back to a chars/token ratio when the gem is absent.
+  install_if -> { Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1') } do
+    # Pinned to 0.5.x — tokenizers 0.6 requires Ruby 3.2+, which would
+    # break our 3.1 CI matrix row.
+    gem 'tokenizers', '~> 0.5.0'
+  end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -36,9 +36,11 @@ group :development, :test do
   # their own Gemfile to opt into exact sizing (see docs/CONFIGURATION_REFERENCE).
   # Gated to Ruby >= 3.1 — the gem itself requires 3.1+, and the TokenCounter
   # falls back to a chars/token ratio when the gem is absent.
-  install_if -> { Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1') } do
-    # Pinned to 0.5.x — tokenizers 0.6 requires Ruby 3.2+, which would
-    # break our 3.1 CI matrix row.
+  # Note: `install_if` still resolves the gem during `bundle lock`, so on
+  # Ruby 3.0 we have to skip the declaration entirely or lock fails before
+  # install runs. Pinned to 0.5.x — tokenizers 0.6 requires Ruby 3.2+,
+  # which would break our 3.1 CI matrix row.
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1')
     gem 'tokenizers', '~> 0.5.0'
   end
 end

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Woods.configure do |config|
     config.embedding_options = { api_key: ENV['OPENAI_API_KEY'] }
   else
     config.embedding_provider = :ollama
-    config.embedding_options = { base_url: 'http://localhost:11434' }
+    config.embedding_options = { model: 'nomic-embed-text', host: 'http://localhost:11434' }
   end
 end
 ```

--- a/docs/BACKEND_MATRIX.md
+++ b/docs/BACKEND_MATRIX.md
@@ -287,17 +287,25 @@ config.vector_store = :sqlite_faiss
 
 **Best for:** Code-specific retrieval where embedding quality matters. Code 3's 32K token window is significant — many extracted units exceed 8K tokens, especially with inlined concerns. The lower dimensionality (1024 vs 1536) also reduces vector storage costs.
 
-### Ollama / Nomic-embed-text (Self-hosted)
+### Ollama (Self-hosted)
 
-**Dimensions:** 768 (nomic-embed-text) / varies by model
-**Max tokens:** 8192 (nomic)
+| Model | Native context | Dimensions | Weights | Notes |
+|---|---|---|---|---|
+| `nomic-embed-text` (default) | 2048 | 768 | 274 MB | General-purpose, ships with Ollama |
+| `bge-m3` | **8192** | 1024 | 1.2 GB | Fewer chunks per unit, stronger code-search benchmarks |
+| `snowflake-arctic-embed2` | 8192 | 1024 | 1.2 GB | Multilingual variant of bge-m3 |
+| `mxbai-embed-large` | 512 | 1024 | 670 MB | Best for short text |
+| `all-minilm` | 256 | 384 | 46 MB | Tight-memory environments |
+
 **Cost:** Hardware only
 **Latency:** ~200ms single (GPU), ~2s single (CPU)
 
 **Strengths:** Fully self-hosted, no data leaves infrastructure, no API costs, works offline.
-**Weaknesses:** Requires GPU for reasonable performance (CPU is 10x slower), lower quality than commercial models, smaller dimensions may reduce retrieval precision.
+**Weaknesses:** Requires GPU for reasonable performance (CPU is 10× slower). `nomic-embed-text`'s 2048-token ceiling requires chunking most real-world Rails units — switch to `bge-m3` for fewer chunks if disk space allows.
 
 **Best for:** Security-sensitive environments, air-gapped networks, cost-sensitive at scale.
+
+> Ollama's `/api/embed` enforces the model's native context length regardless of the `options.num_ctx` override ([ollama/ollama#14186](https://github.com/ollama/ollama/issues/14186)). Woods advertises the native ceiling per model so the chunker sizes inputs correctly — see [EMBEDDING_MODELS.md](EMBEDDING_MODELS.md).
 
 ### Anthropic Embeddings
 
@@ -312,6 +320,7 @@ config.vector_store = :sqlite_faiss
 | **Best for large units** | Voyage Code 3 (32K context) |
 | **Lowest cost** | Ollama + nomic-embed-text |
 | **No external dependencies** | Ollama + nomic-embed-text |
+| **Self-hosted + large units** | Ollama + bge-m3 |
 | **Maximum quality** | OpenAI text-embedding-3-large |
 
 **Critical consideration:** Embedding dimensions must match across your entire index. Changing embedding providers requires a full re-index. Choose carefully at the start.

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -44,8 +44,10 @@ Woods.configure do |config|
     config.embedding_options = { api_key: ENV['OPENAI_API_KEY'] }
   else
     config.embedding_provider = :ollama
-    config.embedding_model = 'nomic-embed-text'
-    config.embedding_options = { base_url: ENV.fetch('OLLAMA_URL', 'http://localhost:11434') }
+    config.embedding_options = {
+      model: 'nomic-embed-text',
+      host: ENV.fetch('OLLAMA_URL', 'http://localhost:11434')
+    }
   end
 end
 ```
@@ -88,11 +90,25 @@ config.embedding_options = {
 
 ```ruby
 config.embedding_provider = :ollama
-config.embedding_model = 'nomic-embed-text'
 config.embedding_options = {
-  base_url: 'http://localhost:11434'
+  model: 'nomic-embed-text',
+  host: 'http://localhost:11434'
+  # num_ctx: 2048  # Optional override — see below
 }
 ```
+
+The provider reads `model:`, `host:`, and `num_ctx:` from `embedding_options`. `num_ctx` is auto-selected from a per-model registry (`nomic-embed-text` → 2048, `bge-m3` → 8192, `snowflake-arctic-embed2` → 8192, `mxbai-embed-large` → 512, `all-minilm` → 256). Unknown models fall back to 2048, matching Ollama's conservative embedding default. Set `num_ctx:` explicitly only when running a model with a known-larger native context that isn't in the registry yet.
+
+**Why `num_ctx` is capped at the native context.** Ollama has an open regression ([ollama/ollama#14186](https://github.com/ollama/ollama/issues/14186)) where `options.num_ctx` does not lift the effective ceiling on `/api/embed` for models whose native context is smaller than the override. Woods advertises the native ceiling so the chunker sizes inputs to what Ollama will actually accept.
+
+**Optional exact tokenization.** Install the [`tokenizers`](https://github.com/ankane/tokenizers-ruby) gem alongside Woods to get BERT WordPiece token counting. Without it, Woods falls back to a chars/token ratio, which under-counts dense Ruby source (CamelCase constants, callback DSLs) and can silently over-pack chunks. Recommended for any Ollama setup.
+
+```ruby
+# Gemfile (optional)
+gem 'tokenizers', '~> 0.5'
+```
+
+See [EMBEDDING_MODELS.md](EMBEDDING_MODELS.md) for the full model comparison and the procedure for adding a new model to the registry.
 
 ## Storage Options
 

--- a/docs/EMBEDDING_MODELS.md
+++ b/docs/EMBEDDING_MODELS.md
@@ -1,0 +1,121 @@
+# Embedding Models
+
+Woods supports OpenAI's embedding API and any model served by a local Ollama
+instance. This doc covers the Ollama side — which model to pick, why the
+default is conservative, and how to add a new one.
+
+## TL;DR
+
+| Model | Native context | Dimensions | Size on disk | Recommended for |
+|---|---|---|---|---|
+| `nomic-embed-text` (default) | 2048 | 768 | 274 MB | General use, small footprint |
+| `bge-m3` | **8192** | 1024 | 1.2 GB | Large Rails units, fewer chunks |
+| `snowflake-arctic-embed2` | 8192 | 1024 | 1.2 GB | Multilingual projects |
+| `mxbai-embed-large` | 512 | 1024 | 670 MB | Short text (tweets, commit msgs) |
+| `all-minilm` | 256 | 384 | 46 MB | Tight-memory environments |
+
+The default is `nomic-embed-text` because it's small, fast, and ships with every
+fresh Ollama install. If you're indexing a large Rails codebase and don't mind
+pulling a bigger model, switching to `bge-m3` usually gives you:
+
+- **Fewer chunks per unit** — 4× the context means most concern-inlined models
+  and service objects fit in a single embedding, which keeps retrieval scores
+  cleaner and the vector index smaller.
+- **Stronger retrieval** — `bge-m3` benchmarks meaningfully better than
+  `nomic-embed-text` on code-search MTEB tasks.
+
+The tradeoff is download size (1.2 GB vs 274 MB), RAM usage during inference,
+and a dimension change (768 → 1024) that requires re-indexing when you switch.
+
+## Switching models
+
+```ruby
+Woods.configure do |config|
+  config.embedding_provider = :ollama
+  config.embedding_options = {
+    model: 'bge-m3',
+    host: 'http://localhost:11434'
+  }
+  # Everything else — chunker sizing, token counting, num_ctx — is picked
+  # up automatically from the model name.
+end
+```
+
+Pull the model first:
+
+```bash
+ollama pull bge-m3
+```
+
+If you switch models on an existing install, drop your vector index before
+re-indexing — the embedding dimension change is incompatible with existing
+vectors. `Woods::Resilience::IndexValidator` will catch this and raise at
+startup if you miss it.
+
+## Why `num_ctx` isn't enough
+
+Ollama has a long-running regression (upstream issue
+[ollama/ollama#14186](https://github.com/ollama/ollama/issues/14186)) where
+`options.num_ctx` does **not** lift the effective context ceiling on
+`/api/embed` for models whose native context is smaller than the requested
+override. For `nomic-embed-text` (native 2048) the server rejects inputs above
+that with a `400 "the input length exceeds the context length"` regardless of
+`num_ctx`.
+
+Woods works around this two ways:
+
+1. **Advertise the native ceiling, not the override.** `Provider::Ollama` keeps
+   a model → native-context registry (`MODEL_CONTEXT_LENGTHS`) so the chunker
+   sizes inputs to what Ollama will actually accept. `num_ctx` is still passed
+   through the request body in case the regression is fixed upstream, but
+   nothing relies on it.
+2. **Verify client-side with the real tokenizer.** When the
+   [`tokenizers`](https://github.com/ankane/tokenizers-ruby) gem is installed,
+   `Embedding::TokenCounter` loads the `bert-base-uncased` WordPiece tokenizer
+   (the one every BERT-family embedding model is built on) and the chunker
+   re-verifies every slice. WordPiece fragments CamelCase and `::` separators
+   differently than character-based estimation suggests — this verification is
+   what catches the 10–20 % gap between our estimate and Ollama's internal
+   count.
+
+## Adding a new model to the registry
+
+If you want Woods to auto-pick `num_ctx` for a model we don't ship support for:
+
+1. Pull the model: `ollama pull your-model`.
+2. Read its native context:
+   ```bash
+   curl -s http://localhost:11434/api/show -d '{"model":"your-model"}' \
+     | jq '.model_info | to_entries[] | select(.key | contains("context_length"))'
+   ```
+3. Verify the server actually honours it (some models report a larger context
+   than the server enforces — see the nomic-embed-text case above). Send a
+   request with a known-large input and check for 400s:
+   ```bash
+   # Probe script in this repo: scripts/probes/ollama_context_probe.rb
+   ruby scripts/probes/ollama_context_probe.rb your-model 8192
+   ```
+4. Add it to `MODEL_CONTEXT_LENGTHS` in `lib/woods/embedding/provider.rb`
+   (keep the value at the **enforced** ceiling, not the advertised one).
+
+## When to stay on `nomic-embed-text`
+
+- Fresh installs, CI, evaluation environments — no extra pull step.
+- Small/toy codebases where the 2048-token ceiling isn't a real constraint.
+- Memory-constrained Ollama hosts (the 1.2 GB `bge-m3` weights vs 274 MB for
+  `nomic-embed-text` can matter on a shared laptop).
+
+## When to switch to `bge-m3` or `snowflake-arctic-embed2`
+
+- Indexing a real-world Rails app where concern-inlined models or long service
+  objects routinely exceed 2048 tokens.
+- You already pay the `tokenizers` gem install cost and want the tighter
+  coupling between client-side verification and server-side enforcement.
+- Multilingual content (Arctic Embed 2 is BGE M3 with a stronger non-English
+  story).
+
+## Related
+
+- [CONFIGURATION_REFERENCE.md](./CONFIGURATION_REFERENCE.md) — full config surface
+- [TOKEN_BENCHMARK.md](./TOKEN_BENCHMARK.md) — where our chars/token numbers come from
+- [BACKEND_MATRIX.md](./BACKEND_MATRIX.md) — picking a vector store that matches

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -337,18 +337,26 @@ All backends work with both MySQL and PostgreSQL application databases. pgvector
 Two embedding providers are supported:
 
 - **OpenAI** — `text-embedding-3-small` (1536 dimensions, default) or `text-embedding-3-large`. Requires an `OPENAI_API_KEY`. Billed per token.
-- **Ollama** — Any locally installed model (e.g., `nomic-embed-text`, `mxbai-embed-large`). Runs locally, no API key or cost. Requires Ollama to be running at `localhost:11434`.
+- **Ollama** — Any locally installed model (e.g., `nomic-embed-text`, `bge-m3`, `mxbai-embed-large`). Runs locally, no API key or cost. Requires Ollama to be running at `localhost:11434`.
 
 ```ruby
 # OpenAI
 config.embedding_provider = :openai
-config.embedding_model = 'text-embedding-3-small'
-config.embedding_options = { api_key: ENV['OPENAI_API_KEY'] }
+config.embedding_options = {
+  api_key: ENV['OPENAI_API_KEY'],
+  model: 'text-embedding-3-small'
+}
 
-# Ollama
+# Ollama — default (2048-token context)
 config.embedding_provider = :ollama
-config.embedding_model = 'nomic-embed-text'
+config.embedding_options = { model: 'nomic-embed-text' }
+
+# Ollama — bge-m3 (8192-token context, fewer chunks per unit)
+config.embedding_provider = :ollama
+config.embedding_options = { model: 'bge-m3' }
 ```
+
+See [EMBEDDING_MODELS.md](EMBEDDING_MODELS.md) for the Ollama model comparison and the procedure for adding a new model.
 
 ---
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -281,7 +281,10 @@ Woods.configure do |config|
     config.embedding_options = { api_key: ENV['OPENAI_API_KEY'] }
   else
     config.embedding_provider = :ollama
-    config.embedding_options = { base_url: ENV.fetch('OLLAMA_URL', 'http://localhost:11434') }
+    config.embedding_options = {
+      model: 'nomic-embed-text',
+      host: ENV.fetch('OLLAMA_URL', 'http://localhost:11434')
+    }
   end
 end
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ What's next: see [COVERAGE_GAP_ANALYSIS.md](COVERAGE_GAP_ANALYSIS.md) for remain
 | [AGENT_GUIDE.md](AGENT_GUIDE.md) | Deep reference for AI agents — workflows, full tool table, relationship type catalog, gotchas |
 | [MCP_TOOL_COOKBOOK.md](MCP_TOOL_COOKBOOK.md) | Scenario-based MCP tool examples — question → tool → parameters → expected output |
 | [RETRIEVAL_GUIDE.md](RETRIEVAL_GUIDE.md) | Query classification, search strategies, RRF ranking, token budget tuning, and troubleshooting |
+| [EMBEDDING_MODELS.md](EMBEDDING_MODELS.md) | Picking an Ollama embedding model — context windows, dimensions, tradeoffs, and how the context-length registry works |
 
 ## Reference
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -331,8 +331,40 @@ For 429 — embedding generation is automatically retried with backoff. If rate 
 3. If using a non-default port, update config:
 
 ```ruby
-config.embedding_options = { base_url: 'http://localhost:11434' }
+config.embedding_options = { host: 'http://localhost:11434' }
 ```
+
+---
+
+### Ollama `400 "the input length exceeds the context length"`
+
+**Symptom:** `rake woods:embed` fails with `Ollama API error: 400 {"error":"the input length exceeds the context length"}`. Individual chunks may look smaller than the configured `num_ctx`.
+
+**Cause:** Ollama's `/api/embed` endpoint enforces the model's **native** `context_length`, not the `options.num_ctx` override (see [ollama/ollama#14186](https://github.com/ollama/ollama/issues/14186)). For `nomic-embed-text` that's 2048 tokens, regardless of what `num_ctx` is set to. Separately, without the `tokenizers` gem, Woods estimates token counts from character length, which under-counts dense Ruby source — so chunks that look safe by char count still trip the 2048-token ceiling.
+
+**Fix:** Upgrade to Woods 1.3+ and install the `tokenizers` gem:
+
+```ruby
+# Gemfile
+gem 'woods', '~> 1.3'
+gem 'tokenizers', '~> 0.5'   # exact BERT WordPiece token counting
+```
+
+Woods now:
+
+1. Advertises the native context ceiling per model (2048 for `nomic-embed-text`, 8192 for `bge-m3`/`snowflake-arctic-embed2`, etc.) so the chunker sizes inputs correctly.
+2. Uses the real BERT tokenizer to verify every chunk, catching the 10–20% gap between char-based estimates and Ollama's internal count.
+
+If you want fewer chunks per unit and have the disk space, switch to a larger-context model:
+
+```ruby
+config.embedding_options = {
+  model: 'bge-m3',       # 8192 native context, 1024 dims
+  host: 'http://localhost:11434'
+}
+```
+
+Pull the model first (`ollama pull bge-m3`) and **drop the vector index before re-embedding** — the dimension change (768 → 1024) is incompatible with existing vectors. See [EMBEDDING_MODELS.md](EMBEDDING_MODELS.md) for the full tradeoff matrix.
 
 ---
 

--- a/lib/generators/woods/templates/woods.rb.tt
+++ b/lib/generators/woods/templates/woods.rb.tt
@@ -53,11 +53,14 @@ Woods.configure do |config|
   # config.embedding_model    = 'text-embedding-3-small'
   # config.embedding_options  = { api_key: ENV['OPENAI_API_KEY'] }
 
-  # Ollama (local, no API key needed):
+  # Ollama (local, no API key needed). `num_ctx` is auto-selected per model
+  # (nomic-embed-text → 2048, bge-m3 → 8192). Install `gem "tokenizers"` for
+  # exact BERT WordPiece token counting on dense Ruby source. See
+  # docs/EMBEDDING_MODELS.md for the full model comparison.
   # config.embedding_provider = :ollama
-  # config.embedding_model    = 'nomic-embed-text'
   # config.embedding_options  = {
-  #   base_url: ENV.fetch('OLLAMA_URL', 'http://localhost:11434')
+  #   model: 'nomic-embed-text',
+  #   host: ENV.fetch('OLLAMA_URL', 'http://localhost:11434')
   # }
 
   # ── Storage ─────────────────────────────────────────────────────────────

--- a/lib/woods/builder.rb
+++ b/lib/woods/builder.rb
@@ -8,6 +8,9 @@ require_relative 'storage/metadata_store'
 require_relative 'storage/graph_store'
 require_relative 'embedding/provider'
 require_relative 'embedding/openai'
+require_relative 'embedding/text_preparer'
+require_relative 'embedding/token_counter'
+require_relative 'chunking/semantic_chunker'
 
 module Woods
   # Builder reads a {Configuration} and instantiates the appropriate adapters,
@@ -120,7 +123,104 @@ module Woods
       end
     end
 
+    # Build a {Embedding::TextPreparer} calibrated to a given provider.
+    #
+    # OpenAI embedders use tiktoken (cl100k_base) — 4.0 chars/token is a
+    # good conservative average. Ollama BERT/WordPiece tokenizers
+    # (nomic-embed-text, bge-*) run much hotter on dense Ruby/Rails
+    # source — long CamelCase constants, docstrings, callback DSLs, and
+    # heavy symbol use all sit below 2.0 chars/token in practice.
+    # Empirically, a 16 KB chunk of `ActionMailer::Base` still blows the
+    # 8192-token budget at 2.0 chars/token, so we budget at 1.5 to stay
+    # clear of tokenizer surprises even on the densest Rails internals.
+    #
+    # `max_tokens` tracks the provider's actual input budget when it
+    # reports one, falling back to the TextPreparer default otherwise.
+    #
+    # @param provider [Embedding::Provider::Interface]
+    # @return [Embedding::TextPreparer]
+    def build_text_preparer(provider)
+      chars_per_token = chars_per_token_for(provider)
+      budget = provider.respond_to?(:max_input_tokens) ? provider.max_input_tokens : nil
+      max_tokens = budget || Embedding::TextPreparer::DEFAULT_MAX_TOKENS
+
+      Embedding::TextPreparer.new(max_tokens: max_tokens, chars_per_token: chars_per_token)
+    end
+
+    # Build a {Chunking::SemanticChunker} sized to a given provider.
+    #
+    # `max_chars` is derived from the provider's input budget and the
+    # matching chars-per-token ratio, minus the context-prefix
+    # allowance the Indexer accounts for separately. Units that exceed
+    # this ceiling get sliced so no single chunk can blow the provider's
+    # input cap.
+    #
+    # For Ollama (and other BERT/WordPiece-backed models), char-based
+    # estimation is unreliable — CamelCase, `::` separators, and symbol
+    # literals tokenize much denser than chars/token averages suggest.
+    # When the optional `tokenizers` gem is installed, pass a
+    # {Embedding::TokenCounter} and `max_tokens` so the chunker can
+    # verify every slice with the real tokenizer and re-split any piece
+    # that still exceeds `num_ctx`. See docs/EMBEDDING_CHUNK_SIZING.md.
+    #
+    # Ollama v0.13.5+ stopped honouring `truncate: true` on `/api/embed`
+    # (ollama/ollama#14186), so any chunk that exceeds `num_ctx` returns
+    # a 400 rather than being silently truncated. Exact client-side
+    # sizing is the only reliable path until the regression is fixed
+    # upstream.
+    #
+    # @param provider [Embedding::Provider::Interface]
+    # @return [Chunking::SemanticChunker]
+    def build_chunker(provider)
+      budget = provider.respond_to?(:max_input_tokens) ? provider.max_input_tokens : nil
+      max_chars = ((budget * chars_per_token_for(provider)).floor - CHUNKER_PREFIX_ALLOWANCE if budget)
+
+      token_counter = token_counter_for(provider)
+      max_tokens = token_counter && budget ? budget - PREFIX_TOKEN_ALLOWANCE : nil
+
+      Chunking::SemanticChunker.new(
+        max_chars: max_chars,
+        token_counter: token_counter,
+        max_tokens: max_tokens
+      )
+    end
+
+    # Character allowance reserved for the TextPreparer context prefix
+    # ([type] id / namespace / file / deps) — kept in sync with the
+    # Indexer's own PREFIX_CHAR_ALLOWANCE constant.
+    CHUNKER_PREFIX_ALLOWANCE = 512
+    private_constant :CHUNKER_PREFIX_ALLOWANCE
+
+    # Token-side sibling of {CHUNKER_PREFIX_ALLOWANCE}. Reserved for the
+    # TextPreparer prefix when tokenizer-driven sizing is active — a bit
+    # generous to cover long file paths and dep lists.
+    PREFIX_TOKEN_ALLOWANCE = 256
+    private_constant :PREFIX_TOKEN_ALLOWANCE
+
     private
+
+    # Return a TokenCounter for providers that benefit from exact token
+    # counting. OpenAI's tiktoken ratios are already stable at 4.0
+    # chars/token on code, so it doesn't need this.
+    #
+    # @param provider [Embedding::Provider::Interface]
+    # @return [Embedding::TokenCounter, nil]
+    def token_counter_for(provider)
+      return unless provider.is_a?(Embedding::Provider::Ollama)
+
+      Embedding::TokenCounter.new
+    end
+
+    # Tokenizer-calibrated chars/token ratio for the given provider.
+    #
+    # @param provider [Embedding::Provider::Interface]
+    # @return [Float]
+    def chars_per_token_for(provider)
+      case provider
+      when Embedding::Provider::Ollama then 1.5
+      else Embedding::TextPreparer::DEFAULT_CHARS_PER_TOKEN
+      end
+    end
 
     # Instantiate the metadata store adapter specified by the configuration.
     #

--- a/lib/woods/chunking/semantic_chunker.rb
+++ b/lib/woods/chunking/semantic_chunker.rb
@@ -29,27 +29,75 @@ module Woods
       end
     end
 
+    # Class-like unit types that MethodChunker handles — anything
+    # shaped as "class or module with public methods, maybe privates,
+    # maybe callbacks/filters." Extend this list when new extractors
+    # produce units of similar structure.
+    METHOD_CHUNKABLE_TYPES = %i[
+      service job mailer concern policy pundit_policy serializer
+      decorator presenter interactor query_object value_object
+      component view_component action_cable_channel channel
+      graphql_resolver graphql_type helper validator api_client poro
+      manager configuration
+    ].freeze
+
     # Splits ExtractedUnits into semantic chunks based on unit type.
     #
     # Models are split by: summary, associations, validations, callbacks,
     # scopes, methods. Controllers are split by: summary (filters), per-action.
-    # Other types use whole-unit or method-level splitting based on size.
+    # Class-like types (services, jobs, mailers, concerns, policies, …) split
+    # by summary + per-public-method + bundled privates via MethodChunker.
+    # Other types stay whole.
+    #
+    # Any chunk that still exceeds `max_chars` after semantic splitting is
+    # sliced into line-balanced sub-chunks so no single chunk is ever larger
+    # than the embedding provider's input budget.
     #
     # Units below the token threshold are returned as a single :whole chunk.
     #
     # @example
-    #   chunker = SemanticChunker.new(threshold: 200)
+    #   chunker = SemanticChunker.new(threshold: 200, max_chars: 20_480)
     #   chunks = chunker.chunk(extracted_unit)
     #   chunks.map(&:chunk_type) # => [:summary, :associations, :validations, :methods]
     #
-    class SemanticChunker
+    class SemanticChunker # rubocop:disable Metrics/ClassLength
       # Default token threshold below which units stay whole.
       DEFAULT_THRESHOLD = 200
 
+      # Minimum chars-per-slice budget during tokenizer-driven recursive
+      # splitting. Prevents unbounded halving on pathological content
+      # (e.g., a single 2000-char regex line that tokenizes into 6000
+      # tokens because BERT WordPiece fragments every `\w+` boundary).
+      MIN_SLICE_CHARS = 256
+      private_constant :MIN_SLICE_CHARS
+
       # @param threshold [Integer] Token count threshold for chunking
-      def initialize(threshold: DEFAULT_THRESHOLD)
+      # @param max_chars [Integer, nil] Hard character ceiling for any single
+      #   chunk. When set, any chunk larger than this is sliced into
+      #   line-balanced sub-chunks. `nil` disables the safety net.
+      # @param token_counter [Woods::Embedding::TokenCounter, nil] Optional
+      #   exact-token counter. When both this and `max_tokens` are set,
+      #   oversize detection uses the real tokenizer rather than the
+      #   char-length estimate, and post-slice verification recursively
+      #   re-splits any piece that still exceeds `max_tokens`.
+      # @param max_tokens [Integer, nil] Token budget used with
+      #   `token_counter` for the authoritative oversize check.
+      def initialize(threshold: DEFAULT_THRESHOLD, max_chars: nil,
+                     token_counter: nil, max_tokens: nil)
         @threshold = threshold
+        @max_chars = max_chars
+        @token_counter = token_counter
+        @max_tokens = max_tokens
       end
+
+      # @return [Woods::Embedding::TokenCounter, nil]
+      attr_reader :token_counter
+
+      # @return [Integer, nil]
+      attr_reader :max_tokens
+
+      # @return [Integer, nil]
+      attr_reader :max_chars
 
       # Split an ExtractedUnit into semantic chunks.
       #
@@ -59,14 +107,75 @@ module Woods
         return [] if unit.source_code.nil? || unit.source_code.strip.empty?
         return [build_whole_chunk(unit)] if unit.estimated_tokens <= @threshold
 
-        case unit.type
-        when :model then ModelChunker.new(unit).chunk
-        when :controller then ControllerChunker.new(unit).chunk
-        else [build_whole_chunk(unit)]
-        end
+        enforce_char_limit(chunks_for(unit), unit)
+      end
+
+      # Enforce {@max_chars} on a unit's already-populated `chunks` array
+      # (hashes produced by extraction or a prior chunking pass). Oversize
+      # chunks are split into line-balanced siblings with `_part_N` chunk
+      # types; small chunks pass through unchanged. No-op when `@max_chars`
+      # is unset or `unit.chunks` is empty.
+      #
+      # Exists so the Indexer can apply the same ceiling to pre-chunked
+      # units (e.g. `rails_source`) that extraction already sliced — the
+      # extractor's own chunker is unaware of the embedding provider's
+      # budget and can emit chunks larger than the ceiling we'd pick here.
+      #
+      # @param unit [ExtractedUnit]
+      # @return [void]
+      def enforce_chunk_limits!(unit)
+        return unless enforcement_active?
+        return if unit.chunks.nil? || unit.chunks.empty?
+
+        unit.chunks = unit.chunks.flat_map { |chunk| split_oversize_hash_chunk(chunk) }
       end
 
       private
+
+      # True when either the char ceiling or the token-based verifier is
+      # wired up.
+      def enforcement_active?
+        @max_chars || (@token_counter && @max_tokens)
+      end
+
+      # Token-authoritative oversize check, falling back to char length.
+      def oversize?(content)
+        return false if content.nil? || content.empty?
+        return @token_counter.count(content) > @max_tokens if tokenizer_active?
+
+        @max_chars && content.length > @max_chars
+      end
+
+      def tokenizer_active?
+        @token_counter && @max_tokens
+      end
+
+      # @param chunk [Hash] a unit-chunk hash (symbol or string keys)
+      # @return [Array<Hash>]
+      def split_oversize_hash_chunk(chunk)
+        content = chunk[:content] || chunk['content']
+        return [chunk] if content.nil? || !oversize?(content)
+
+        chunk_type = chunk[:chunk_type] || chunk['chunk_type'] || :whole
+        verified_slices(content).each_with_index.map do |slice, idx|
+          { content: slice, chunk_type: :"#{chunk_type}_part_#{idx}" }
+        end
+      end
+
+      # Dispatch to the type-appropriate chunker.
+      #
+      # @param unit [ExtractedUnit]
+      # @return [Array<Chunk>]
+      def chunks_for(unit)
+        case unit.type
+        when :model then ModelChunker.new(unit).chunk
+        when :controller then ControllerChunker.new(unit).chunk
+        else
+          return MethodChunker.new(unit).chunk if METHOD_CHUNKABLE_TYPES.include?(unit.type)
+
+          [build_whole_chunk(unit)]
+        end
+      end
 
       # Build a single :whole chunk for small units.
       #
@@ -79,6 +188,102 @@ module Woods
           parent_identifier: unit.identifier,
           parent_type: unit.type
         )
+      end
+
+      # Slice any chunk whose content exceeds `@max_chars` into
+      # line-balanced sub-chunks. Preserves chunk_type with a `_part_N`
+      # suffix so downstream consumers can see they came from the same
+      # section.
+      #
+      # @param chunks [Array<Chunk>]
+      # @param unit [ExtractedUnit]
+      # @return [Array<Chunk>]
+      def enforce_char_limit(chunks, unit)
+        return chunks unless @max_chars
+
+        chunks.flat_map { |chunk| split_oversize_chunk(chunk, unit) }
+      end
+
+      # @param chunk [Chunk]
+      # @param unit [ExtractedUnit]
+      # @return [Array<Chunk>]
+      def split_oversize_chunk(chunk, unit)
+        return [chunk] unless oversize?(chunk.content)
+
+        verified_slices(chunk.content).each_with_index.map do |slice, idx|
+          Chunk.new(
+            content: slice,
+            chunk_type: :"#{chunk.chunk_type}_part_#{idx}",
+            parent_identifier: unit.identifier,
+            parent_type: unit.type
+          )
+        end
+      end
+
+      # Slice by lines, then (when a tokenizer is wired in) recursively
+      # re-split any slice whose real token count still exceeds the
+      # budget. Char-based slicing alone is unreliable on dense Rails
+      # source because BERT WordPiece tokenizes `::`-heavy constants at
+      # far below our estimate; the verifier catches those cases.
+      #
+      # @param content [String]
+      # @return [Array<String>]
+      def verified_slices(content)
+        limit = @max_chars || estimated_char_budget
+        slices = slice_by_lines(content, limit)
+        return slices unless tokenizer_active?
+
+        slices.flat_map { |slice| verify_slice(slice, limit) }
+      end
+
+      # Ensure a single post-line-split slice fits the token budget.
+      # Halves the char limit and reslices if it doesn't. Stops at
+      # {MIN_SLICE_CHARS} to avoid unbounded recursion on content that
+      # cannot be split line-wise (minified output, huge regex literals).
+      #
+      # @param slice [String]
+      # @param char_limit [Integer]
+      # @return [Array<String>]
+      def verify_slice(slice, char_limit)
+        return [slice] unless @token_counter.count(slice) > @max_tokens
+
+        smaller = char_limit / 2
+        return [slice] if smaller < MIN_SLICE_CHARS
+
+        slice_by_lines(slice, smaller).flat_map { |sub| verify_slice(sub, smaller) }
+      end
+
+      # Conservative char budget used when no explicit `max_chars` was
+      # given but the tokenizer is active. Uses a permissive estimate
+      # because the verifier will halve this further as needed.
+      def estimated_char_budget
+        return 0 unless @max_tokens
+
+        @max_tokens * 2
+      end
+
+      # Greedy line-based slicing that respects a supplied `limit`.
+      # Lines longer than `limit` are hard-cut (lossy — but such lines
+      # are already pathological: minified JSON dumps, long regexes).
+      #
+      # @param content [String]
+      # @param limit [Integer]
+      # @return [Array<String>]
+      def slice_by_lines(content, limit = @max_chars)
+        slices = []
+        current = String.new
+        content.each_line do |line|
+          line_parts = line.length > limit ? line.scan(/.{1,#{limit}}/m) : [line]
+          line_parts.each do |part|
+            if current.length + part.length > limit && !current.empty?
+              slices << current
+              current = String.new
+            end
+            current << part
+          end
+        end
+        slices << current unless current.empty?
+        slices
       end
     end
 
@@ -288,6 +493,123 @@ module Woods
           chunks << build_chunk(:"action_#{action_name}", action_lines.join)
         end
 
+        chunks
+      end
+    end
+
+    # Generic method-aware chunker for class-like unit types.
+    #
+    # Splits into:
+    # - `:summary` — class/module declaration, includes, constants,
+    #   attr_* DSL, class-level method calls, and any class-level code
+    #   before the first public method.
+    # - `:method_<name>` — one chunk per public instance method.
+    # - `:private_methods` — all private/protected methods bundled
+    #   together (they're usually implementation helpers and rarely
+    #   queried individually).
+    #
+    # Used for services, jobs, mailers, concerns, policies, serializers,
+    # decorators, presenters, interactors, form objects, components,
+    # GraphQL resolvers, helpers, validators, and other class-like units.
+    #
+    # @api private
+    class MethodChunker
+      include ChunkBuilder
+
+      # @param unit [ExtractedUnit]
+      def initialize(unit)
+        @unit = unit
+      end
+
+      # @return [Array<Chunk>]
+      def chunk
+        state = parse_lines(@unit.source_code.lines)
+        build_chunks(state).reject(&:empty?)
+      end
+
+      private
+
+      # Parse lines into summary + per-public-method + private buffers.
+      #
+      # @param lines [Array<String>]
+      # @return [Hash]
+      def parse_lines(lines)
+        state = {
+          summary: [], methods: {}, private_methods: [],
+          current_method: nil, depth: 0, in_private: false
+        }
+        lines.each do |line|
+          if state[:current_method]
+            track_method_line(state, line)
+          else
+            classify_top_level_line(state, line)
+          end
+        end
+
+        state
+      end
+
+      # While inside a method body, collect every line and track depth so
+      # we know when the method closes. Blocks (`do...end`, `if...end`)
+      # nest inside methods and must be balanced before the method's own
+      # `end` line counts.
+      def track_method_line(state, line)
+        target = state[:in_private] ? state[:private_methods] : state[:methods][state[:current_method]]
+        target << line
+
+        state[:depth] += 1 if line.match?(/\bdo\b/) && !line.match?(/\bend\b/)
+        return unless line.strip.match?(/^end\s*$/)
+
+        state[:depth] -= 1
+        return unless state[:depth] <= 0
+
+        state[:current_method] = nil
+        state[:depth] = 0
+      end
+
+      # Classify a class-body line: privacy marker, method start, or
+      # summary content (DSL calls, attrs, comments, includes).
+      def classify_top_level_line(state, line)
+        if line.match?(PRIVATE_PATTERN)
+          state[:in_private] = true
+          state[:private_methods] << line
+        elsif line.match?(METHOD_PATTERN)
+          start_method(state, line)
+        elsif state[:in_private]
+          state[:private_methods] << line
+        else
+          state[:summary] << line
+        end
+      end
+
+      def start_method(state, line)
+        method_name = line[/def\s+(?:self\.)?(\w+)/, 1]
+        state[:current_method] = method_name
+        state[:depth] = 1
+
+        if state[:in_private]
+          state[:private_methods] << line
+        else
+          # Preserve insertion order — Hash does this by default, but we
+          # initialize the entry here so `build_chunks` below walks
+          # methods in source order.
+          state[:methods][method_name] = [line]
+        end
+      end
+
+      # Build the final chunk array from the parse state.
+      #
+      # @param state [Hash]
+      # @return [Array<Chunk>]
+      def build_chunks(state)
+        chunks = []
+        chunks << build_chunk(:summary, state[:summary].join) if state[:summary].any?
+
+        state[:methods].each do |method_name, lines|
+          chunks << build_chunk(:"method_#{method_name}", lines.join)
+        end
+
+        chunks << build_chunk(:private_methods, state[:private_methods].join) if state[:private_methods].any?
         chunks
       end
     end

--- a/lib/woods/embedding/indexer.rb
+++ b/lib/woods/embedding/indexer.rb
@@ -4,19 +4,26 @@ require 'json'
 require 'digest'
 
 require_relative '../extracted_unit'
+require_relative '../chunking/semantic_chunker'
 
 module Woods
   module Embedding
     # Orchestrates the indexing pipeline: reads extracted units, prepares text,
     # generates embeddings, and stores vectors. Supports full and incremental
     # modes with checkpoint-based resumability.
-    class Indexer
+    class Indexer # rubocop:disable Metrics/ClassLength
+      # @param chunker [Chunking::SemanticChunker, nil] Splits oversize units
+      #   into semantically coherent chunks before embedding. `nil` disables
+      #   chunking — units go to the provider whole (useful in tests).
       # @param checkpoint_interval [Integer] Save checkpoint every N batches (default: 10)
-      def initialize(provider:, text_preparer:, vector_store:, output_dir:, batch_size: 32, checkpoint_interval: 10) # rubocop:disable Metrics/ParameterLists
+      def initialize(provider:, text_preparer:, vector_store:, output_dir:, # rubocop:disable Metrics/ParameterLists
+                     chunker: Chunking::SemanticChunker.new,
+                     batch_size: 32, checkpoint_interval: 10)
         @provider = provider
         @text_preparer = text_preparer
         @vector_store = vector_store
         @output_dir = output_dir
+        @chunker = chunker
         @batch_size = batch_size
         @checkpoint_interval = checkpoint_interval
       end
@@ -91,7 +98,54 @@ module Woods
 
       def prepare_texts(unit_data)
         unit = build_unit(unit_data)
-        unit.chunks&.any? ? @text_preparer.prepare_chunks(unit) : [@text_preparer.prepare(unit)]
+        apply_chunking(unit) if @chunker && unit.chunks.empty? && needs_chunking?(unit)
+        # Extraction may have emitted chunks larger than the provider's
+        # budget (rails_source in particular). Enforce the ceiling on
+        # whatever chunks we have before handing off to the provider.
+        @chunker&.enforce_chunk_limits!(unit) if unit.chunks.any?
+        unit.chunks.any? ? @text_preparer.prepare_chunks(unit) : [@text_preparer.prepare(unit)]
+      end
+
+      # Does this unit exceed the embedding provider's single-input
+      # budget? Returns false when the provider reports no budget, when
+      # the TextPreparer has no calibrated chars-per-token ratio, or when
+      # the unit's source fits.
+      #
+      # When the configured chunker carries a real tokenizer
+      # (Embedding::TokenCounter) we also consult it — dense Ruby source
+      # tokenizes hotter than chars/token averages suggest, and Ollama
+      # rejects over-budget input outright (see ollama/ollama#14186).
+      def needs_chunking?(unit)
+        budget_tokens = @provider.respond_to?(:max_input_tokens) ? @provider.max_input_tokens : nil
+        return false if budget_tokens.nil?
+        return false unless @text_preparer.respond_to?(:chars_per_token)
+
+        source = unit.source_code || ''
+        return true if chunker_token_oversize?(source)
+
+        # Subtract a small prefix allowance — the TextPreparer adds a few
+        # hundred characters of context header ([type] identifier / file /
+        # dependencies) that count toward the budget too.
+        char_budget = (budget_tokens * @text_preparer.chars_per_token).floor - PREFIX_CHAR_ALLOWANCE
+        char_budget.positive? && source.length > char_budget
+      end
+
+      # Ask the chunker's real tokenizer whether `source` already exceeds
+      # the token budget. Returns false when the chunker wasn't built with
+      # one (e.g., OpenAI path), leaving the char-based check in charge.
+      def chunker_token_oversize?(source)
+        return false unless @chunker&.token_counter && @chunker.max_tokens
+
+        @chunker.token_counter.count(source) > @chunker.max_tokens
+      end
+
+      # Populate unit.chunks from the configured chunker. The chunker's
+      # own `max_chars` safety net is what guarantees each chunk fits,
+      # so we pass the same char budget through here.
+      def apply_chunking(unit)
+        unit.chunks = @chunker.chunk(unit).map do |chunk|
+          { content: chunk.content, chunk_type: chunk.chunk_type }
+        end
       end
 
       def build_unit(data)
@@ -103,6 +157,12 @@ module Woods
         unit.chunks = (data['chunks'] || []).map { |c| c.transform_keys(&:to_sym) }
         unit
       end
+
+      # Character budget reserved for the TextPreparer context prefix
+      # ("[type] id / namespace / file / dependencies: …"). Typical
+      # prefixes run ~200–400 chars; 512 gives room to spare.
+      PREFIX_CHAR_ALLOWANCE = 512
+      private_constant :PREFIX_CHAR_ALLOWANCE
 
       def embed_and_store(items, checkpoint, stats)
         return if items.empty?

--- a/lib/woods/embedding/openai.rb
+++ b/lib/woods/embedding/openai.rb
@@ -24,6 +24,11 @@ module Woods
           'text-embedding-3-small' => 1536,
           'text-embedding-3-large' => 3072
         }.freeze
+        # OpenAI embedding models currently share an 8191-token input cap
+        # across text-embedding-3-small / -3-large / ada-002. We round down
+        # to 8192 to match the industry-standard budget — the tiktoken
+        # heuristic lives in TextPreparer.
+        MAX_INPUT_TOKENS = 8192
 
         # @param api_key [String] OpenAI API key
         # @param model [String] OpenAI embedding model name (default: text-embedding-3-small)
@@ -71,6 +76,14 @@ module Woods
         # @return [String] the OpenAI model name
         def model_name
           @model
+        end
+
+        # Maximum input length OpenAI will accept for a single embedding
+        # text. All current text-embedding-* models cap at ~8k tokens.
+        #
+        # @return [Integer]
+        def max_input_tokens
+          MAX_INPUT_TOKENS
         end
 
         private

--- a/lib/woods/embedding/provider.rb
+++ b/lib/woods/embedding/provider.rb
@@ -49,6 +49,16 @@ module Woods
         def model_name
           raise NotImplementedError
         end
+
+        # Return the maximum input length the provider will accept for a
+        # single text, in tokens. Used by the indexer to decide when a unit
+        # must be chunked before embedding.
+        #
+        # @return [Integer, nil] token budget, or nil if the provider has no hard cap
+        # @raise [NotImplementedError] if not implemented by the provider
+        def max_input_tokens
+          raise NotImplementedError
+        end
       end
 
       # Ollama adapter for local embeddings via the Ollama HTTP API.
@@ -65,22 +75,42 @@ module Woods
 
         DEFAULT_MODEL = 'nomic-embed-text'
         DEFAULT_HOST = 'http://localhost:11434'
-        # Ollama caps embedding inputs at `num_ctx` tokens (default 2048),
-        # which truncates most real-world Rails units. nomic-embed-text
-        # supports up to 8192, matching the TextPreparer max_tokens default,
-        # so we lift the cap here to line the two up.
-        DEFAULT_NUM_CTX = 8192
 
-        # @param model [String] Ollama model name (default: nomic-embed-text)
+        # Ollama enforces the model's native context length on `/api/embed`
+        # regardless of the `num_ctx` override — we've validated this
+        # against 0.15.x for nomic-embed-text (rejects >2048) and bge-m3
+        # (accepts up to 8192, silently truncates above). Advertise the
+        # native ceiling so the chunker can size inputs correctly. Models
+        # outside this registry fall back to Ollama's conservative 2048
+        # default.
+        #
+        # See `docs/EMBEDDING_MODELS.md` for the tradeoff matrix and
+        # instructions for adding a new model here.
+        MODEL_CONTEXT_LENGTHS = {
+          'nomic-embed-text' => 2048,
+          'bge-m3' => 8192,
+          'mxbai-embed-large' => 512,
+          'snowflake-arctic-embed' => 512,
+          'snowflake-arctic-embed2' => 8192,
+          'all-minilm' => 256
+        }.freeze
+
+        # Fallback when the configured model isn't in the registry.
+        FALLBACK_NUM_CTX = 2048
+
+        # @param model [String] Ollama model name (default: nomic-embed-text).
+        #   Set to `"bge-m3"` or `"snowflake-arctic-embed2"` for an 8192-token
+        #   context and skip most chunking for dense Rails units.
         # @param host [String] Ollama server URL (default: http://localhost:11434)
-        # @param num_ctx [Integer, nil] Ollama context window in tokens. `nil`
-        #   uses Ollama's default (2048 for most embedding models — usually
-        #   too small). Defaults to 8192, which matches nomic-embed-text's
-        #   max and the TextPreparer default.
-        def initialize(model: DEFAULT_MODEL, host: DEFAULT_HOST, num_ctx: DEFAULT_NUM_CTX)
+        # @param num_ctx [Integer, nil] Ollama context window in tokens. When
+        #   `nil` (the default), the provider picks the model's native
+        #   context from `MODEL_CONTEXT_LENGTHS`, falling back to 2048 for
+        #   unknown models. Set explicitly only if running a model with a
+        #   known-larger native context that isn't in the registry yet.
+        def initialize(model: DEFAULT_MODEL, host: DEFAULT_HOST, num_ctx: nil)
           @model = model
           @host = host
-          @num_ctx = num_ctx
+          @num_ctx = num_ctx || MODEL_CONTEXT_LENGTHS.fetch(model, FALLBACK_NUM_CTX)
           @uri = URI("#{host}/api/embed")
         end
 
@@ -118,6 +148,16 @@ module Woods
         # @return [String] the Ollama model name
         def model_name
           @model
+        end
+
+        # Maximum input length Ollama will accept — tracks the configured
+        # context window. `nil` when `num_ctx` is disabled, signalling that
+        # the model's own default applies and the caller should treat the
+        # budget as unknown.
+        #
+        # @return [Integer, nil]
+        def max_input_tokens
+          @num_ctx
         end
 
         private

--- a/lib/woods/embedding/text_preparer.rb
+++ b/lib/woods/embedding/text_preparer.rb
@@ -19,11 +19,25 @@ module Woods
     #   chunks = preparer.prepare_chunks(unit)
     class TextPreparer
       DEFAULT_MAX_TOKENS = 8192
+      # 4.0 matches tiktoken (cl100k_base) averages for Ruby source — see
+      # docs/TOKEN_BENCHMARK.md. It's the right ratio for OpenAI models.
+      # BERT/WordPiece tokenizers (nomic-embed-text, bge-*) run hotter on
+      # code, closer to 2.5 chars/token, so callers embedding with those
+      # models should override this to keep truncation honest.
+      DEFAULT_CHARS_PER_TOKEN = 4.0
 
       # @param max_tokens [Integer] maximum token budget for prepared text
-      def initialize(max_tokens: DEFAULT_MAX_TOKENS)
+      # @param chars_per_token [Float] tokenizer-calibrated char/token ratio
+      def initialize(max_tokens: DEFAULT_MAX_TOKENS, chars_per_token: DEFAULT_CHARS_PER_TOKEN)
         @max_tokens = max_tokens
+        @chars_per_token = chars_per_token
       end
+
+      # @return [Float] configured chars-per-token ratio
+      attr_reader :chars_per_token
+
+      # @return [Integer] configured token budget
+      attr_reader :max_tokens
 
       # Prepare text for embedding from an ExtractedUnit.
       #
@@ -98,13 +112,18 @@ module Woods
 
       # Truncate text to fit within the token budget.
       #
+      # Uses the configured `chars_per_token` ratio to estimate both the
+      # token count and the safe character cap. Truncation is a last
+      # resort — by the time text reaches here the chunker should have
+      # already split oversize units into pieces that fit.
+      #
       # @param text [String] the text to truncate
       # @return [String] text within token limits
       def enforce_token_limit(text)
-        estimated = (text.length / 4.0).ceil
+        estimated = (text.length / @chars_per_token).ceil
         return text if estimated <= @max_tokens
 
-        max_chars = (@max_tokens * 4.0).floor
+        max_chars = (@max_tokens * @chars_per_token).floor
         text[0...max_chars]
       end
     end

--- a/lib/woods/embedding/token_counter.rb
+++ b/lib/woods/embedding/token_counter.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module Woods
+  module Embedding
+    # Exact or estimated token counts for embedding inputs.
+    #
+    # When the optional `tokenizers` gem (ankane) is installed, loads the
+    # `bert-base-uncased` WordPiece tokenizer that nomic-embed-text is
+    # built on and returns exact token counts. Otherwise falls back to a
+    # conservative chars/token ratio and warns once.
+    #
+    # Exact counting is strictly preferred for the Ollama path — Ollama
+    # v0.13.5+ stopped honouring the `truncate: true` flag on
+    # `/api/embed` (see ollama/ollama#14186), so chunks that exceed
+    # `num_ctx` return a 400 instead of being truncated. Client-side
+    # sizing is the only reliable option until the regression is fixed
+    # upstream, and chars/token ratios vary too widely across Rails
+    # internals to cover every case with a fixed number.
+    #
+    # @example
+    #   counter = Woods::Embedding::TokenCounter.new
+    #   counter.count("ActionController::Metal::ConditionalGet")  # => 13
+    class TokenCounter
+      # HuggingFace tokenizer id shared by every nomic-embed-text variant.
+      BERT_MODEL = 'bert-base-uncased'
+
+      # Conservative floor for when the tokenizer gem isn't installed.
+      # Lower than any ratio we've observed failing in the testbed
+      # against dense Rails source. Still approximate — install
+      # `tokenizers` for exact counts.
+      CONSERVATIVE_CHARS_PER_TOKEN = 1.2
+
+      # @param chars_per_token [Float] fallback ratio when the tokenizer
+      #   is unavailable
+      # @param tokenizer_id [String] HuggingFace model id passed to
+      #   `Tokenizers.from_pretrained`
+      def initialize(chars_per_token: CONSERVATIVE_CHARS_PER_TOKEN, tokenizer_id: BERT_MODEL)
+        @chars_per_token = chars_per_token
+        @tokenizer_id = tokenizer_id
+        @load_attempted = false
+        @load_mutex = Mutex.new
+      end
+
+      # @return [Float] fallback chars-per-token ratio
+      attr_reader :chars_per_token
+
+      # Exact token count when the tokenizer is loaded, chars/token
+      # estimate otherwise.
+      #
+      # @param text [String, nil]
+      # @return [Integer]
+      def count(text)
+        return 0 if text.nil? || text.empty?
+
+        tok = tokenizer
+        tok ? tok.encode(text).ids.length : estimate(text)
+      end
+
+      # True when the real tokenizer is loaded and in use.
+      #
+      # @return [Boolean]
+      def exact?
+        !tokenizer.nil?
+      end
+
+      private
+
+      def estimate(text)
+        (text.length / @chars_per_token).ceil
+      end
+
+      # Lazy-load the tokenizer under a mutex so concurrent first-calls
+      # don't each trigger a separate download. After the first attempt
+      # (successful or not) we memoize the result and skip the load path.
+      def tokenizer
+        @load_mutex.synchronize do
+          return @tokenizer if @load_attempted
+
+          @load_attempted = true
+          @tokenizer = try_load
+        end
+      end
+
+      def try_load
+        require 'tokenizers'
+        Tokenizers.from_pretrained(@tokenizer_id)
+      rescue LoadError
+        warn_once(
+          'Exact token counting disabled: `tokenizers` gem not installed. ' \
+          "Falling back to #{@chars_per_token} chars/token estimation. " \
+          "Add `gem 'tokenizers', '~> 0.5'` to your Gemfile for exact sizing on Ollama."
+        )
+        nil
+      rescue StandardError => e
+        warn_once(
+          "Could not load tokenizer #{@tokenizer_id.inspect} " \
+          "(#{e.class}: #{e.message}). Falling back to chars/token estimate."
+        )
+        nil
+      end
+
+      def warn_once(message)
+        Kernel.warn("[woods] #{message}")
+      end
+    end
+  end
+end

--- a/lib/woods/mcp/bootstrapper.rb
+++ b/lib/woods/mcp/bootstrapper.rb
@@ -94,7 +94,7 @@ module Woods
           config.graph_store = :in_memory
           config.embedding_provider = :ollama
           config.embedding_options = {
-            base_url: ENV.fetch('OLLAMA_BASE_URL', 'http://localhost:11434'),
+            host: ENV.fetch('OLLAMA_BASE_URL', 'http://localhost:11434'),
             model: ENV.fetch('OLLAMA_EMBED_MODEL', 'nomic-embed-text')
           }
         end

--- a/lib/woods/tasks.rb
+++ b/lib/woods/tasks.rb
@@ -19,15 +19,21 @@ module Woods
     # silently ignored configuration, which was invisible until the provider
     # tried to reach an unreachable default host.
     #
+    # The TextPreparer and SemanticChunker are tuned to the selected
+    # provider so oversize units are split into chunks that fit the
+    # provider's input budget (e.g. Ollama's num_ctx, OpenAI's 8k cap).
+    #
     # @return [Embedding::Indexer]
     def build_embed_indexer
       config = Woods.configuration
       builder = Builder.new(config)
+      provider = builder.build_embedding_provider
 
       Embedding::Indexer.new(
-        provider: builder.build_embedding_provider,
-        text_preparer: Embedding::TextPreparer.new,
+        provider: provider,
+        text_preparer: builder.build_text_preparer(provider),
         vector_store: builder.build_vector_store,
+        chunker: builder.build_chunker(provider),
         output_dir: ENV.fetch('WOODS_OUTPUT', config.output_dir)
       )
     end

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -365,4 +365,82 @@ RSpec.describe Woods::Builder do
       described_class.new(config).build_retriever
     end
   end
+
+  describe '#build_text_preparer' do
+    let(:config) { Woods::Configuration.new }
+    subject(:builder) { described_class.new(config) }
+
+    it 'uses 1.5 chars/token for Ollama providers (BERT/WordPiece on dense Rails source)' do
+      provider = Woods::Embedding::Provider::Ollama.new
+      preparer = builder.build_text_preparer(provider)
+      expect(preparer.chars_per_token).to eq(1.5)
+    end
+
+    it 'tracks the Ollama provider num_ctx as max_tokens' do
+      provider = Woods::Embedding::Provider::Ollama.new(num_ctx: 4096)
+      preparer = builder.build_text_preparer(provider)
+      expect(preparer.max_tokens).to eq(4096)
+    end
+
+    it 'uses 4.0 chars/token and the 8192 cap for OpenAI providers' do
+      provider = Woods::Embedding::Provider::OpenAI.new(api_key: 'sk-test')
+      preparer = builder.build_text_preparer(provider)
+      expect(preparer.chars_per_token).to eq(4.0)
+      expect(preparer.max_tokens).to eq(8192)
+    end
+
+    it 'falls back to the preparer default when the provider has no budget' do
+      provider = instance_double(Woods::Embedding::Provider::Ollama,
+                                 max_input_tokens: nil, model_name: 'custom')
+      preparer = builder.build_text_preparer(provider)
+      expect(preparer.max_tokens).to eq(Woods::Embedding::TextPreparer::DEFAULT_MAX_TOKENS)
+    end
+  end
+
+  describe '#build_chunker' do
+    let(:config) { Woods::Configuration.new }
+    subject(:builder) { described_class.new(config) }
+
+    it 'sizes max_chars from provider budget and tokenizer ratio' do
+      provider = Woods::Embedding::Provider::Ollama.new(num_ctx: 8192)
+      chunker = builder.build_chunker(provider)
+
+      # Stub a unit that exceeds the budget and confirm splitting happens.
+      unit = Woods::ExtractedUnit.new(
+        type: :service, identifier: 'Big', file_path: 's.rb'
+      )
+      body = (['    something_long_enough(a, b, c)'] * 2500).join("\n")
+      unit.source_code = "class Big\n  def call\n#{body}\n  end\nend"
+      unit.metadata = {}
+
+      chunks = chunker.chunk(unit)
+      # 8192 * 1.5 - 512 = 11776 chars
+      expect(chunks.map(&:content)).to all(satisfy { |c| c.length <= 11_776 })
+    end
+
+    it 'disables the safety net when the provider advertises no budget' do
+      provider = Woods::Embedding::Provider::Ollama.new(num_ctx: nil)
+      chunker = builder.build_chunker(provider)
+      # A tiny unit should still produce exactly one :whole chunk.
+      unit = Woods::ExtractedUnit.new(type: :service, identifier: 'Tiny', file_path: 't.rb')
+      unit.source_code = "class Tiny\nend"
+      unit.metadata = {}
+      expect(chunker.chunk(unit).size).to eq(1)
+    end
+
+    it 'wires a TokenCounter for Ollama providers' do
+      provider = Woods::Embedding::Provider::Ollama.new(num_ctx: 8192)
+      chunker = builder.build_chunker(provider)
+      counter = chunker.instance_variable_get(:@token_counter)
+      max_tokens = chunker.instance_variable_get(:@max_tokens)
+      expect(counter).to be_a(Woods::Embedding::TokenCounter)
+      expect(max_tokens).to eq(8192 - 256)
+    end
+
+    it 'skips the TokenCounter for OpenAI (tiktoken ratios are stable)' do
+      provider = Woods::Embedding::Provider::OpenAI.new(api_key: 'sk-test')
+      chunker = builder.build_chunker(provider)
+      expect(chunker.instance_variable_get(:@token_counter)).to be_nil
+    end
+  end
 end

--- a/spec/chunking/semantic_chunker_spec.rb
+++ b/spec/chunking/semantic_chunker_spec.rb
@@ -277,4 +277,259 @@ RSpec.describe Woods::Chunking::SemanticChunker do
       expect(chunks).to all(be_a(Woods::Chunking::Chunk))
     end
   end
+
+  describe '#chunk with class-like units (MethodChunker)' do
+    subject(:chunker) { described_class.new(threshold: 10) }
+
+    let(:service_source) do
+      <<~RUBY
+        class PaymentProcessor
+          include Retryable
+
+          REQUIRED_ATTRS = %i[amount currency].freeze
+
+          attr_reader :order
+
+          def initialize(order)
+            @order = order
+          end
+
+          def call
+            charge_card
+            record_payment
+          end
+
+          def refund
+            stripe.refund(charge_id)
+          end
+
+          private
+
+          def charge_card
+            stripe.charge(order.amount)
+          end
+
+          def record_payment
+            Payment.create!(order: order)
+          end
+        end
+      RUBY
+    end
+
+    let(:service_unit) do
+      unit = Woods::ExtractedUnit.new(
+        type: :service,
+        identifier: 'PaymentProcessor',
+        file_path: 'app/services/payment_processor.rb'
+      )
+      unit.source_code = service_source
+      unit.metadata = {}
+      unit
+    end
+
+    it 'produces a summary chunk with class declaration and DSL calls' do
+      types = chunker.chunk(service_unit).map(&:chunk_type)
+      expect(types.first).to eq(:summary)
+    end
+
+    it 'produces one chunk per public method' do
+      types = chunker.chunk(service_unit).map(&:chunk_type)
+      expect(types).to include(:method_initialize, :method_call, :method_refund)
+    end
+
+    it 'bundles private methods into a single chunk' do
+      chunks = chunker.chunk(service_unit)
+      private_chunk = chunks.find { |c| c.chunk_type == :private_methods }
+
+      expect(private_chunk).not_to be_nil
+      expect(private_chunk.content).to include('def charge_card')
+      expect(private_chunk.content).to include('def record_payment')
+    end
+
+    it 'applies to jobs, mailers, concerns, policies, and other class-like types' do
+      %i[job mailer concern policy pundit_policy serializer decorator
+         interactor component graphql_resolver helper validator api_client].each do |type|
+        unit = Woods::ExtractedUnit.new(type: type, identifier: 'Thing', file_path: 'x.rb')
+        unit.source_code = service_source
+        unit.metadata = {}
+        types = chunker.chunk(unit).map(&:chunk_type)
+        expect(types).to include(:method_call), "expected MethodChunker to handle #{type}"
+      end
+    end
+
+    it 'leaves unhandled types as :whole' do
+      unit = Woods::ExtractedUnit.new(type: :migration, identifier: 'AddFoo', file_path: 'm.rb')
+      unit.source_code = service_source
+      unit.metadata = {}
+      types = chunker.chunk(unit).map(&:chunk_type)
+      expect(types).to eq([:whole])
+    end
+  end
+
+  describe '#chunk with a max_chars safety net' do
+    # 1kB ceiling — well under anything real but easy to exceed in a test.
+    subject(:chunker) { described_class.new(threshold: 10, max_chars: 1024) }
+
+    let(:huge_service_unit) do
+      body = (['    something_long_enough_to_matter(arg1, arg2, arg3)'] * 200).join("\n")
+      unit = Woods::ExtractedUnit.new(
+        type: :service,
+        identifier: 'HugeService',
+        file_path: 'app/services/huge_service.rb'
+      )
+      unit.source_code = "class HugeService\n  def call\n#{body}\n  end\nend"
+      unit.metadata = {}
+      unit
+    end
+
+    it 'slices any chunk whose content exceeds max_chars into parts' do
+      chunks = chunker.chunk(huge_service_unit)
+      expect(chunks.map(&:content)).to all(satisfy { |c| c.length <= 1024 })
+    end
+
+    it 'preserves provenance in the sliced chunk_type suffix' do
+      chunks = chunker.chunk(huge_service_unit)
+      # The oversize method chunk should emit :method_call_part_0, _part_1, …
+      sliced_types = chunks.map(&:chunk_type).select { |t| t.to_s.start_with?('method_call_part_') }
+      expect(sliced_types.size).to be >= 2
+    end
+
+    it 'leaves already-small chunks alone' do
+      small_service = Woods::ExtractedUnit.new(
+        type: :service, identifier: 'Small', file_path: 's.rb'
+      )
+      small_service.source_code = "class Small\n  def call\n    :ok\n  end\nend"
+      small_service.metadata = {}
+      chunks = chunker.chunk(small_service)
+      expect(chunks.map(&:chunk_type)).not_to include(a_string_matching(/_part_/))
+    end
+
+    it 'handles a single line longer than max_chars by hard-splitting it' do
+      long_line = 'x' * 3000
+      unit = Woods::ExtractedUnit.new(type: :service, identifier: 'Long', file_path: 'l.rb')
+      unit.source_code = "class Long\n  def call\n#{long_line}\n  end\nend"
+      unit.metadata = {}
+      chunks = chunker.chunk(unit)
+      expect(chunks.map(&:content)).to all(satisfy { |c| c.length <= 1024 })
+    end
+  end
+
+  describe '#enforce_chunk_limits!' do
+    subject(:chunker) { described_class.new(max_chars: 1024) }
+
+    let(:unit) do
+      unit = Woods::ExtractedUnit.new(
+        type: :rails_source, identifier: 'Rails::Big', file_path: '/gems/rails/big.rb'
+      )
+      unit.source_code = 'class Big; end'
+      unit.metadata = {}
+      unit
+    end
+
+    it 'splits oversize pre-existing chunks into line-balanced siblings' do
+      body = (['    long_line_to_ensure_slicing(arg1, arg2)'] * 50).join("\n")
+      unit.chunks = [{ content: body, chunk_type: :section }]
+
+      chunker.enforce_chunk_limits!(unit)
+
+      expect(unit.chunks.size).to be > 1
+      expect(unit.chunks.map { |c| c[:content].length }).to all(be <= 1024)
+      expect(unit.chunks.map { |c| c[:chunk_type] }).to all(match(/section_part_\d+/))
+    end
+
+    it 'leaves small pre-existing chunks untouched' do
+      unit.chunks = [{ content: 'short content', chunk_type: :summary }]
+
+      chunker.enforce_chunk_limits!(unit)
+
+      expect(unit.chunks).to eq([{ content: 'short content', chunk_type: :summary }])
+    end
+
+    it 'accepts string-keyed chunk hashes (ExtractedUnit JSON roundtrip shape)' do
+      body = ('x' * 2000)
+      unit.chunks = [{ 'content' => body, 'chunk_type' => 'blob' }]
+
+      chunker.enforce_chunk_limits!(unit)
+
+      expect(unit.chunks.size).to be > 1
+      expect(unit.chunks.map { |c| c[:chunk_type] }).to all(match(/blob_part_\d+/))
+    end
+
+    it 'is a no-op when max_chars is unset' do
+      unbounded = described_class.new
+      body = ('x' * 5000)
+      unit.chunks = [{ content: body, chunk_type: :blob }]
+
+      unbounded.enforce_chunk_limits!(unit)
+
+      expect(unit.chunks.size).to eq(1)
+    end
+
+    it 'is a no-op on empty chunks array' do
+      unit.chunks = []
+      expect { chunker.enforce_chunk_limits!(unit) }.not_to(change { unit.chunks })
+    end
+  end
+
+  describe '#enforce_chunk_limits! with a token-authoritative counter' do
+    let(:fake_counter) do
+      Class.new do
+        attr_reader :calls
+
+        def initialize(lengths_over:)
+          @lengths_over = lengths_over
+          @calls = 0
+        end
+
+        def count(text)
+          @calls += 1
+          @lengths_over.any? { |limit| text.length > limit } ? 9_000 : 100
+        end
+      end
+    end
+
+    let(:unit) do
+      Woods::ExtractedUnit.new(
+        type: :rails_source, identifier: 'Giant::Class', file_path: 'x.rb'
+      )
+    end
+
+    it 'uses the real tokenizer to detect oversize slices and re-splits them' do
+      # Oversize while > 1000 chars; fits below.
+      counter = fake_counter.new(lengths_over: [1000])
+      chunker = described_class.new(
+        max_chars: 2000, token_counter: counter, max_tokens: 8192
+      )
+      unit.chunks = [{ content: ("line of code\n" * 200), chunk_type: :whole }]
+
+      chunker.enforce_chunk_limits!(unit)
+
+      expect(unit.chunks.size).to be > 1
+      expect(unit.chunks.map { |c| c[:content].length }).to all(be <= 1000)
+    end
+
+    it 'stops recursive splitting at the MIN_SLICE_CHARS floor' do
+      counter = fake_counter.new(lengths_over: [0])
+      chunker = described_class.new(
+        max_chars: 2000, token_counter: counter, max_tokens: 8192
+      )
+      unit.chunks = [{ content: ('x' * 3000), chunk_type: :whole }]
+
+      chunker.enforce_chunk_limits!(unit)
+
+      expect(unit.chunks).not_to be_empty
+      expect(unit.chunks.size).to be < 50
+    end
+
+    it 'activates enforcement even when max_chars is nil' do
+      counter = fake_counter.new(lengths_over: [1000])
+      chunker = described_class.new(
+        max_chars: nil, token_counter: counter, max_tokens: 8192
+      )
+      unit.chunks = [{ content: ("row\n" * 500), chunk_type: :whole }]
+
+      expect { chunker.enforce_chunk_limits!(unit) }
+        .to(change { unit.chunks.size })
+    end
+  end
 end

--- a/spec/embedding/indexer_spec.rb
+++ b/spec/embedding/indexer_spec.rb
@@ -317,4 +317,126 @@ RSpec.describe Woods::Embedding::Indexer do
       expect(stats).to eq({ processed: 0, skipped: 0, errors: 0 })
     end
   end
+
+  # Regression — Ollama rejects inputs over its num_ctx (default 2048,
+  # we configure 8192). Without auto-chunking, real-world services with
+  # >~20 KB of source hit "400 the input length exceeds the context
+  # length" and the whole embed run aborts. The Indexer must chunk
+  # oversize units before sending them to the provider.
+  describe 'auto-chunking for oversize units' do
+    let(:budget_provider_class) do
+      Class.new(stub_provider_class) do
+        def max_input_tokens
+          8192
+        end
+      end
+    end
+
+    let(:nomic_preparer) do
+      Woods::Embedding::TextPreparer.new(max_tokens: 8192, chars_per_token: 2.5)
+    end
+
+    let(:provider) { budget_provider_class.new }
+    let(:text_preparer) { nomic_preparer }
+
+    let(:chunker) { Woods::Chunking::SemanticChunker.new(threshold: 10, max_chars: 20_000) }
+
+    let(:indexer) do
+      described_class.new(
+        provider: provider,
+        text_preparer: text_preparer,
+        vector_store: vector_store,
+        output_dir: output_dir,
+        chunker: chunker,
+        batch_size: 4
+      )
+    end
+
+    let(:huge_service) do
+      body = (['    work_on(item)'] * 4000).join("\n")
+      {
+        'type' => 'service',
+        'identifier' => 'BigService',
+        'file_path' => 'app/services/big_service.rb',
+        'namespace' => nil,
+        'source_code' => "class BigService\n  def call(item)\n#{body}\n  end\n  def other; :ok; end\nend",
+        'dependencies' => [],
+        'chunks' => [],
+        'source_hash' => 'big123'
+      }
+    end
+
+    before do
+      File.write(File.join(output_dir, 'big_service.json'), JSON.generate(huge_service))
+    end
+
+    it 'splits oversize units into multiple embeddings' do
+      stats = indexer.index_all
+      expect(stats[:processed]).to be > 1
+    end
+
+    it 'stores each chunk under a #chunk_N id' do
+      indexer.index_all
+      ids = vector_store.search([0.1, 0.2], limit: 100).map(&:id)
+      expect(ids).to all(match(/\ABigService#chunk_\d+\z/))
+    end
+
+    it 'respects the provider char budget on every embedded text' do
+      recorded_texts = []
+      allow(provider).to receive(:embed_batch).and_wrap_original do |orig, texts|
+        recorded_texts.concat(texts)
+        orig.call(texts)
+      end
+
+      indexer.index_all
+      budget = 8192 * 2.5
+      expect(recorded_texts).to all(satisfy { |t| t.length <= budget })
+    end
+
+    it 'skips chunking when the provider advertises no budget' do
+      no_budget_provider = stub_provider_class.new # no max_input_tokens method
+      small_indexer = described_class.new(
+        provider: no_budget_provider,
+        text_preparer: text_preparer,
+        vector_store: vector_store,
+        output_dir: output_dir,
+        chunker: chunker,
+        batch_size: 4
+      )
+      stats = small_indexer.index_all
+      # Provider without a budget => no auto-chunking, unit goes whole.
+      expect(stats[:processed]).to eq(1)
+    end
+
+    # Regression — `rails_source` units arrive from extraction with
+    # `chunks` already populated. Those chunks are not sized against
+    # the embedding provider's budget, so the Indexer must re-enforce
+    # the chunker's max_chars ceiling on them before sending. Prior
+    # to this the oversize pre-existing chunk hit Ollama unchanged and
+    # produced `400 the input length exceeds the context length`.
+    it 'splits oversize pre-existing chunks so none exceed the char budget' do
+      huge_line = 'x' * 30_000
+      pre_chunked_unit = {
+        'type' => 'rails_source',
+        'identifier' => 'Rails::Big',
+        'file_path' => '/gems/rails/big.rb',
+        'namespace' => nil,
+        'source_code' => 'class Big; end',
+        'dependencies' => [],
+        'chunks' => [{ 'content' => huge_line, 'chunk_type' => 'section' }],
+        'source_hash' => 'rails123'
+      }
+      File.write(File.join(output_dir, 'rails_big.json'), JSON.generate(pre_chunked_unit))
+
+      recorded_texts = []
+      allow(provider).to receive(:embed_batch).and_wrap_original do |orig, texts|
+        recorded_texts.concat(texts)
+        orig.call(texts)
+      end
+
+      indexer.index_all
+      budget = 8192 * 2.5
+      expect(recorded_texts).to all(satisfy { |t| t.length <= budget })
+    end
+  end
 end

--- a/spec/embedding/openai_spec.rb
+++ b/spec/embedding/openai_spec.rb
@@ -121,6 +121,12 @@ RSpec.describe Woods::Embedding::Provider::OpenAI do
     end
   end
 
+  describe '#max_input_tokens' do
+    it 'returns the OpenAI embedding model budget' do
+      expect(provider.max_input_tokens).to eq(8192)
+    end
+  end
+
   describe 'HTTP timeout configuration' do
     before { allow(http_double).to receive(:request).and_return(success_response) }
 

--- a/spec/embedding/provider_spec.rb
+++ b/spec/embedding/provider_spec.rb
@@ -114,6 +114,20 @@ RSpec.describe Woods::Embedding::Provider do
       end
     end
 
+    describe '#max_input_tokens' do
+      it 'tracks an explicit num_ctx override' do
+        expect(described_class.new(num_ctx: 4096).max_input_tokens).to eq(4096)
+      end
+
+      it 'falls back to the registry for the configured model' do
+        expect(described_class.new(model: 'bge-m3').max_input_tokens).to eq(8192)
+      end
+
+      it 'uses the conservative fallback for unknown models' do
+        expect(described_class.new(model: 'mystery-embed').max_input_tokens).to eq(2048)
+      end
+    end
+
     describe 'error handling' do
       let(:error_response) do
         instance_double(Net::HTTPInternalServerError, code: '500', body: 'model not found')
@@ -159,28 +173,36 @@ RSpec.describe Woods::Embedding::Provider do
     describe 'context window (num_ctx)' do
       before { allow(http_double).to receive(:request).and_return(success_response) }
 
-      # Regression — without `options.num_ctx`, Ollama caps embedding input at
-      # its 2048-token default and returns 400 ("the input length exceeds the
-      # context length") on most real-world Rails units. nomic-embed-text
-      # supports 8192, matching the TextPreparer default.
-      it 'defaults to sending options.num_ctx = 8192' do
+      # Regression — Ollama's `/api/embed` enforces the model's native context
+      # length regardless of `options.num_ctx` (see ollama/ollama#14186). We
+      # advertise the native ceiling so the chunker sizes inputs correctly —
+      # for nomic-embed-text that's 2048.
+      it 'defaults to the native context for nomic-embed-text' do
         provider.embed('text')
         expect(http_double).to have_received(:request) do |req|
           body = JSON.parse(req.body)
-          expect(body.dig('options', 'num_ctx')).to eq(8192)
+          expect(body.dig('options', 'num_ctx')).to eq(2048)
         end
       end
 
-      it 'includes num_ctx in batch requests' do
-        allow(http_double).to receive(:request).and_return(batch_success_response)
-        provider.embed_batch(%w[a b])
+      it 'auto-selects num_ctx from the registry for known models' do
+        described_class.new(model: 'bge-m3').embed('text')
         expect(http_double).to have_received(:request) do |req|
           body = JSON.parse(req.body)
           expect(body.dig('options', 'num_ctx')).to eq(8192)
         end
       end
 
-      it 'honours a custom num_ctx' do
+      it 'includes the registry num_ctx in batch requests' do
+        allow(http_double).to receive(:request).and_return(batch_success_response)
+        described_class.new(model: 'bge-m3').embed_batch(%w[a b])
+        expect(http_double).to have_received(:request) do |req|
+          body = JSON.parse(req.body)
+          expect(body.dig('options', 'num_ctx')).to eq(8192)
+        end
+      end
+
+      it 'honours an explicit num_ctx override' do
         described_class.new(num_ctx: 4096).embed('text')
         expect(http_double).to have_received(:request) do |req|
           body = JSON.parse(req.body)
@@ -188,11 +210,11 @@ RSpec.describe Woods::Embedding::Provider do
         end
       end
 
-      it 'omits the options key entirely when num_ctx is nil' do
-        described_class.new(num_ctx: nil).embed('text')
+      it 'falls back to the conservative default for unknown models' do
+        described_class.new(model: 'mystery-embed').embed('text')
         expect(http_double).to have_received(:request) do |req|
           body = JSON.parse(req.body)
-          expect(body).not_to have_key('options')
+          expect(body.dig('options', 'num_ctx')).to eq(2048)
         end
       end
     end

--- a/spec/embedding/text_preparer_spec.rb
+++ b/spec/embedding/text_preparer_spec.rb
@@ -161,6 +161,24 @@ RSpec.describe Woods::Embedding::TextPreparer do
       result = preparer.prepare(unit)
       expect(result).to include('validates :email, presence: true')
     end
+
+    context 'with a provider-tuned chars_per_token ratio' do
+      # nomic-embed-text (BERT WordPiece) runs ~2.5 chars/token on code —
+      # much hotter than the default tiktoken-calibrated 4.0. Provider-
+      # specific ratios keep truncation honest for non-OpenAI embedders.
+      subject(:nomic_preparer) do
+        described_class.new(max_tokens: 8192, chars_per_token: 2.5)
+      end
+
+      it 'truncates more aggressively for BERT-style tokenizers' do
+        result = nomic_preparer.prepare(large_unit)
+        expect(result.length).to be <= (8192 * 2.5).floor
+      end
+
+      it 'exposes the configured ratio' do
+        expect(nomic_preparer.chars_per_token).to eq(2.5)
+      end
+    end
   end
 
   describe '#prepare_chunks' do

--- a/spec/embedding/token_counter_spec.rb
+++ b/spec/embedding/token_counter_spec.rb
@@ -3,6 +3,17 @@
 require 'spec_helper'
 require 'woods/embedding/token_counter'
 
+# Pre-load tokenizers so stub_const('Tokenizers', fake) below isn't racing
+# with try_load's `require 'tokenizers'`. Without this pre-load, the gem's
+# top-level `module Tokenizers` re-opens the stubbed module under random
+# test orderings, leaking the real `from_pretrained` onto the fake.
+begin
+  require 'tokenizers'
+rescue LoadError
+  # gem absent (Ruby 3.0 row): try_load hits its LoadError branch, which
+  # is the equivalent failure path for these specs.
+end
+
 RSpec.describe Woods::Embedding::TokenCounter do
   subject(:counter) { described_class.new }
 

--- a/spec/embedding/token_counter_spec.rb
+++ b/spec/embedding/token_counter_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'woods/embedding/token_counter'
+
+RSpec.describe Woods::Embedding::TokenCounter do
+  subject(:counter) { described_class.new }
+
+  describe '#count' do
+    it 'returns 0 for nil' do
+      expect(counter.count(nil)).to eq(0)
+    end
+
+    it 'returns 0 for empty string' do
+      expect(counter.count('')).to eq(0)
+    end
+
+    context 'when the tokenizers gem is available (Gemfile test group)' do
+      it 'returns exact token counts via bert-base-uncased' do
+        skip 'tokenizers gem not installed' unless counter.exact?
+
+        # Sanity check: a dense Rails-style constant tokenizes into more
+        # pieces than a naive chars/4 would suggest — nothing specific
+        # to assert about the ratio, but the count must be > 0 and the
+        # tokenizer must round-trip via #decode.
+        count = counter.count('ActionController::Metal::ConditionalGet')
+        expect(count).to be > 0
+        expect(count).to be < 'ActionController::Metal::ConditionalGet'.length
+      end
+
+      it 'reports exact? true' do
+        skip 'tokenizers gem not installed' unless counter.exact?
+        expect(counter.exact?).to be(true)
+      end
+    end
+
+    context 'when tokenizer loading fails' do
+      before do
+        fake_tokenizers = Module.new do
+          def self.from_pretrained(*)
+            raise StandardError, 'simulated network failure'
+          end
+        end
+        stub_const('Tokenizers', fake_tokenizers)
+      end
+
+      it 'falls back to chars/token estimation' do
+        counter = described_class.new(chars_per_token: 2.0)
+        # 10-char input / 2.0 chars_per_token = 5 tokens
+        expect(counter.count('0123456789')).to eq(5)
+      end
+
+      it 'memoizes the failed load so it only warns once' do
+        counter = described_class.new
+        expect(Kernel).to receive(:warn).once
+        counter.count('first call triggers load + warn')
+        counter.count('second call stays on the fallback path')
+      end
+
+      it 'reports exact? false' do
+        expect(described_class.new.exact?).to be(false)
+      end
+    end
+
+    context 'when the tokenizers gem is missing' do
+      before do
+        # Force the soft-require branch even though the gem is present.
+        allow_any_instance_of(described_class).to receive(:require)
+          .with('tokenizers').and_raise(LoadError, 'simulated missing gem')
+      end
+
+      it 'falls back to chars/token estimation' do
+        counter = described_class.new(chars_per_token: 4.0)
+        # 12 chars / 4.0 = 3 tokens
+        expect(counter.count('hello world!')).to eq(3)
+      end
+
+      it 'warns with install instructions' do
+        expect(Kernel).to receive(:warn).with(/gem 'tokenizers'/)
+        described_class.new.count('anything')
+      end
+    end
+  end
+
+  describe '#exact?' do
+    it 'lazy-loads only on first call' do
+      counter = described_class.new
+      # Before any count call, no load is attempted — but exact? itself
+      # triggers the load, so call it once and verify the second call
+      # is idempotent.
+      first = counter.exact?
+      second = counter.exact?
+      expect(first).to eq(second)
+    end
+  end
+
+  describe 'thread safety' do
+    it 'loads the tokenizer at most once under concurrent access' do
+      counter = described_class.new
+      results = Array.new(4) { Thread.new { counter.count('racing call') } }.map(&:value)
+      expect(results).to all(be_a(Integer))
+    end
+  end
+end

--- a/spec/support/fake_embedding_provider.rb
+++ b/spec/support/fake_embedding_provider.rb
@@ -51,6 +51,14 @@ module Woods
           'fake-embedding-test'
         end
 
+        # No input budget — signals the indexer to skip auto-chunking.
+        # Tests that need chunking behaviour should subclass and override.
+        #
+        # @return [nil]
+        def max_input_tokens
+          nil
+        end
+
         private
 
         # Convert text to a normalized vector using bag-of-words hashing.

--- a/spec/tasks_spec.rb
+++ b/spec/tasks_spec.rb
@@ -8,11 +8,22 @@ RSpec.describe Woods::Tasks do
   describe '.build_embed_indexer' do
     let(:fake_provider) { instance_double(Woods::Embedding::Provider::Ollama) }
     let(:fake_vector_store) { instance_double(Woods::Storage::VectorStore::InMemory) }
+    let(:fake_text_preparer) { instance_double(Woods::Embedding::TextPreparer) }
+    let(:fake_chunker) { instance_double(Woods::Chunking::SemanticChunker) }
     let(:captured) { {} }
 
+    # Guard against random-seed ordering: this spec file mocks at the
+    # Builder level, which needs Woods.configuration to be non-nil when
+    # build_embed_indexer runs. Other specs in the suite happen to call
+    # Woods.configure, but we cannot rely on order — Ruby 3.1 CI already
+    # tripped on this under a different seed.
     before do
+      Woods.configure { |c| c.output_dir ||= '/tmp/woods-tasks-default' }
+
       allow_any_instance_of(Woods::Builder).to receive(:build_embedding_provider).and_return(fake_provider)
       allow_any_instance_of(Woods::Builder).to receive(:build_vector_store).and_return(fake_vector_store)
+      allow_any_instance_of(Woods::Builder).to receive(:build_text_preparer).and_return(fake_text_preparer)
+      allow_any_instance_of(Woods::Builder).to receive(:build_chunker).and_return(fake_chunker)
 
       allow(Woods::Embedding::Indexer).to receive(:new).and_wrap_original do |original, **kwargs|
         captured.merge!(kwargs)
@@ -29,7 +40,8 @@ RSpec.describe Woods::Tasks do
 
       expect(captured[:provider]).to be(fake_provider)
       expect(captured[:vector_store]).to be(fake_vector_store)
-      expect(captured[:text_preparer]).to be_a(Woods::Embedding::TextPreparer)
+      expect(captured[:text_preparer]).to be(fake_text_preparer)
+      expect(captured[:chunker]).to be(fake_chunker)
     end
 
     it 'uses config.output_dir by default' do


### PR DESCRIPTION
Ollama's /api/embed enforces each model's native context length regardless of options.num_ctx (ollama/ollama#14186). The provider previously hard-coded num_ctx=8192, so nomic-embed-text (native 2048) rejected real-world Rails units with "400 the input length exceeds the context length". Compounding this, the indexer's chunking gate used a chars/token estimate that under-counts dense Ruby source, so chunks that looked safe by char count still blew the token budget.

- Per-model MODEL_CONTEXT_LENGTHS registry in Provider::Ollama; num_ctx is auto-selected from the model name (nomic-embed-text=2048, bge-m3=8192, snowflake-arctic-embed2=8192, mxbai-embed-large=512, all-minilm=256). Unknown models fall back to 2048.
- New Embedding::TokenCounter loads the bert-base-uncased WordPiece tokenizer via the optional `tokenizers` gem for exact client-side verification. Falls back to a 1.5 chars/token ratio when the gem isn't installed.
- Indexer#needs_chunking? now consults the chunker's TokenCounter so token-over-budget units are split before being sent to Ollama.
- SemanticChunker exposes token_counter/max_tokens/max_chars readers; MethodChunker and token-aware enforce_chunk_limits! wired through Builder + tasks.rake.

Docs + user-facing snippets corrected to the long-standing API shape (Ollama takes `host:`, not `base_url:`):
- New docs/EMBEDDING_MODELS.md with model comparison, num_ctx regression explanation, and the procedure for adding a new model.
- Updated CONFIGURATION_REFERENCE, TROUBLESHOOTING, BACKEND_MATRIX, FAQ, GETTING_STARTED, README, and the woods:install template.
- mcp/bootstrapper.rb auto-detect path was passing base_url: to Ollama.new — the resulting ArgumentError was silently swallowed by the outer rescue. Now passes host:.

## Summary

Brief description of the changes.

## Motivation

Why is this change needed? Link any related issues (e.g., `Fixes #123`).

## Changes

- ...

## Testing

How was this tested? Include relevant specs or manual verification steps.

## Checklist

- [ ] Tests added/updated
- [ ] `bundle exec rake spec` passes
- [ ] `bundle exec rubocop` passes
- [ ] CHANGELOG.md updated (if user-facing change)
- [ ] Documentation updated (if applicable)
