### PR TITLE
fix(embedding): all-minilm chunk-drop + PR #70 review followups + Ollama read_timeout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ exe/
 - All extractors return `Array<ExtractedUnit>`
 - Use `Rails.root.join()` for paths, never string concatenation
 - JSON output uses string keys, snake_case
-- Token estimation: `(string.length / 4.0).ceil` — Benchmarked against tiktoken (cl100k_base) on 19 Ruby source files. Actual mean is 4.41 chars/token. Uses 4.0 as a conservative floor (~10.6% overestimate). See docs/TOKEN_BENCHMARK.md.
+- Token estimation: `(string.length / 4.0).ceil` for the OpenAI path — Benchmarked against tiktoken (cl100k_base) on 19 Ruby source files. Actual mean is 4.41 chars/token. Uses 4.0 as a conservative floor (~10.6% overestimate). See docs/TOKEN_BENCHMARK.md. The Ollama path uses 1.5 chars/token (BERT WordPiece) — see `Builder#chars_per_token_for` and `docs/EMBEDDING_MODELS.md`.
 - Error handling: raise `Woods::ExtractionError` for recoverable extraction failures, let unexpected errors propagate. Always `rescue StandardError`, never bare `rescue`.
 
 ## Testing

--- a/lib/woods/builder.rb
+++ b/lib/woods/builder.rb
@@ -161,7 +161,7 @@ module Woods
     # When the optional `tokenizers` gem is installed, pass a
     # {Embedding::TokenCounter} and `max_tokens` so the chunker can
     # verify every slice with the real tokenizer and re-split any piece
-    # that still exceeds `num_ctx`. See docs/EMBEDDING_CHUNK_SIZING.md.
+    # that still exceeds `num_ctx`. See docs/EMBEDDING_MODELS.md.
     #
     # Ollama v0.13.5+ stopped honouring `truncate: true` on `/api/embed`
     # (ollama/ollama#14186), so any chunk that exceeds `num_ctx` returns
@@ -174,6 +174,13 @@ module Woods
     def build_chunker(provider)
       budget = provider.respond_to?(:max_input_tokens) ? provider.max_input_tokens : nil
       max_chars = ((budget * chars_per_token_for(provider)).floor - CHUNKER_PREFIX_ALLOWANCE if budget)
+
+      # Guard against a budget so small that the prefix allowance leaves
+      # no room for content. Without this, SemanticChunker#slice_by_lines
+      # passes a negative repeat count to String#scan, which returns []
+      # — every chunk becomes empty and is silently dropped, producing
+      # zero embeddings with no error. Surface the misconfiguration loudly.
+      raise ArgumentError, chunker_budget_message(provider, budget) if max_chars && max_chars <= 0
 
       token_counter = token_counter_for(provider)
       max_tokens = token_counter && budget ? budget - PREFIX_TOKEN_ALLOWANCE : nil
@@ -220,6 +227,14 @@ module Woods
       when Embedding::Provider::Ollama then 1.5
       else Embedding::TextPreparer::DEFAULT_CHARS_PER_TOKEN
       end
+    end
+
+    # Diagnostic for the build_chunker budget guard.
+    def chunker_budget_message(provider, budget)
+      "embedding model '#{provider.respond_to?(:model) ? provider.model : provider.class}' " \
+        "reports a max_input_tokens of #{budget}, which leaves no room for " \
+        "the chunk prefix (#{CHUNKER_PREFIX_ALLOWANCE} chars). Configure a " \
+        'model with a larger native context, or set num_ctx explicitly.'
     end
 
     # Instantiate the metadata store adapter specified by the configuration.

--- a/lib/woods/cache/cache_middleware.rb
+++ b/lib/woods/cache/cache_middleware.rb
@@ -77,6 +77,19 @@ module Woods
         @provider.model_name
       end
 
+      # Delegate the per-provider input cap so Builder's chunker / text
+      # preparer wiring keeps working when the cache wrapper is in front
+      # of the provider. Without this, `respond_to?(:max_input_tokens)`
+      # returns true (inherited from Interface) but the call raises
+      # NotImplementedError.
+      #
+      # @return [Integer, nil]
+      def max_input_tokens
+        return @provider.max_input_tokens if @provider.respond_to?(:max_input_tokens)
+
+        nil
+      end
+
       private
 
       # Split texts into cached hits and uncached misses.

--- a/lib/woods/chunking/semantic_chunker.rb
+++ b/lib/woods/chunking/semantic_chunker.rb
@@ -190,16 +190,21 @@ module Woods
         )
       end
 
-      # Slice any chunk whose content exceeds `@max_chars` into
+      # Slice any chunk whose content exceeds the active budget into
       # line-balanced sub-chunks. Preserves chunk_type with a `_part_N`
       # suffix so downstream consumers can see they came from the same
       # section.
+      #
+      # When `@max_chars` is nil but a token verifier is wired up, we
+      # still need to walk every chunk — `oversize?` will fall through
+      # to the token check. Skipping when only `@max_chars` is missing
+      # leaves the token-based path unreachable from this method.
       #
       # @param chunks [Array<Chunk>]
       # @param unit [ExtractedUnit]
       # @return [Array<Chunk>]
       def enforce_char_limit(chunks, unit)
-        return chunks unless @max_chars
+        return chunks unless enforcement_active?
 
         chunks.flat_map { |chunk| split_oversize_chunk(chunk, unit) }
       end

--- a/lib/woods/embedding/openai.rb
+++ b/lib/woods/embedding/openai.rb
@@ -24,11 +24,12 @@ module Woods
           'text-embedding-3-small' => 1536,
           'text-embedding-3-large' => 3072
         }.freeze
-        # OpenAI embedding models currently share an 8191-token input cap
-        # across text-embedding-3-small / -3-large / ada-002. We round down
-        # to 8192 to match the industry-standard budget — the tiktoken
-        # heuristic lives in TextPreparer.
-        MAX_INPUT_TOKENS = 8192
+        # OpenAI embedding models share an 8191-token input cap across
+        # text-embedding-3-small / -3-large / ada-002. The chunker uses
+        # this as a hard ceiling — the actual chunk size lands well
+        # below it once chars-per-token estimation and the prefix
+        # allowance are factored in (see Builder#build_chunker).
+        MAX_INPUT_TOKENS = 8191
 
         # @param api_key [String] OpenAI API key
         # @param model [String] OpenAI embedding model name (default: text-embedding-3-small)

--- a/lib/woods/embedding/provider.rb
+++ b/lib/woods/embedding/provider.rb
@@ -92,11 +92,22 @@ module Woods
           'mxbai-embed-large' => 512,
           'snowflake-arctic-embed' => 512,
           'snowflake-arctic-embed2' => 8192,
-          'all-minilm' => 256
+          # all-minilm: 512 is the model's context length, NOT the 384
+          # embedding dimension and NOT the 256 some sources confuse with
+          # the dimension. With a 256-token budget the chunker formula
+          # produces a negative max_chars and silently drops every chunk.
+          'all-minilm' => 512
         }.freeze
 
         # Fallback when the configured model isn't in the registry.
         FALLBACK_NUM_CTX = 2048
+
+        # Default read timeout for /api/embed. The previous 30s default
+        # was too short for batched embed calls on cold models — Ollama
+        # has to load the model on first call, and an N-item batch can
+        # easily exceed 30s on a CPU-only host. 120s leaves headroom
+        # without wedging the whole pipeline on a genuinely dead server.
+        DEFAULT_READ_TIMEOUT = 120
 
         # @param model [String] Ollama model name (default: nomic-embed-text).
         #   Set to `"bge-m3"` or `"snowflake-arctic-embed2"` for an 8192-token
@@ -107,10 +118,14 @@ module Woods
         #   context from `MODEL_CONTEXT_LENGTHS`, falling back to 2048 for
         #   unknown models. Set explicitly only if running a model with a
         #   known-larger native context that isn't in the registry yet.
-        def initialize(model: DEFAULT_MODEL, host: DEFAULT_HOST, num_ctx: nil)
+        # @param read_timeout [Integer] HTTP read timeout in seconds.
+        #   Bump this for slow / cold-start hosts or very large batches.
+        def initialize(model: DEFAULT_MODEL, host: DEFAULT_HOST, num_ctx: nil,
+                       read_timeout: DEFAULT_READ_TIMEOUT)
           @model = model
           @host = host
           @num_ctx = num_ctx || MODEL_CONTEXT_LENGTHS.fetch(model, FALLBACK_NUM_CTX)
+          @read_timeout = read_timeout
           @uri = URI("#{host}/api/embed")
         end
 
@@ -151,11 +166,11 @@ module Woods
         end
 
         # Maximum input length Ollama will accept — tracks the configured
-        # context window. `nil` when `num_ctx` is disabled, signalling that
-        # the model's own default applies and the caller should treat the
-        # budget as unknown.
+        # context window. Always populated: the constructor resolves
+        # `num_ctx` to the model's registry entry or {FALLBACK_NUM_CTX},
+        # so this method never returns nil for an Ollama provider.
         #
-        # @return [Integer, nil]
+        # @return [Integer]
         def max_input_tokens
           @num_ctx
         end
@@ -210,7 +225,7 @@ module Woods
           http = Net::HTTP.new(@uri.host, @uri.port)
           http.use_ssl = @uri.scheme == 'https'
           http.open_timeout = 10
-          http.read_timeout = 30
+          http.read_timeout = @read_timeout
           http.keep_alive_timeout = 30
           http.start
           @http_client = http

--- a/lib/woods/embedding/token_counter.rb
+++ b/lib/woods/embedding/token_counter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'set'
+
 module Woods
   module Embedding
     # Exact or estimated token counts for embedding inputs.
@@ -99,8 +101,32 @@ module Woods
         nil
       end
 
+      # Per-process dedup so multiple TokenCounter instances (one per
+      # retriever build, plus one per chunker, plus tests) don't each
+      # spam the same fallback warning. The mutex keeps the dedup set
+      # consistent under the same concurrent-first-call pattern that
+      # the per-instance load mutex protects against.
+      @warned_messages = Set.new
+      @warned_mutex = Mutex.new
+
+      class << self
+        attr_reader :warned_messages, :warned_mutex
+
+        # Reset the per-process warning dedup. For tests only — production
+        # callers should never need to clear it.
+        def reset_warned!
+          @warned_mutex.synchronize { @warned_messages.clear }
+        end
+      end
+
       def warn_once(message)
-        Kernel.warn("[woods] #{message}")
+        full = "[woods] #{message}"
+        self.class.warned_mutex.synchronize do
+          return if self.class.warned_messages.include?(full)
+
+          self.class.warned_messages << full
+        end
+        Kernel.warn(full)
       end
     end
   end

--- a/lib/woods/mcp/server.rb
+++ b/lib/woods/mcp/server.rb
@@ -4,6 +4,7 @@ require 'logger'
 require 'mcp'
 require 'time'
 require 'set'
+require_relative '../tasks'
 require_relative 'index_reader'
 require_relative 'tool_response_renderer'
 
@@ -727,17 +728,12 @@ module Woods
             guard&.record!(:embedding)
 
             Thread.new do
-              config = Woods.configuration
-              builder = Woods::Builder.new(config)
-              provider = builder.build_embedding_provider
-              text_preparer = Woods::Embedding::TextPreparer.new
-              vector_store = builder.build_vector_store
-              indexer = Woods::Embedding::Indexer.new(
-                provider: provider,
-                text_preparer: text_preparer,
-                vector_store: vector_store,
-                output_dir: config.output_dir
-              )
+              # Share the rake-task wiring so the MCP path picks up the
+              # provider-tuned TextPreparer + token-aware chunker. Without
+              # this, MCP-triggered embedding still hit Ollama's "input
+              # length exceeds context length" error after the rake path
+              # was fixed in PR #70.
+              indexer = Woods::Tasks.build_embed_indexer
               incremental ? indexer.index_incremental : indexer.index_all
             rescue StandardError => e
               logger = defined?(Rails) ? Rails.logger : Logger.new($stderr)

--- a/lib/woods/resilience/retryable_provider.rb
+++ b/lib/woods/resilience/retryable_provider.rb
@@ -69,6 +69,18 @@ module Woods
         @provider.model_name
       end
 
+      # Delegate the per-provider input cap. The retry wrapper does not
+      # change the provider's budget, so just hand through whatever the
+      # inner provider reports. Without this, `respond_to?` returns true
+      # via Interface but the call raises NotImplementedError.
+      #
+      # @return [Integer, nil]
+      def max_input_tokens
+        return @provider.max_input_tokens if @provider.respond_to?(:max_input_tokens)
+
+        nil
+      end
+
       private
 
       # Execute a block with retry logic and exponential backoff.

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -226,6 +226,35 @@ RSpec.describe Woods::Builder do
     end
   end
 
+  # ── Builder#build_chunker — budget guard ──────────────────────────────
+
+  describe '#build_chunker budget guard' do
+    let(:config) { Woods::Configuration.new }
+    let(:builder) { described_class.new(config) }
+
+    # A provider whose context window leaves no headroom after the
+    # CHUNKER_PREFIX_ALLOWANCE (512 chars). Without the guard, the
+    # negative max_chars lands in SemanticChunker#slice_by_lines and
+    # silently drops every chunk — see PR #70 review notes.
+    let(:tiny_provider) do
+      Class.new(Woods::Embedding::Provider::Ollama) do
+        def initialize
+          super(model: 'tiny-test-model', num_ctx: 64)
+        end
+      end.new
+    end
+
+    it 'raises ArgumentError when max_chars would be non-positive' do
+      expect { builder.build_chunker(tiny_provider) }
+        .to raise_error(ArgumentError, /no room for the chunk prefix/)
+    end
+
+    it 'still builds a chunker when the budget leaves positive headroom' do
+      reasonable = Woods::Embedding::Provider::Ollama.new(model: 'all-minilm')
+      expect { builder.build_chunker(reasonable) }.not_to raise_error
+    end
+  end
+
   # ── Builder#build_vector_store — unknown type ────────────────────────
 
   describe '#build_vector_store with unknown type' do
@@ -382,11 +411,11 @@ RSpec.describe Woods::Builder do
       expect(preparer.max_tokens).to eq(4096)
     end
 
-    it 'uses 4.0 chars/token and the 8192 cap for OpenAI providers' do
+    it 'uses 4.0 chars/token and the 8191 cap for OpenAI providers' do
       provider = Woods::Embedding::Provider::OpenAI.new(api_key: 'sk-test')
       preparer = builder.build_text_preparer(provider)
       expect(preparer.chars_per_token).to eq(4.0)
-      expect(preparer.max_tokens).to eq(8192)
+      expect(preparer.max_tokens).to eq(8191)
     end
 
     it 'falls back to the preparer default when the provider has no budget' do

--- a/spec/embedding/openai_spec.rb
+++ b/spec/embedding/openai_spec.rb
@@ -122,8 +122,8 @@ RSpec.describe Woods::Embedding::Provider::OpenAI do
   end
 
   describe '#max_input_tokens' do
-    it 'returns the OpenAI embedding model budget' do
-      expect(provider.max_input_tokens).to eq(8192)
+    it 'returns the OpenAI embedding model budget (8191 — the actual API cap)' do
+      expect(provider.max_input_tokens).to eq(8191)
     end
   end
 

--- a/spec/embedding/provider_spec.rb
+++ b/spec/embedding/provider_spec.rb
@@ -126,6 +126,15 @@ RSpec.describe Woods::Embedding::Provider do
       it 'uses the conservative fallback for unknown models' do
         expect(described_class.new(model: 'mystery-embed').max_input_tokens).to eq(2048)
       end
+
+      # Regression for the silent-chunk-drop bug fixed alongside the
+      # build_chunker guard. all-minilm has a 512-token context (NOT
+      # the 384 embedding dimension and NOT the 256 some sources cite);
+      # a 256-token budget would push max_chars negative and cause
+      # SemanticChunker to drop every chunk silently.
+      it 'reports 512 for all-minilm (the model context, not the dimension)' do
+        expect(described_class.new(model: 'all-minilm').max_input_tokens).to eq(512)
+      end
     end
 
     describe 'error handling' do

--- a/spec/embedding/token_counter_spec.rb
+++ b/spec/embedding/token_counter_spec.rb
@@ -17,6 +17,11 @@ end
 RSpec.describe Woods::Embedding::TokenCounter do
   subject(:counter) { described_class.new }
 
+  # warn_once dedupes warnings per-process, so any spec that asserts
+  # Kernel.warn fires must start from a clean slate — otherwise an
+  # earlier example's warning would suppress this one.
+  before { described_class.reset_warned! }
+
   describe '#count' do
     it 'returns 0 for nil' do
       expect(counter.count(nil)).to eq(0)

--- a/spec/mcp/server_spec.rb
+++ b/spec/mcp/server_spec.rb
@@ -685,13 +685,6 @@ RSpec.describe Woods::MCP::Server do
       described_class.build(index_dir: fixture_dir, operator: operator, response_format: :json)
     end
 
-    let(:mock_builder) do
-      double('Builder').tap do |b|
-        allow(b).to receive(:build_embedding_provider).and_return(double('provider'))
-        allow(b).to receive(:build_vector_store).and_return(double('vector_store'))
-      end
-    end
-
     let(:mock_indexer) do
       double('Indexer').tap do |i|
         allow(i).to receive(:index_all)
@@ -699,15 +692,11 @@ RSpec.describe Woods::MCP::Server do
       end
     end
 
-    let(:text_preparer_class) { double('TextPreparerClass', new: double('text_preparer')) }
-    let(:indexer_class) { double('IndexerClass', new: mock_indexer) }
-
     before do
-      mock_config = Struct.new(:output_dir).new(fixture_dir)
-      Woods.configuration = mock_config
-      allow(Woods::Builder).to receive(:new).and_return(mock_builder)
-      stub_const('Woods::Embedding::TextPreparer', text_preparer_class)
-      stub_const('Woods::Embedding::Indexer', indexer_class)
+      # The MCP pipeline_embed tool now delegates to Woods::Tasks.build_embed_indexer
+      # so it picks up the same provider-tuned chunker/text-preparer wiring as
+      # the rake task path. Stub at that seam.
+      allow(Woods::Tasks).to receive(:build_embed_indexer).and_return(mock_indexer)
     end
 
     after do


### PR DESCRIPTION
## Summary

Bundle of fixes from the PR #70 code review (and one related runtime issue hit on a host app right after the merge). One critical silent-data-loss bug + a handful of correctness/wiring gaps the review caught.

## Critical

### `all-minilm` silently drops every chunk

`Embedding::Provider::Ollama::MODEL_CONTEXT_LENGTHS['all-minilm']` was set to `256`. That's adjacent to the embedding dimension (384), not the model's 512-token context window. With a 256-token budget, `Builder#build_chunker` computes:

```
max_chars = (256 * 1.5).floor - CHUNKER_PREFIX_ALLOWANCE  # = 384 - 512 = -128
```

`-128` lands in `SemanticChunker#slice_by_lines`, which calls `String#scan(/.{1,-128}/m)`. A negative repeat returns `[]`. Every chunk becomes empty and is filtered out by the `unless current.empty?` guard. **Net result: any unit embedded with `all-minilm` produces zero chunks → zero embeddings → no error, no warning.**

Fix: corrected the registry value to `512` (the actual context length), and added a guard in `build_chunker` that raises `ArgumentError` if the budget would yield a non-positive `max_chars`. So future misconfigured models fail loudly instead of silently dropping work.

### Ollama `Net::ReadTimeout` on cold-start models

A host app hit `Net::ReadTimeout` right after PR #70 merged:

```
Woods::Error: Embedding failed: Ollama API error (retry failed):
  Net::ReadTimeout with #<TCPSocket:(closed)>
```

The hard-coded 30s `read_timeout` is too short for cold-start models or large batches. Bumped the default to 120s and made it configurable via `embedding_options[:read_timeout]`.

## Review followups (all from PR #70 multi-agent review)

| Fix | Why |
|---|---|
| OpenAI `MAX_INPUT_TOKENS` 8192 → 8191 | Real API cap; the comment claimed "round down to 8192" which actually rounded *up* by one. |
| MCP `pipeline_embed` routes through `Woods::Tasks.build_embed_indexer` | Inline construction skipped the provider-tuned chunker and TextPreparer — same Ollama context bug PR #70 fixed for rake was still latent here. |
| `CachedEmbeddingProvider` + `RetryableProvider` delegate `max_input_tokens` | Both `include Interface` (which raises `NotImplementedError`), so `respond_to?` returned true but the call would raise. Latent foot-gun if either wrapper ever fronts the chunker/preparer wiring. |
| `SemanticChunker#enforce_char_limit` keys off `enforcement_active?` | Returned early on `nil` `max_chars`, bypassing the token verifier even when `TokenCounter` + `max_tokens` were wired in. |
| `TokenCounter#warn_once` is now actually once-per-process | Per-instance memoization meant N TokenCounter instances → N copies of the same fallback warning. Class-level `Set` + `Mutex` dedup. |
| `Ollama#max_input_tokens` YARD doc | Claimed a nil return path the constructor makes unreachable. |
| `Builder#build_chunker` doc cross-ref | Pointed at the non-existent `EMBEDDING_CHUNK_SIZING.md`; now points at `EMBEDDING_MODELS.md`. |
| `CLAUDE.md` token-estimation note | Flags that the Ollama path uses 1.5 chars/token (BERT WordPiece) while the OpenAI path stays at 4.0. |

## Test plan

- [x] `bundle exec rake spec` passes (4072 examples, 0 failures, 2 pending — the existing `tiktoken_ruby` pendings)
- [x] `bundle exec rubocop` passes (404 files, 0 offenses)
- [x] Regression spec asserts `all-minilm` reports 512
- [x] Regression spec asserts `build_chunker` raises rather than silently producing empty chunks
- [x] MCP server spec exercises the `pipeline_embed → Tasks.build_embed_indexer` seam

## Out of scope

- Auditing the rest of the model registry against upstream Ollama specs (only `all-minilm` was wrong).
- Whether `RetryableProvider` should retry on `Net::ReadTimeout` differently now that the per-call timeout is longer.