### PR TITLE
fix(storage): add missing MetadataStore::InMemory + friendly sqlite3 error

### DIFF
--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -157,6 +157,24 @@ config.metadata_store_options = {
 }
 ```
 
+Requires the `sqlite3` gem in your host bundle. Rails apps backed by
+MySQL or PostgreSQL won't have it by default — selecting `:sqlite`
+without it raises `Woods::ConfigurationError` with install
+instructions. For MySQL/Postgres-only hosts, use `:in_memory` (below)
+unless cross-process metadata persistence matters.
+
+### In-Memory Metadata
+
+```ruby
+config.metadata_store = :in_memory
+```
+
+Pure-Ruby hash-backed store. No external dependencies, no persistence
+— vectors and metadata both live in the building process and die with
+it. The `_index.json` manifest under `output_dir` is the durable
+metadata for the index MCP server, so this is a reasonable default
+for hosts that don't bundle `sqlite3`.
+
 ## Presets
 
 For quick setup, use named presets that configure storage + embedding together:

--- a/lib/woods/storage/metadata_store.rb
+++ b/lib/woods/storage/metadata_store.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'time'
 
 module Woods
+  # Same conditional-define pattern used elsewhere in the gem so this
+  # file can be required in isolation (e.g. by specs that bypass the
+  # full lib/woods.rb load) without tripping NameError on the friendly
+  # missing-sqlite3 raise below.
+  class Error < StandardError; end unless defined?(Woods::Error)
+  class ConfigurationError < Error; end unless defined?(Woods::ConfigurationError)
+
   module Storage
     # MetadataStore provides an interface for storing and querying unit metadata.
     #
@@ -85,6 +93,88 @@ module Woods
         end
       end
 
+      # Pure-Ruby metadata store backed by a hash. No external dependencies,
+      # no persistence — vectors and metadata both live in the building
+      # process and die with it. Suitable for hosts that don't bundle the
+      # `sqlite3` gem (e.g., MySQL- or Postgres-only Rails apps), and for
+      # short-lived processes that rebuild the index per run.
+      #
+      # @example
+      #   store = InMemory.new
+      #   store.store("User", { type: "model", namespace: "Admin" })
+      #   store.find("User")  # => { "type" => "model", "namespace" => "Admin" }
+      #
+      class InMemory
+        include Interface
+
+        def initialize
+          @data = {}
+        end
+
+        # @see Interface#store
+        def store(id, metadata)
+          @data[id] = stringify_keys(metadata).merge('updated_at' => Time.now.iso8601)
+        end
+
+        # @see Interface#find
+        def find(id)
+          record = @data[id]
+          return nil unless record
+
+          record.except('updated_at')
+        end
+
+        # @see Interface#find_batch
+        def find_batch(ids)
+          ids.each_with_object({}) do |id, result|
+            data = find(id)
+            result[id] = data if data
+          end
+        end
+
+        # @see Interface#find_by_type
+        def find_by_type(type)
+          target = type.to_s
+          @data.each_with_object([]) do |(id, record), out|
+            next unless record['type'].to_s == target
+
+            out << record.except('updated_at').merge('id' => id)
+          end
+        end
+
+        # @see Interface#search
+        def search(query, fields: nil)
+          needle = query.to_s
+          @data.each_with_object([]) do |(id, record), out|
+            haystacks = fields ? fields.map { |f| record[f.to_s] } : [JSON.generate(record)]
+            next unless haystacks.compact.any? { |h| h.to_s.include?(needle) }
+
+            out << record.except('updated_at').merge('id' => id)
+          end
+        end
+
+        # @see Interface#delete
+        def delete(id)
+          @data.delete(id)
+        end
+
+        # @see Interface#count
+        def count
+          @data.size
+        end
+
+        private
+
+        # Match the SQLite adapter's string-key contract regardless of how
+        # the caller serialises the input hash. Without this, find/search
+        # consumers that expect string keys (the SQLite path round-trips
+        # through JSON, which always returns strings) would break under
+        # symbol-keyed test fixtures.
+        def stringify_keys(hash)
+          hash.each_with_object({}) { |(k, v), out| out[k.to_s] = v }
+        end
+      end
+
       # SQLite-backed metadata store using the JSON1 extension.
       #
       # Stores unit metadata as JSON in a single table with type indexing
@@ -100,7 +190,14 @@ module Woods
 
         # @param db_path [String] Path to the SQLite database file, or ":memory:" for in-memory
         def initialize(db_path = ':memory:')
-          require 'sqlite3'
+          begin
+            require 'sqlite3'
+          rescue LoadError
+            raise Woods::ConfigurationError,
+                  'metadata_store: :sqlite requires the sqlite3 gem in your Gemfile. ' \
+                  "Add `gem 'sqlite3'` and re-bundle, or set " \
+                  "`config.metadata_store = :in_memory` if you don't need cross-process persistence."
+          end
           @db = ::SQLite3::Database.new(db_path)
           @db.results_as_hash = true
           create_table

--- a/spec/storage/metadata_store_spec.rb
+++ b/spec/storage/metadata_store_spec.rb
@@ -174,5 +174,121 @@ RSpec.describe Woods::Storage::MetadataStore do
         expect(store.count).to eq(1)
       end
     end
+
+    describe 'missing sqlite3 gem' do
+      it 'raises a friendly Woods::ConfigurationError instead of LoadError' do
+        # Simulate the gem not being present in the host bundle.
+        original_method = Kernel.instance_method(:require)
+        allow_any_instance_of(Woods::Storage::MetadataStore::SQLite)
+          .to receive(:require).with('sqlite3').and_raise(LoadError)
+
+        expect { described_class.new(':memory:') }
+          .to raise_error(Woods::ConfigurationError, /sqlite3 gem.+Gemfile.+:in_memory/m)
+      ensure
+        Kernel.send(:define_method, :require, original_method) if original_method
+      end
+    end
+  end
+
+  describe Woods::Storage::MetadataStore::InMemory do
+    let(:store) { described_class.new }
+
+    # The in-memory adapter and the SQLite adapter must be substitutable
+    # — Builder picks one based on config without the rest of the pipeline
+    # caring. These specs lock the contract: same shape in, same shape out.
+
+    describe '#store / #count / #find' do
+      it 'tracks count and round-trips a record' do
+        expect(store.count).to eq(0)
+
+        store.store('User', { type: 'model', file_path: 'app/models/user.rb' })
+        expect(store.count).to eq(1)
+
+        result = store.find('User')
+        expect(result['type']).to eq('model')
+        expect(result['file_path']).to eq('app/models/user.rb')
+      end
+
+      it 'upserts on duplicate IDs' do
+        store.store('User', { type: 'model', version: 1 })
+        store.store('User', { type: 'model', version: 2 })
+
+        expect(store.count).to eq(1)
+        expect(store.find('User')['version']).to eq(2)
+      end
+
+      it 'returns nil for missing IDs' do
+        expect(store.find('Nonexistent')).to be_nil
+      end
+
+      it 'stringifies symbol keys to match the SQLite contract' do
+        store.store('User', { type: :model, namespace: :Admin })
+
+        result = store.find('User')
+        expect(result['type']).to eq(:model)
+        expect(result['namespace']).to eq(:Admin)
+      end
+    end
+
+    describe '#find_by_type' do
+      before do
+        store.store('User', { type: 'model' })
+        store.store('Order', { type: 'model' })
+        store.store('AuthService', { type: 'service' })
+      end
+
+      it 'returns all units of the given type' do
+        results = store.find_by_type('model')
+
+        expect(results.map { |r| r['id'] }).to contain_exactly('User', 'Order')
+      end
+
+      it 'accepts symbol types' do
+        expect(store.find_by_type(:service).map { |r| r['id'] }).to eq(['AuthService'])
+      end
+    end
+
+    describe '#search' do
+      before do
+        store.store('User', { type: 'model', description: 'User account model' })
+        store.store('AuthService', { type: 'service', description: 'Authentication service' })
+      end
+
+      it 'searches across all metadata fields by default' do
+        ids = store.search('account').map { |r| r['id'] }
+        expect(ids).to eq(['User'])
+      end
+
+      it 'restricts to specified fields when given' do
+        ids = store.search('account', fields: ['description']).map { |r| r['id'] }
+        expect(ids).to eq(['User'])
+      end
+
+      it 'returns empty when nothing matches' do
+        expect(store.search('nope')).to be_empty
+      end
+    end
+
+    describe '#delete' do
+      it 'removes a unit by ID' do
+        store.store('User', { type: 'model' })
+        store.delete('User')
+
+        expect(store.find('User')).to be_nil
+        expect(store.count).to eq(0)
+      end
+    end
+
+    describe '#find_batch' do
+      it 'returns a hash of id => record for found ids' do
+        store.store('User', { type: 'model' })
+        store.store('Order', { type: 'model' })
+
+        result = store.find_batch(%w[User Order Missing])
+
+        expect(result.keys).to contain_exactly('User', 'Order')
+        expect(result['User']['type']).to eq('model')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Two related fixes for hosts that don't bundle the `sqlite3` gem (MySQL- or Postgres-only Rails apps). Surfaced when admin (a MySQL host) tried to call `Builder#build_retriever` after PR #71 merged — the gem's wiring forced an `sqlite3` require that the host bundle couldn't satisfy.

## What's broken

### 1. `MetadataStore::InMemory` was referenced but didn't exist

`Builder#build_metadata_store` (`lib/woods/builder.rb:246`) has:

```ruby
case @config.metadata_store
when :in_memory then Storage::MetadataStore::InMemory.new
when :sqlite then Storage::MetadataStore::SQLite.new(...)
```

…but `Storage::MetadataStore::InMemory` was never defined. Selecting `:in_memory` would `NameError` at runtime. Probably never tripped because all three Builder `PRESETS` hardcode `:sqlite`.

### 2. Missing `sqlite3` produced an opaque `LoadError`

`MetadataStore::SQLite#initialize` did a bare `require 'sqlite3'` with no rescue, so MySQL/Postgres hosts got:

```
cannot load such file -- sqlite3 (LoadError)
  /usr/local/lib/ruby/3.4.0/bundled_gems.rb:82
```

…with no hint that this is a host-bundle issue or that an alternative exists.

## What's in this PR

| Change | File |
|---|---|
| Add pure-Ruby `MetadataStore::InMemory` adapter (no external deps, hash-backed, includes `Interface`) | `lib/woods/storage/metadata_store.rb` |
| Symbol-key stringification on store so `record['type']` works under either backend | same file |
| Friendly `Woods::ConfigurationError` when `:sqlite` is selected without sqlite3, pointing at `:in_memory` | same file |
| Conditional `Error`/`ConfigurationError` defines so the file can be required in isolation (matches the existing pattern in `console/eval_guard.rb`, `ast/parser.rb`, etc.) | same file |
| Full Interface contract specs for `InMemory` + symbol-key substitutability spec + friendly-error spec | `spec/storage/metadata_store_spec.rb` |
| Docs section for `:in_memory` + note on the SQLite section explaining the sqlite3 dependency | `docs/CONFIGURATION_REFERENCE.md` |

CLAUDE.md mandate: *"Backend agnostic — never hardcode or default to a single backend."* The missing `:in_memory` adapter and the opaque sqlite3 `LoadError` were the two remaining ways the gem still failed that test for non-SQLite hosts.

## Verification

- 4084 specs / 0 failures / 2 pending (the existing tiktoken_ruby pendings)
- RuboCop clean on all touched files
- Smoke: `Builder.new(config).build_retriever` with `config.metadata_store = :in_memory` returns a wired `Retriever` whose metadata store is `Woods::Storage::MetadataStore::InMemory` (was `NameError` before)

## Test plan

- [x] `bundle exec rake spec` passes
- [x] `bundle exec rubocop` passes
- [x] Smoke through `Builder#build_retriever` with the new `:in_memory` selection
- [x] Spec asserts the friendly error message when sqlite3 require fails

## Out of scope

- Changing `Builder::PRESETS[:local]` away from `:sqlite`. The preset is reasonable for hosts that already have sqlite3 (most Rails dev setups). Choosing `:in_memory` is a per-host decision, not a default to flip.
- Adding a `:mysql` metadata store. `docs/BACKEND_MATRIX.md` already mentions one as future work; that's a separate, much larger change.