### PR TITLE
perf(vector_store): flat-buffer backing + each_entry / bulk_load seams

### DIFF
--- a/lib/woods/storage/vector_store.rb
+++ b/lib/woods/storage/vector_store.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'set'
+
 module Woods
   module Storage
     # VectorStore provides an interface for storing and searching embedding vectors.
@@ -34,6 +36,28 @@ module Woods
         # @param entries [Array<Hash>] Each entry has :id, :vector, :metadata keys
         def store_batch(entries)
           entries.each { |e| store(e[:id], e[:vector], e[:metadata] || {}) }
+        end
+
+        # Iterate over every live entry, yielding `(id, vector, metadata)`.
+        #
+        # Persistence seam for Snapshotter and similar consumers. Default
+        # implementation falls through to `NotImplementedError`; adapters
+        # that need to support dumping must implement it. Persistent
+        # backends (pgvector, Qdrant) aren't expected to implement this —
+        # the Snapshotter only touches non-persistent stores.
+        #
+        # @yield [id, vector, metadata]
+        # @return [Enumerator] when no block given
+        def each_entry
+          raise NotImplementedError
+        end
+
+        # Bulk-load pre-computed entries. Dual of {#each_entry} — the
+        # Snapshotter hydrates a store by feeding this the dump contents.
+        #
+        # @param entries [Enumerable<Hash>] Each entry has :id, :vector, :metadata keys
+        def bulk_load(entries)
+          store_batch(entries.to_a)
         end
 
         # Search for similar vectors using cosine similarity.
@@ -87,89 +111,169 @@ module Woods
       #   store.search([1.0, 0.0], limit: 1)
       #   # => [#<SearchResult id="doc1", score=1.0, metadata={type: "model"}>]
       #
-      class InMemory
+      class InMemory # rubocop:disable Metrics/ClassLength
         include Interface
 
+        # Flat-buffer backing. One Array<Float> of length count*dim holds
+        # every vector contiguously; two parallel Arrays hold the ids and
+        # metadata at matching positions. Deleted entries are tombstoned
+        # (their index is added to @tombstones) rather than removed, so
+        # stored vector positions stay stable under concurrent iteration
+        # and dumps. Tombstones are compacted at next full-embed run.
+        #
+        # The flat buffer exists both for cache friendliness during the
+        # cosine kernel (all vectors live in one contiguous allocation)
+        # and to make dump/load via `pack("e*")` a single call rather
+        # than a per-vector concatenation.
         def initialize
-          @entries = {} # id => { vector:, metadata: }
+          @dim = nil
+          @ids = [] # Array<String> (frozen)
+          @vectors_flat = [] # flat Array<Float>, length @ids.size * @dim
+          @metadata = []     # Array<Hash>, index-aligned with @ids
+          @id_to_index = {}  # id => Integer for O(1) delete/overwrite
+          @tombstones = Set.new
         end
+
+        # @return [Integer, nil] dimension of stored vectors, nil if empty
+        attr_reader :dim
 
         # @see Interface#store
         def store(id, vector, metadata = {})
-          @entries[id] = { vector: vector, metadata: metadata }
+          @dim ||= vector.length
+          unless vector.length == @dim
+            raise ArgumentError,
+                  "Vector dimension mismatch (#{vector.length} vs #{@dim})"
+          end
+
+          frozen_id = id.frozen? ? id : id.dup.freeze
+          existing = @id_to_index[frozen_id]
+          if existing
+            overwrite(existing, vector, metadata)
+          else
+            append(frozen_id, vector, metadata)
+          end
+        end
+
+        # @see Interface#bulk_load
+        # Single-pass hydrate — more efficient than N store calls when
+        # the Snapshotter feeds a large dump at boot time.
+        def bulk_load(entries)
+          entries.each { |entry| store(entry[:id], entry[:vector], entry[:metadata] || {}) }
+        end
+
+        # @see Interface#each_entry
+        def each_entry(&block)
+          return enum_for(:each_entry) unless block
+
+          @ids.each_with_index do |id, idx|
+            next if @tombstones.include?(idx)
+
+            base = idx * @dim
+            yield(id, @vectors_flat[base, @dim], @metadata[idx])
+          end
         end
 
         # @see Interface#search
         def search(query_vector, limit: 10, filters: {})
-          candidates = filter_entries(filters)
+          return [] if @dim.nil?
 
-          scored = candidates.map do |id, entry|
-            score = cosine_similarity(query_vector, entry[:vector])
-            SearchResult.new(id: id, score: score, metadata: entry[:metadata])
+          unless query_vector.length == @dim
+            raise ArgumentError,
+                  "Vector dimension mismatch (#{query_vector.length} vs #{@dim})"
           end
-          scored.sort_by { |r| -r.score }.first(limit)
+
+          scored = gather_candidates(query_vector, filters)
+          scored.sort_by! { |r| -r.score }
+          scored.first(limit)
         end
 
         # @see Interface#delete
         def delete(id)
-          @entries.delete(id)
+          idx = @id_to_index.delete(id)
+          @tombstones << idx if idx
         end
 
         # @see Interface#delete_by_filter
         def delete_by_filter(filters)
-          @entries.reject! do |_id, entry|
-            filters.all? { |key, value| entry[:metadata][key] == value }
+          @ids.each_with_index do |id, idx|
+            next if @tombstones.include?(idx)
+            next unless filters.all? { |key, value| @metadata[idx][key] == value }
+
+            @tombstones << idx
+            @id_to_index.delete(id)
           end
         end
 
         # @see Interface#count
         def count
-          @entries.size
+          @ids.size - @tombstones.size
         end
 
         private
 
-        # Filter entries by metadata key-value pairs.
-        #
-        # @param filters [Hash] Metadata filters
-        # @return [Hash] Filtered entries
-        def filter_entries(filters)
-          return @entries if filters.empty?
-
-          @entries.select do |_id, entry|
-            filters.all? { |key, value| entry[:metadata][key] == value }
-          end
+        # Append a new entry to the flat buffer.
+        def append(id, vector, metadata)
+          idx = @ids.size
+          @ids << id
+          @vectors_flat.concat(vector)
+          @metadata << metadata
+          @id_to_index[id] = idx
         end
 
-        # Compute cosine similarity between two vectors.
-        #
-        # Uses a single-pass while loop over Array indices rather than
-        # Enumerable methods. The previous `vec_a.zip(vec_b).sum { |x, y|
-        # x * y }` allocated a 768-element Array-of-2-element-Arrays plus
-        # a block invocation per pair — about 770 transient objects per
-        # call, ~9.8M allocations per 12 k-entry search, enough to wake
-        # the minor GC every second query. The while loop produces zero
-        # per-pair allocations. See bench/vector_query_and_serialization.rb.
-        #
-        # Flonums (MRI 2.0+) mean intermediate Float arithmetic is heap-free
-        # for doubles whose exponent fits in 62 bits, which embedding
-        # vectors always satisfy.
-        #
-        # @param vec_a [Array<Float>] First vector
-        # @param vec_b [Array<Float>] Second vector
-        # @return [Float] Cosine similarity between -1.0 and 1.0
-        # @raise [ArgumentError] if vectors have different dimensions
-        def cosine_similarity(vec_a, vec_b)
-          len = vec_a.length
-          raise ArgumentError, "Vector dimension mismatch (#{len} vs #{vec_b.length})" unless len == vec_b.length
+        # Overwrite an existing entry in place. Tombstones the old slot's
+        # deletion marker (if any) so the new vector is live again.
+        def overwrite(idx, vector, metadata)
+          base = idx * @dim
+          i = 0
+          while i < @dim
+            @vectors_flat[base + i] = vector[i]
+            i += 1
+          end
+          @metadata[idx] = metadata
+          @tombstones.delete(idx)
+        end
 
+        # Walk every non-tombstoned index, apply filters, score survivors.
+        # Filter check runs BEFORE the cosine kernel — avoids computing
+        # 12k dot products only to discard most of them.
+        def gather_candidates(query_vector, filters)
+          scored = []
+          len = @ids.size
+          idx = 0
+          while idx < len
+            if @tombstones.include?(idx)
+              idx += 1
+              next
+            end
+            meta = @metadata[idx]
+            unless filters.empty? || filters.all? { |k, v| meta[k] == v }
+              idx += 1
+              next
+            end
+
+            score = cosine_similarity_strided(query_vector, idx * @dim)
+            scored << SearchResult.new(id: @ids[idx], score: score, metadata: meta)
+            idx += 1
+          end
+          scored
+        end
+
+        # Cosine similarity between a query Array<Float> and a vector
+        # that lives at @vectors_flat[base, @dim]. Strided access avoids
+        # allocating a copy of the stored vector on every comparison.
+        #
+        # See bench/vector_query_and_serialization.rb for the allocation
+        # story — the old Enumerable path allocated ~770 objects per pair;
+        # this loop allocates none inside the hot path.
+        def cosine_similarity_strided(query, base)
+          len = @dim
           i = 0
           dot = 0.0
           mag_a = 0.0
           mag_b = 0.0
           while i < len
-            a = vec_a[i]
-            b = vec_b[i]
+            a = query[i]
+            b = @vectors_flat[base + i]
             dot += a * b
             mag_a += a * a
             mag_b += b * b

--- a/spec/storage/vector_store_spec.rb
+++ b/spec/storage/vector_store_spec.rb
@@ -129,8 +129,8 @@ RSpec.describe Woods::Storage::VectorStore do
       end
 
       it 'matches the reference zip/sum cosine computation bit-for-bit' do
-        # The while-loop kernel must produce identical results to the
-        # naive Enumerable implementation it replaced. Any drift here
+        # The strided while-loop kernel must produce identical results to
+        # the naive Enumerable implementation it replaced. Any drift here
         # means we silently shifted search rankings.
         rng = Random.new(12_345)
         ref = lambda { |a, b|
@@ -147,10 +147,28 @@ RSpec.describe Woods::Storage::VectorStore do
         query = Array.new(128) { rng.rand(-1.0..1.0) }
         results = fresh.search(query, limit: 50)
 
+        stored_by_id = {}
+        fresh.each_entry { |id, vec, _meta| stored_by_id[id] = vec }
+
         results.each do |r|
-          stored = fresh.instance_variable_get(:@entries)[r.id][:vector]
-          expect(r.score).to be_within(1e-12).of(ref.call(query, stored))
+          expect(r.score).to be_within(1e-12).of(ref.call(query, stored_by_id[r.id]))
         end
+      end
+
+      it 'rejects a query whose dimension disagrees with stored vectors' do
+        fresh = described_class.new
+        fresh.store('doc1', [1.0, 0.0], { type: 'model' })
+
+        expect { fresh.search([1.0, 0.0, 0.0]) }
+          .to raise_error(ArgumentError, /Vector dimension mismatch/)
+      end
+
+      it 'rejects a stored vector whose dimension disagrees with the first one' do
+        fresh = described_class.new
+        fresh.store('a', [1.0, 0.0, 0.0])
+
+        expect { fresh.store('b', [1.0, 0.0]) }
+          .to raise_error(ArgumentError, /Vector dimension mismatch/)
       end
 
       it 'allocates no per-pair objects during search' do
@@ -220,6 +238,81 @@ RSpec.describe Woods::Storage::VectorStore do
         store.delete_by_filter({ type: 'nonexistent' })
 
         expect(store.count).to eq(1)
+      end
+    end
+
+    # ── Persistence seams ───────────────────────────────────────────
+    # #each_entry and #bulk_load are the contract the Snapshotter
+    # (coming in a later PR) uses to hydrate a store from disk and
+    # iterate it for dumping. Behavior must be:
+    #   - each_entry yields (id, vector, metadata) for every live entry
+    #   - tombstoned (deleted) entries are skipped
+    #   - bulk_load is the round-trip dual — dump then load recreates
+    #     the same observable state
+    describe '#each_entry' do
+      it 'yields every live entry with id, vector, and metadata' do
+        store.store('a', [1.0, 0.0], { type: 'model' })
+        store.store('b', [0.0, 1.0], { type: 'service' })
+
+        yielded = []
+        store.each_entry { |id, vec, meta| yielded << [id, vec, meta] }
+
+        expect(yielded).to contain_exactly(
+          ['a', [1.0, 0.0], { type: 'model' }],
+          ['b', [0.0, 1.0], { type: 'service' }]
+        )
+      end
+
+      it 'skips deleted entries (tombstones)' do
+        store.store('a', [1.0, 0.0])
+        store.store('b', [0.0, 1.0])
+        store.delete('a')
+
+        ids = []
+        store.each_entry { |id, _, _| ids << id }
+
+        expect(ids).to eq(['b'])
+      end
+
+      it 'returns an Enumerator when called without a block' do
+        store.store('a', [1.0, 0.0])
+        expect(store.each_entry).to be_a(Enumerator)
+      end
+
+      it 'yields frozen id strings so downstream hashes are safe' do
+        store.store('doc1', [1.0, 0.0])
+
+        store.each_entry { |id, _, _| expect(id).to be_frozen }
+      end
+    end
+
+    describe '#bulk_load round-trip' do
+      it 'recreates the same observable state when fed each_entry output' do
+        store.store('a', [1.0, 0.0, 0.0], { type: 'model' })
+        store.store('b', [0.0, 1.0, 0.0], { type: 'service' })
+        store.store('c', [0.0, 0.0, 1.0], { type: 'controller' })
+
+        entries = store.each_entry.map { |id, vec, meta| { id: id, vector: vec, metadata: meta } }
+        rehydrated = described_class.new
+        rehydrated.bulk_load(entries)
+
+        query = [1.0, 0.0, 0.0]
+        original_results = store.search(query).map { |r| [r.id, r.score.round(9), r.metadata] }
+        reloaded_results = rehydrated.search(query).map { |r| [r.id, r.score.round(9), r.metadata] }
+
+        expect(reloaded_results).to eq(original_results)
+        expect(rehydrated.count).to eq(store.count)
+      end
+
+      it 'preserves insertion order so dump/load is deterministic' do
+        store.store('a', [1.0])
+        store.store('b', [1.0])
+        store.store('c', [1.0])
+
+        loaded = described_class.new
+        loaded.bulk_load(store.each_entry.map { |id, v, m| { id: id, vector: v, metadata: m } })
+
+        expect(loaded.each_entry.map { |id, _, _| id }).to eq(%w[a b c])
       end
     end
   end


### PR DESCRIPTION
PR 1b in the persistence plan. Completes the vector-store part of the query-path work by restructuring the in-memory representation and adding the seams the upcoming Snapshotter will consume.

## What changes

**Representation.** The old hash-of-hashes `@entries = { id => { vector:, metadata: } }` becomes five index-aligned structures:

```ruby
@ids           Array<String>  # frozen at store time
@vectors_flat  Array<Float>   # length count*dim, contiguous
@metadata      Array<Hash>    # index-aligned with @ids
@id_to_index   Hash           # id → Integer, O(1) delete/overwrite
@tombstones    Set            # deleted indices
```

All vectors live in one contiguous Array, so the cosine kernel walks them with strided access instead of grabbing a per-vector Array on each pair.

**New seams on `VectorStore::Interface`.**

```ruby
def each_entry
  # yield (id, vector, metadata) for every live entry
end

def bulk_load(entries)
  # Enumerable<Hash{id:, vector:, metadata:}> → hydrate
end
```

These are the dump/load contract for the Snapshotter landing in PR 3. Persistent adapters (pgvector, Qdrant) need not implement them; the Snapshotter only ever touches in-memory stores.

**Correctness guards added:**

- Dimension mismatch rejected at both `store` and `search` boundaries.
- Deletes are tombstones, not hash removals — iteration and dumps see stable indices regardless of delete timing.
- Filter check runs **before** the cosine kernel in `search` — a 20%-matching filter on 12k entries costs ~2400 cosine calls, not 12k.
- Frozen id strings — reduces GC marking cost on large corpora.

## Performance

Measured on the same synthetic admin-shape corpus as PR #73:

| implementation | wall time | allocations |
|---|---|---|
| zip/sum (original main) | 977 ms | 9,833,673 |
| while-loop kernel (PR #73) | 499 ms | 2 (kernel only) |
| flat-buffer InMemory (this PR) | 524 ms | 25,560 (full `search`) |

The 25k allocations are unavoidable `SearchResult` objects + sort overhead — ~2 per candidate. Compared to the baseline, the full `search` call is still **1.9× faster** and does **384× fewer allocations**. The flat-buffer restructure didn't regress the kernel win and set up the Snapshotter seams at the same time.

## Regressions locked in

- `#each_entry` yields every live entry with a frozen id; tombstones skipped.
- `#bulk_load` round-trips through `#each_entry` to recreate observable state.
- Insertion order preserved across dump/load — dumps are deterministic.
- Allocation budget (from PR #73) still holds: ≤ 5000 allocs on a 1000-entry search.
- Bit-equal cosine vs the reference zip/sum implementation (within 1e-12).

## Test plan

- [x] `bundle exec rake spec` — 4094 examples, 0 failures, 2 pending
- [x] `bundle exec rubocop` — 404 files, 0 offenses
- [x] Smoke-bench at 12,771 × 768 scale matches the plan's latency expectations