### PR TITLE
feat(mcp): decomposed bootstrap flow — typed errors, ProviderProbe, IndexArtifact, Snapshotter seams

### DIFF
--- a/exe/woods-mcp
+++ b/exe/woods-mcp
@@ -23,9 +23,15 @@ require_relative '../lib/woods/embedding/indexer'
 # during MCP stdio transport. The notice fires when multi_json is in the bundle.
 JSON::Validator.use_multi_json = false if defined?(JSON::Validator) && JSON::Validator.respond_to?(:use_multi_json=)
 
-index_dir = Woods::MCP::Bootstrapper.resolve_index_dir(ARGV)
-retriever = Woods::MCP::Bootstrapper.build_retriever
-snapshot_store = Woods::MCP::Bootstrapper.build_snapshot_store(index_dir)
+begin
+  index_dir = Woods::MCP::Bootstrapper.resolve_index_dir(ARGV)
+  retriever, _bootstrap_state = Woods::MCP::Bootstrapper.build_retriever(index_dir: index_dir)
+  snapshot_store = Woods::MCP::Bootstrapper.build_snapshot_store(index_dir)
+rescue Woods::MCP::BootstrapError => e
+  warn "[woods-mcp] #{e.class.name.split('::').last}: #{e.message}"
+  warn "[woods-mcp] details: #{e.details.inspect}" if e.respond_to?(:details) && !e.details.empty?
+  exit 2
+end
 
 server = Woods::MCP::Server.build(index_dir: index_dir, retriever: retriever, snapshot_store: snapshot_store)
 

--- a/exe/woods-mcp-http
+++ b/exe/woods-mcp-http
@@ -22,9 +22,15 @@ require_relative '../lib/woods/mcp/origin_guard'
 require_relative '../lib/woods/embedding/text_preparer'
 require_relative '../lib/woods/embedding/indexer'
 
-index_dir = Woods::MCP::Bootstrapper.resolve_index_dir(ARGV)
-retriever = Woods::MCP::Bootstrapper.build_retriever
-snapshot_store = Woods::MCP::Bootstrapper.build_snapshot_store(index_dir)
+begin
+  index_dir = Woods::MCP::Bootstrapper.resolve_index_dir(ARGV)
+  retriever, _bootstrap_state = Woods::MCP::Bootstrapper.build_retriever(index_dir: index_dir)
+  snapshot_store = Woods::MCP::Bootstrapper.build_snapshot_store(index_dir)
+rescue Woods::MCP::BootstrapError => e
+  warn "[woods-mcp-http] #{e.class.name.split('::').last}: #{e.message}"
+  warn "[woods-mcp-http] details: #{e.details.inspect}" if e.respond_to?(:details) && !e.details.empty?
+  exit 2
+end
 
 port = (ENV['PORT'] || 9292).to_i
 host = ENV['HOST'] || 'localhost'

--- a/lib/woods/index_artifact.rb
+++ b/lib/woods/index_artifact.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require 'pathname'
+require 'json'
+require 'fileutils'
+require 'tempfile'
+
+module Woods
+  # Whole Value for the on-disk artifact layout under +output_dir+.
+  #
+  # Centralises all path derivation and atomic write operations so that no
+  # caller ever assembles paths by hand. The +dumps/latest+ pointer file
+  # provides cross-artifact atomicity: consumers always read the pointer
+  # first; the pointer is flipped last, after the dump directory is fully
+  # fsynced.
+  #
+  # @example Basic usage
+  #   artifact = Woods::IndexArtifact.new(output_dir)
+  #   return if artifact.fresh?
+  #   config = artifact.read_config
+  #   dump_dir = artifact.latest_dump_path
+  #
+  class IndexArtifact
+    # @param output_dir [String, Pathname] path to the extraction output directory
+    def initialize(output_dir)
+      @root = Pathname.new(output_dir.to_s)
+    end
+
+    # The extraction output directory root.
+    #
+    # @return [Pathname]
+    def output_dir
+      @root
+    end
+
+    # Path to the resolved config snapshot written by the embed run.
+    #
+    # @return [Pathname]
+    def config_path
+      @root.join('woods.json')
+    end
+
+    # Root of the per-run dump directories.
+    #
+    # @return [Pathname]
+    def dumps_root
+      @root.join('dumps')
+    end
+
+    # Path to the +dumps/latest+ pointer file (may not exist yet).
+    #
+    # @return [Pathname]
+    def latest_pointer_path
+      dumps_root.join('latest')
+    end
+
+    # Returns true when the artifact has never been populated — +woods.json+
+    # is absent AND the +dumps/latest+ pointer does not exist.
+    #
+    # Once either file is present the artifact is considered non-fresh; the
+    # Bootstrapper uses this to decide whether to raise {Woods::MCP::MissingArtifact}
+    # or proceed with loading.
+    #
+    # @return [Boolean]
+    def fresh?
+      !config_path.exist? && !latest_pointer_path.exist?
+    end
+
+    # Path to the latest complete dump directory, or +nil+.
+    #
+    # Returns +nil+ if the pointer file does not exist, if the pointer content
+    # is blank, or if the directory it names no longer exists (stale pointer).
+    #
+    # @return [Pathname, nil]
+    def latest_dump_path
+      return nil unless latest_pointer_path.exist?
+
+      dirname = latest_pointer_path.read.strip
+      return nil if dirname.empty?
+
+      dir = dumps_root.join(dirname)
+      dir.exist? ? dir : nil
+    end
+
+    # Reads and parses +woods.json+, returning the raw hash.
+    #
+    # Returns +nil+ when the file does not exist. Schema-version validation
+    # is the caller's responsibility (typically {Woods::ResolvedConfig.from_hash}).
+    #
+    # @return [Hash, nil]
+    def read_config
+      return nil unless config_path.exist?
+
+      JSON.parse(config_path.read)
+    end
+
+    # Creates a new timestamped dump directory and returns its path.
+    #
+    # The directory is created immediately so callers can begin writing into
+    # it. +dumps_root+ is created on demand. Directory names use dashes in
+    # place of colons for filesystem compatibility (+%H-%M-%SZ+ not
+    # +%H:%M:%SZ+).
+    #
+    # @param now [Time] timestamp to use for the directory name (default: UTC now)
+    # @return [Pathname]
+    # @raise [Errno::EEXIST] if the target directory already exists
+    def new_dump_dir(now: Time.now.utc)
+      dirname = now.strftime('%Y-%m-%dT%H-%M-%SZ')
+      dir = dumps_root.join(dirname)
+      FileUtils.mkdir_p(dumps_root)
+      Dir.mkdir(dir.to_s)
+      dir
+    end
+
+    # Atomically flips the +latest+ pointer to the given dump directory.
+    #
+    # Uses a temp file + +File.rename+ so a crash mid-flip leaves the previous
+    # pointer intact. +dump_dir+ must exist and resolve to a path inside
+    # +dumps_root+.
+    #
+    # @param dump_dir [Pathname, String] completed dump directory to promote
+    # @return [void]
+    # @raise [ArgumentError] if +dump_dir+ does not exist or is outside +dumps_root+
+    def promote(dump_dir)
+      target = Pathname.new(dump_dir.to_s)
+      root_real = dumps_root.expand_path.to_s
+      target_real = target.exist? ? target.realpath.to_s : ''
+      # Resolve symlinks on both sides before comparing (handles macOS /tmp → /private/var)
+      root_resolved = Pathname.new(root_real).exist? ? Pathname.new(root_real).realpath.to_s : root_real
+      unless target.exist? && target_real.start_with?(root_resolved)
+        raise ArgumentError,
+              'dump_dir must exist inside dumps_root. ' \
+              "Got: #{dump_dir.inspect}, dumps_root: #{dumps_root}"
+      end
+
+      atomic_write(latest_pointer_path, target.basename.to_s)
+    end
+
+    # Atomically writes a resolved config hash as +woods.json+.
+    #
+    # Accepts either a +ResolvedConfig+ (responds to +#to_snapshot_json+) or
+    # a plain +Hash+.
+    #
+    # @param resolved_config_hash [#to_snapshot_json, Hash]
+    # @return [void]
+    def write_config(resolved_config_hash)
+      json = if resolved_config_hash.respond_to?(:to_snapshot_json)
+               resolved_config_hash.to_snapshot_json
+             else
+               JSON.pretty_generate(resolved_config_hash)
+             end
+      atomic_write(config_path, json)
+    end
+
+    private
+
+    def atomic_write(path, content)
+      FileUtils.mkdir_p(path.dirname)
+      tmp = Tempfile.new('.woods-', path.dirname.to_s)
+      tmp.write(content)
+      tmp.flush
+      tmp.fsync
+      tmp.close
+      File.rename(tmp.path, path.to_s)
+    rescue StandardError
+      tmp&.close
+      tmp&.unlink
+      raise
+    end
+  end
+end

--- a/lib/woods/mcp/bootstrap_state.rb
+++ b/lib/woods/mcp/bootstrap_state.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'time'
+
+module Woods
+  module MCP
+    # Tracks the lifecycle state of an MCP server bootstrap sequence.
+    #
+    # Status transitions flow forward: +initializing+ → +hydrating+ →
+    # +hydrated+ (success path), or +initializing+/+hydrating+ → +degraded+
+    # (provider unreachable) or +failed+ (config-invalid). States are mutated
+    # via {#mark} so the +woods_status+ MCP tool always reads consistent values.
+    #
+    # @example Bootstrapper usage
+    #   state = Woods::MCP::BootstrapState.new
+    #   state.mark(:hydrating)
+    #   vector_store = Snapshotter::Vector.load_or_empty(artifact)
+    #   state.mark(:hydrated)
+    #   # or, on provider failure:
+    #   state.mark(:degraded, reason: ProviderUnreachable.new("..."))
+    #
+    class BootstrapState
+      VALID_STATUSES = %i[initializing hydrating hydrated degraded failed].freeze
+
+      # @return [Symbol] one of +:initializing+, +:hydrating+, +:hydrated+,
+      #   +:degraded+, +:failed+
+      attr_reader :status
+
+      # @return [Exception, nil] the exception that caused degradation or failure
+      attr_reader :reason
+
+      # @return [Time, nil] set when status transitions to +:hydrated+
+      attr_reader :hydrated_at
+
+      # @return [Time, nil] set when status transitions to +:degraded+
+      attr_reader :degraded_since
+
+      def initialize
+        @status = :initializing
+        @reason = nil
+        @hydrated_at = nil
+        @degraded_since = nil
+      end
+
+      # Transition to a new status.
+      #
+      # +hydrated_at+ is recorded on +:hydrated+; +degraded_since+ is recorded
+      # on +:degraded+. +reason:+ is accepted for +:degraded+ and +:failed+.
+      #
+      # @param new_status [Symbol] target status (must be in {VALID_STATUSES})
+      # @param reason [Exception, nil] causal exception for degraded/failed states
+      # @param now [Time] timestamp for the transition (default: UTC now)
+      # @return [self]
+      # @raise [ArgumentError] when +new_status+ is not a recognised status
+      def mark(new_status, reason: nil, now: Time.now.utc)
+        unless VALID_STATUSES.include?(new_status)
+          raise ArgumentError,
+                "Unknown status #{new_status.inspect}. " \
+                "Must be one of: #{VALID_STATUSES.map(&:inspect).join(', ')}"
+        end
+
+        @status = new_status
+        @reason = reason
+
+        case new_status
+        when :hydrated
+          @hydrated_at = now
+        when :degraded
+          @degraded_since = now
+        end
+
+        self
+      end
+
+      # Returns a hash suitable for embedding in a +woods_status+ MCP response.
+      #
+      # @return [Hash]
+      def to_h
+        h = { status: @status }
+        h[:reason] = "#{@reason.class}: #{@reason.message}" if @reason
+        h[:hydrated_at] = @hydrated_at.iso8601 if @hydrated_at
+        h[:degraded_since] = @degraded_since.iso8601 if @degraded_since
+        h
+      end
+    end
+  end
+end

--- a/lib/woods/mcp/bootstrapper.rb
+++ b/lib/woods/mcp/bootstrapper.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+require_relative 'errors'
+require_relative 'bootstrap_state'
+require_relative 'provider_probe'
+require_relative '../index_artifact'
+require_relative '../resolved_config'
+require_relative '../storage/snapshotter'
+
 module Woods
   module MCP
     # Shared setup logic for MCP server executables.
@@ -68,58 +75,59 @@ module Woods
         end
       end
 
-      # Attempt to build a retriever for semantic search.
+      # Build a retriever for MCP semantic search.
       #
-      # Auto-configures from environment variables when no explicit configuration
-      # exists. Probes for OpenAI API key first, then checks for a reachable Ollama
-      # instance. Emits a one-line STDERR banner indicating whether semantic search
-      # is enabled and which provider is active.
+      # Flow:
+      #   1. Wrap output_dir in an IndexArtifact (owns path semantics).
+      #   2. If woods.json is present, resolve config from it; otherwise
+      #      either raise MissingArtifact or, if WOODS_ALLOW_AUTODETECT=1,
+      #      fall back to env-var auto-detect (deprecated path).
+      #   3. Build provider + stores from config (no mutation of
+      #      Woods.configuration — the host's initializer stays intact).
+      #   4. Hydrate in-memory stores from dumps (stubs in PR 2; real in PR 3).
+      #   5. Probe the provider. If reachable, state :hydrated. If unreachable,
+      #      state :degraded — retriever is still returned, queries will
+      #      retry on first use.
       #
-      # @return [Woods::Retriever, nil]
-      def self.build_retriever
-        config = Woods.configuration
+      # Config-invalid failures raise typed BootstrapError subclasses;
+      # exe/woods-mcp's top-level catches them and prints a one-line
+      # operator message. Dependency-unreachable failures start degraded
+      # and surface via woods_status.
+      #
+      # @param index_dir [String, nil] Path to the extraction output directory.
+      #   When nil, uses Woods.configuration.output_dir.
+      # @return [Array(Woods::Retriever, Woods::MCP::BootstrapState)]
+      # @raise [Woods::MCP::BootstrapError] on config-invalid (missing
+      #   credentials, dimension mismatch, unsupported artifact, missing
+      #   artifact with autodetect off).
+      def self.build_retriever(index_dir: nil)
+        state = BootstrapState.new
+        state.mark(:hydrating)
 
-        openai_key = ENV.fetch('OPENAI_API_KEY', nil)
-        if !config.embedding_provider && openai_key
-          config.vector_store = :in_memory
-          config.metadata_store = :in_memory
-          config.graph_store = :in_memory
-          config.embedding_provider = :openai
-          config.embedding_options = { api_key: openai_key }
-        end
+        artifact = build_artifact(index_dir)
+        config = resolve_or_autodetect(artifact)
+        return [nil, state] unless config.embedding_provider
 
-        if !config.embedding_provider && ollama_reachable?
-          config.vector_store = :in_memory
-          config.metadata_store = :in_memory
-          config.graph_store = :in_memory
-          config.embedding_provider = :ollama
-          config.embedding_options = {
-            host: ENV.fetch('OLLAMA_BASE_URL', 'http://localhost:11434'),
-            model: ENV.fetch('OLLAMA_EMBED_MODEL', 'nomic-embed-text')
-          }
-        end
+        resolved = ResolvedConfig.from_configuration(config)
+        retriever = build_retriever_from_config(config, resolved, artifact)
+        probe_and_mark_state(config, state)
+        warn "[woods-mcp] semantic search: #{state.status} (#{config.embedding_provider})"
 
-        if config.embedding_provider
-          retriever = Woods::Builder.new(config).build_retriever
-          warn "[woods-mcp] semantic search: enabled (#{config.embedding_provider})"
-          retriever
-        else
-          warn '[woods-mcp] semantic search: disabled — set OPENAI_API_KEY, ' \
-               'or run Ollama (brew install ollama && ollama serve)'
-          nil
-        end
-      rescue StandardError => e
-        warn "Note: Semantic search unavailable (#{e.message}). Using pattern-based search only."
-        nil
+        [retriever, state]
+      end
+
+      # Backwards-compatible wrapper — existing callers (exe/woods-mcp and
+      # exe/woods-mcp-http) just want the retriever. They rescue typed
+      # BootstrapError at their own top level; we do not catch here.
+      def self.build_retriever_compat(index_dir: nil)
+        retriever, _state = build_retriever(index_dir: index_dir)
+        retriever
       end
 
       # Check whether Ollama is reachable at the configured base URL.
       #
-      # Uses a 500ms timeout so startup is not meaningfully delayed when Ollama
-      # is absent. Probes /api/tags (the documented list-models endpoint) so any
-      # running Ollama version responds. Treats any non-5xx response as reachable
-      # — we only care whether something is listening, not whether the response
-      # body is well-formed. Returns false on any network error or timeout.
+      # Kept for the legacy auto-detect path only. New code should use
+      # {Woods::MCP::ProviderProbe.reachable!} via the ResolvedConfig flow.
       #
       # @return [Boolean]
       def self.ollama_reachable?
@@ -138,6 +146,91 @@ module Woods
       rescue StandardError
         false
       end
+
+      # Resolve an IndexArtifact from the passed dir or Woods.configuration.
+      def self.build_artifact(index_dir)
+        dir = index_dir || Woods.configuration.output_dir
+        IndexArtifact.new(dir) if dir
+      end
+      private_class_method :build_artifact
+
+      # If the artifact has a woods.json, read it. Otherwise either
+      # raise MissingArtifact or — when WOODS_ALLOW_AUTODETECT=1 —
+      # fall through to env-var auto-detect. The env flag is opt-in
+      # because silent fallback was the failure mode we eliminated.
+      def self.resolve_or_autodetect(artifact)
+        config = Woods.configuration
+
+        if artifact && !artifact.fresh?
+          # Real config snapshot reading lands in PR 3 — for now, if the
+          # artifact has a woods.json we trust the host's initializer
+          # (which configured the provider) and skip autodetect.
+          return config
+        end
+
+        return config if config.embedding_provider
+
+        if ENV['WOODS_ALLOW_AUTODETECT'] != '1'
+          raise MissingArtifact.new(
+            'No woods.json found and WOODS_ALLOW_AUTODETECT is unset. ' \
+            'Run `bundle exec rake woods:extract` in your host app, or set ' \
+            'WOODS_ALLOW_AUTODETECT=1 to probe env vars (deprecated).',
+            details: { output_dir: artifact&.output_dir&.to_s }
+          )
+        end
+
+        warn '[woods-mcp] deprecated_autodetect: falling back to env-var auto-detect (no woods.json found)'
+        autodetect_config(config)
+      end
+      private_class_method :resolve_or_autodetect
+
+      # Legacy env-var auto-detect path. Only reachable when
+      # WOODS_ALLOW_AUTODETECT=1 and no woods.json is present. Mutates
+      # Woods.configuration — not great, but preserves the shape the
+      # HTTP entry point was written against. To be removed alongside
+      # the env-var path in a later PR.
+      def self.autodetect_config(config)
+        openai_key = ENV.fetch('OPENAI_API_KEY', nil)
+        if openai_key
+          config.vector_store = :in_memory
+          config.metadata_store = :in_memory
+          config.graph_store = :in_memory
+          config.embedding_provider = :openai
+          config.embedding_options = { api_key: openai_key }
+        elsif ollama_reachable?
+          config.vector_store = :in_memory
+          config.metadata_store = :in_memory
+          config.graph_store = :in_memory
+          config.embedding_provider = :ollama
+          config.embedding_options = {
+            host: ENV.fetch('OLLAMA_BASE_URL', 'http://localhost:11434'),
+            model: ENV.fetch('OLLAMA_EMBED_MODEL', 'nomic-embed-text')
+          }
+        end
+
+        config
+      end
+      private_class_method :autodetect_config
+
+      def self.build_retriever_from_config(config, _resolved, _artifact)
+        # Snapshotter hydration is stubbed in PR 2 — the Builder constructs
+        # empty InMemory stores, same as before. PR 3 wires in the real
+        # Snapshotter.load_or_empty call after build so the returned
+        # retriever sees hydrated vectors.
+        Woods::Builder.new(config).build_retriever
+      end
+      private_class_method :build_retriever_from_config
+
+      def self.probe_and_mark_state(config, state)
+        provider = Woods::Builder.new(config).build_embedding_provider
+        ProviderProbe.reachable!(provider)
+        state.mark(:hydrated)
+      rescue ProviderUnreachable => e
+        state.mark(:degraded, reason: e)
+        warn "[woods-mcp] provider unreachable at boot: #{e.url} (#{e.reason}); " \
+             'starting degraded — will retry on first query'
+      end
+      private_class_method :probe_and_mark_state
     end
   end
 end

--- a/lib/woods/mcp/errors.rb
+++ b/lib/woods/mcp/errors.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require_relative '../storage/inapplicable_backend'
+
+module Woods
+  module MCP
+    # Base class for all bootstrap-time failures in the MCP server.
+    #
+    # Inherits directly from {Woods::Error} — a sibling of {Woods::ConfigurationError},
+    # not a child. Artifact/runtime state errors grouped here do not describe
+    # declared-configuration problems, so grouping under ConfigurationError would
+    # mislead host apps that rescue it.
+    #
+    # Each subclass carries a +details+ hash with structured context for operator
+    # messages. The +exe/woods-mcp+ top-level rescue formats this into a one-line
+    # hint.
+    #
+    # @example Rescue in an MCP entry point
+    #   rescue Woods::MCP::BootstrapError => e
+    #     warn "woods-mcp: #{e.class}: #{e.message}"
+    #     exit 2
+    class BootstrapError < Woods::Error
+      # @return [Hash] Structured context for operator diagnostics
+      attr_reader :details
+
+      # @param message [String]
+      # @param details [Hash] Structured context (artifact paths, versions, etc.)
+      def initialize(message = nil, details: {})
+        super(message)
+        @details = details
+      end
+    end
+
+    # Raised when a required credential (e.g. OpenAI API key) is absent and
+    # cannot be resolved from the config snapshot or environment.
+    #
+    # @example
+    #   raise Woods::MCP::MissingCredential.new(
+    #     "OPENAI_API_KEY is required for OpenAI provider",
+    #     details: { credential: "OPENAI_API_KEY", provider: "openai" }
+    #   )
+    class MissingCredential < BootstrapError; end
+
+    # Raised when a stored config snapshot contradicts the active host config
+    # in a way that cannot be reconciled (e.g. provider class mismatch).
+    #
+    # @example
+    #   raise Woods::MCP::ConfigMismatch.new(
+    #     "Stored config uses Ollama but host config specifies OpenAI",
+    #     details: { stored: "Ollama", host: "OpenAI" }
+    #   )
+    class ConfigMismatch < BootstrapError; end
+
+    # Raised when the dimension recorded in the config snapshot or vector dump
+    # does not match the dimension reported by the active embedding provider.
+    #
+    # @example
+    #   raise Woods::MCP::DimensionMismatch.new(
+    #     "Provider dimension 1536 does not match stored dimension 768",
+    #     details: { expected: 768, actual: 1536 }
+    #   )
+    class DimensionMismatch < BootstrapError; end
+
+    # Raised when the +schema_version+ in +woods.json+ or a dump file is
+    # newer than the maximum version this gem release supports, or when the
+    # artifact header is corrupted and cannot be parsed.
+    #
+    # @example
+    #   raise Woods::MCP::UnsupportedArtifact.new(
+    #     "woods.json schema_version 3 > supported max 1",
+    #     details: { artifact_version: 3, max_supported: 1, path: config_path.to_s }
+    #   )
+    class UnsupportedArtifact < BootstrapError; end
+
+    # Raised when +woods.json+ is absent from +output_dir+ and the env flag
+    # +WOODS_ALLOW_AUTODETECT+ is not set. Hosts that have never run an embed
+    # see a clear failure message rather than silent degradation.
+    #
+    # @example
+    #   raise Woods::MCP::MissingArtifact.new(
+    #     "No woods.json found in /app/tmp/woods. Run `rake woods:embed` first.",
+    #     details: { output_dir: "/app/tmp/woods" }
+    #   )
+    class MissingArtifact < BootstrapError; end
+
+    # Raised when the configured embedding provider cannot be reached at boot.
+    # This is a **recoverable** sibling of {BootstrapError} — it is deliberately
+    # outside the BootstrapError hierarchy because the MCP server starts degraded
+    # and retries on first query rather than refusing to start.
+    #
+    # {Bootstrapper} catches this internally; nothing upstream should rescue it.
+    #
+    # @example
+    #   raise Woods::MCP::ProviderUnreachable.new(
+    #     "http://host.docker.internal:11434 refused connection",
+    #     details: { url: "http://host.docker.internal:11434", reason: "connection refused" }
+    #   )
+    class ProviderUnreachable < Woods::Error
+      # @return [String] URL that was probed
+      attr_reader :url
+      # @return [String] Machine-readable failure reason (e.g. "connection_refused",
+      #   "timeout", "http_500", "unauthorized", "dns_failure")
+      attr_reader :reason
+      # @return [Hash] Structured context forwarded to operators for diagnosis
+      attr_reader :details
+
+      # Supports two call styles:
+      #
+      #   Woods::MCP::ProviderUnreachable.new(url: "http://...", reason: "timeout")
+      #   Woods::MCP::ProviderUnreachable.new("message", details: { ... })
+      #
+      # The kwarg form is preferred — probes have url/reason in hand and the
+      # message is derived. The positional form exists for callers that
+      # already have a formatted message.
+      def initialize(message = nil, url: nil, reason: nil, details: {})
+        @url = url || details[:url] || details['url']
+        @reason = reason || details[:reason] || details['reason']
+        @details = details.dup
+        @details[:url] = @url if @url && !@details.key?(:url) && !@details.key?('url')
+        @details[:reason] = @reason if @reason && !@details.key?(:reason) && !@details.key?('reason')
+        super(message || default_message)
+      end
+
+      private
+
+      def default_message
+        return "#{@url}: #{@reason}" if @url && @reason
+        return "provider unreachable (#{@reason})" if @reason
+
+        'provider unreachable'
+      end
+    end
+  end
+end

--- a/lib/woods/mcp/provider_probe.rb
+++ b/lib/woods/mcp/provider_probe.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'uri'
+
+module Woods
+  module MCP
+    # Probes an embedding provider's HTTP endpoint to confirm it is reachable
+    # before the MCP server commits to a fully-hydrated start.
+    #
+    # A probe is pure: input → result-or-raise. No logging, no stderr writes,
+    # no side effects. The caller decides what to do with a failure.
+    #
+    # Raises {Woods::MCP::ProviderUnreachable} on any network failure with
+    # structured +url:+ and +reason:+ fields so callers can pattern-match on
+    # the reason string. Raises +ArgumentError+ for unknown provider classes —
+    # that is a programming error, not a runtime condition.
+    #
+    # @example
+    #   Woods::MCP::ProviderProbe.reachable!(provider)  # → provider or raises
+    module ProviderProbe
+      # Connect timeout for Ollama probes (LAN/localhost — fail fast).
+      OLLAMA_OPEN_TIMEOUT = 0.5
+      # Read timeout for Ollama probes.
+      OLLAMA_READ_TIMEOUT = 0.5
+
+      # Connect timeout for OpenAI probes (WAN — allow for latency).
+      OPENAI_OPEN_TIMEOUT = 2.0
+      # Read timeout for OpenAI probes.
+      OPENAI_READ_TIMEOUT = 2.0
+
+      # Probe +provider+ and return it if reachable.
+      #
+      # Dispatches on the provider's concrete class:
+      # - {Woods::Embedding::Provider::Ollama} → +GET /api/tags+ on the
+      #   configured host. Any non-5xx response is treated as reachable.
+      # - {Woods::Embedding::Provider::OpenAI} → +GET /v1/models+ on
+      #   +api.openai.com:443+. A 401 response raises +ProviderUnreachable+
+      #   with +reason: "unauthorized"+ because an invalid key means the
+      #   provider cannot be used; network failures raise with the appropriate
+      #   reason string.
+      # - Any other class → raises +ArgumentError+.
+      #
+      # @param provider [Woods::Embedding::Provider::Ollama,
+      #   Woods::Embedding::Provider::OpenAI] a concrete embedding provider
+      # @return [Object] the same +provider+ if reachable
+      # @raise [Woods::MCP::ProviderUnreachable] if the endpoint is unreachable,
+      #   times out, returns 5xx, or (for OpenAI) returns 401
+      # @raise [ArgumentError] if +provider+ is not a recognised provider class
+      def self.reachable!(provider)
+        case provider
+        when Woods::Embedding::Provider::Ollama
+          probe_ollama!(provider)
+        when Woods::Embedding::Provider::OpenAI
+          probe_openai!(provider)
+        else
+          raise ArgumentError,
+                "#{self}.reachable! does not know how to probe #{provider.class} — " \
+                'add a provider-specific probe method or implement #probe_url'
+        end
+        provider
+      end
+
+      # Probe the Ollama instance backing +provider+.
+      #
+      # @param provider [Woods::Embedding::Provider::Ollama]
+      # @raise [Woods::MCP::ProviderUnreachable]
+      # @api private
+      def self.probe_ollama!(provider)
+        base_url = provider.instance_variable_get(:@host)
+        http_get!(base_url, '/api/tags',
+                  open_timeout: OLLAMA_OPEN_TIMEOUT,
+                  read_timeout: OLLAMA_READ_TIMEOUT,
+                  use_ssl: URI.parse(base_url).scheme == 'https') do |response|
+          if response.is_a?(Net::HTTPServerError)
+            raise Woods::MCP::ProviderUnreachable.new(
+              url: base_url,
+              reason: 'http_500'
+            )
+          end
+        end
+      end
+      private_class_method :probe_ollama!
+
+      # Probe the OpenAI API endpoint.
+      #
+      # A 401 Unauthorized response is treated as +ProviderUnreachable+ with
+      # +reason: "unauthorized"+ — the key is invalid and the provider cannot
+      # serve requests.
+      #
+      # @param provider [Woods::Embedding::Provider::OpenAI]
+      # @raise [Woods::MCP::ProviderUnreachable]
+      # @api private
+      def self.probe_openai!(_provider)
+        base_url = 'https://api.openai.com'
+        http_get!(base_url, '/v1/models',
+                  open_timeout: OPENAI_OPEN_TIMEOUT,
+                  read_timeout: OPENAI_READ_TIMEOUT,
+                  use_ssl: true) do |response|
+          if response.is_a?(Net::HTTPUnauthorized)
+            raise Woods::MCP::ProviderUnreachable.new(
+              url: base_url,
+              reason: 'unauthorized'
+            )
+          end
+
+          if response.is_a?(Net::HTTPServerError)
+            raise Woods::MCP::ProviderUnreachable.new(
+              url: base_url,
+              reason: 'http_500'
+            )
+          end
+        end
+      end
+      private_class_method :probe_openai!
+
+      # Execute +GET path+ against +base_url+ and yield the response to the
+      # caller's block for provider-specific checks.
+      #
+      # All network-level exceptions are translated into
+      # {Woods::MCP::ProviderUnreachable} with a machine-readable reason
+      # string before propagating.
+      #
+      # @param base_url [String] scheme + host + optional port
+      # @param path [String] request path
+      # @param open_timeout [Numeric]
+      # @param read_timeout [Numeric]
+      # @param use_ssl [Boolean]
+      # @yieldparam response [Net::HTTPResponse]
+      # @raise [Woods::MCP::ProviderUnreachable]
+      # @api private
+      def self.http_get!(base_url, path, open_timeout:, read_timeout:, use_ssl:)
+        uri = URI.parse(base_url)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.open_timeout = open_timeout
+        http.read_timeout = read_timeout
+        http.use_ssl = use_ssl
+
+        response = http.start { |h| h.get(path) }
+        yield response
+      rescue Errno::ECONNREFUSED, Errno::ECONNRESET
+        raise Woods::MCP::ProviderUnreachable.new(url: base_url, reason: 'connection_refused')
+      rescue Net::OpenTimeout, Errno::ETIMEDOUT, Net::ReadTimeout
+        raise Woods::MCP::ProviderUnreachable.new(url: base_url, reason: 'timeout')
+      rescue SocketError
+        raise Woods::MCP::ProviderUnreachable.new(url: base_url, reason: 'dns_failure')
+      end
+      private_class_method :http_get!
+    end
+  end
+end

--- a/lib/woods/resolved_config.rb
+++ b/lib/woods/resolved_config.rb
@@ -1,0 +1,258 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'time'
+require_relative 'mcp/errors'
+
+module Woods
+  # Immutable Whole Value representing the resolved embedding configuration
+  # captured at embed time and read back by the MCP server at boot.
+  #
+  # This is NOT a declared-config bag of fields — it records what was
+  # *actually used* during embedding (provider class, model, host, dimension,
+  # store types). The MCP server compares a stored {ResolvedConfig} against
+  # the current host config to detect incompatible re-deployments.
+  #
+  # Build via {.from_hash} (parses +woods.json+) or {.from_configuration}
+  # (captures the current {Woods::Configuration} at embed time).
+  #
+  # @example Parsing woods.json
+  #   config = Woods::ResolvedConfig.from_hash(JSON.parse(File.read("woods.json")))
+  #   config.dimension          # => 768
+  #   config.provider_signature # => "Ollama/nomic-embed-text@http://host.docker.internal:11434"
+  #
+  # @example Asserting compatibility before hydrating stores
+  #   stored = Woods::ResolvedConfig.from_hash(snapshot)
+  #   live   = Woods::ResolvedConfig.from_configuration(Woods.configuration)
+  #   live.assert_compatible!(stored)
+  class ResolvedConfig # rubocop:disable Metrics/ClassLength
+    # The only schema version this gem release can read or write.
+    SCHEMA_VERSION_SUPPORTED = 1
+
+    # @return [Integer]
+    attr_reader :schema_version
+
+    # @return [String] Gem version at embed time (e.g. "1.2.0")
+    attr_reader :gem_version
+
+    # @return [Time]
+    attr_reader :created_at
+
+    # @return [Hash] Provider details — :class, :model, :host, :num_ctx, :read_timeout, :dimension
+    attr_reader :embedding_provider
+
+    # @return [Hash] Store types — :vector_store, :metadata_store, :graph_store (Symbols)
+    attr_reader :stores
+
+    # Parse a +woods.json+ hash into a {ResolvedConfig}.
+    #
+    # @param raw [Hash] Parsed JSON hash (string or symbol keys)
+    # @return [ResolvedConfig]
+    # @raise [Woods::MCP::UnsupportedArtifact] if schema_version is not supported
+    def self.from_hash(raw)
+      data = normalize_keys(raw)
+      validate_schema_version!(data[:schema_version].to_i)
+
+      new(
+        schema_version: data[:schema_version].to_i,
+        gem_version: data[:gem_version].to_s,
+        created_at: parse_time(data[:created_at]),
+        embedding_provider: parse_provider(data[:embedding_provider] || {}),
+        stores: parse_stores(data[:stores] || {})
+      )
+    end
+
+    # Capture the current {Woods::Configuration} as a {ResolvedConfig}.
+    #
+    # @param config [Woods::Configuration]
+    # @param gem_version [String] Defaults to {Woods::VERSION}
+    # @return [ResolvedConfig]
+    def self.from_configuration(config, gem_version: nil) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+      require_relative 'version'
+
+      opts = config.embedding_options || {}
+      dim = opts[:dimension] || opts['dimension']
+
+      provider = {
+        class: resolve_provider_class(config.embedding_provider),
+        model: (opts[:model] || opts['model'] || config.embedding_model).to_s,
+        dimension: dim.to_i,
+        host: opts[:host] || opts['host'],
+        num_ctx: opts[:num_ctx] || opts['num_ctx'],
+        read_timeout: opts[:read_timeout] || opts['read_timeout']
+      }.compact
+
+      new(
+        schema_version: SCHEMA_VERSION_SUPPORTED,
+        gem_version: (gem_version || Woods::VERSION).to_s,
+        created_at: Time.now.utc,
+        embedding_provider: provider,
+        stores: {
+          vector_store: config.vector_store,
+          metadata_store: config.metadata_store,
+          graph_store: config.graph_store
+        }
+      )
+    end
+
+    # @param schema_version [Integer]
+    # @param gem_version [String]
+    # @param created_at [Time]
+    # @param embedding_provider [Hash]
+    # @param stores [Hash]
+    def initialize(schema_version:, gem_version:, created_at:, embedding_provider:, stores:)
+      @schema_version = schema_version
+      @gem_version = gem_version.to_s.freeze
+      @created_at = created_at
+      @embedding_provider = embedding_provider.transform_values { |val| val.is_a?(String) ? val.freeze : val }.freeze
+      @stores = stores.freeze
+      freeze
+    end
+
+    # @return [Integer] Embedding dimension declared by the provider
+    def dimension
+      embedding_provider[:dimension].to_i
+    end
+
+    # Short string identifying this provider configuration, useful for log
+    # messages and {ConfigMismatch} error text.
+    #
+    # @return [String] e.g. "Ollama/nomic-embed-text@http://host.docker.internal:11434"
+    def provider_signature
+      klass = embedding_provider[:class].to_s.split('::').last
+      model = embedding_provider[:model]
+      host  = embedding_provider[:host]
+      host ? "#{klass}/#{model}@#{host}" : "#{klass}/#{model}"
+    end
+
+    # Returns +true+ if +other+ uses the same provider class, model, dimension,
+    # and store types. Ignores gem version, read_timeout, num_ctx, and created_at.
+    #
+    # @param other [ResolvedConfig]
+    # @return [Boolean]
+    def matches?(other)
+      embedding_provider[:class] == other.embedding_provider[:class] &&
+        embedding_provider[:model] == other.embedding_provider[:model] &&
+        dimension == other.dimension &&
+        stores[:vector_store] == other.stores[:vector_store] &&
+        stores[:metadata_store] == other.stores[:metadata_store] &&
+        stores[:graph_store] == other.stores[:graph_store]
+    end
+
+    # Assert that +stored_config+ (the config captured at embed time) is
+    # compatible with +self+ (the live host config). Raises typed errors
+    # so the operator can diagnose the mismatch without reading source.
+    #
+    # @param stored_config [ResolvedConfig]
+    # @raise [Woods::MCP::DimensionMismatch] if dimensions differ
+    # @raise [Woods::MCP::ConfigMismatch] if provider class or model differs
+    # @return [void]
+    def assert_compatible!(stored_config)
+      assert_dimensions_match!(stored_config)
+      assert_provider_matches!(stored_config)
+    end
+
+    # Serialize to a Hash suitable for +JSON.generate+ and round-trippable
+    # through {.from_hash}.
+    #
+    # @return [Hash]
+    def to_snapshot_json
+      {
+        'schema_version' => schema_version,
+        'gem_version' => gem_version,
+        'created_at' => created_at.iso8601,
+        'embedding_provider' => embedding_provider.transform_keys(&:to_s),
+        'stores' => stores.transform_keys(&:to_s).transform_values(&:to_s)
+      }
+    end
+
+    # @return [Hash]
+    def to_h
+      to_snapshot_json.freeze
+    end
+
+    private
+
+    def assert_dimensions_match!(stored_config)
+      return if dimension == stored_config.dimension
+
+      raise Woods::MCP::DimensionMismatch.new(
+        "Provider dimension #{dimension} does not match stored dimension #{stored_config.dimension}. " \
+        'Re-run `rake woods:embed` to rebuild the index.',
+        details: {
+          expected: stored_config.dimension,
+          actual: dimension,
+          stored_at: stored_config.created_at.iso8601
+        }
+      )
+    end
+
+    def assert_provider_matches!(stored_config)
+      return if embedding_provider[:class] == stored_config.embedding_provider[:class] &&
+                embedding_provider[:model] == stored_config.embedding_provider[:model]
+
+      raise Woods::MCP::ConfigMismatch.new(
+        "Host provider #{provider_signature} does not match stored provider #{stored_config.provider_signature}. " \
+        'Re-run `rake woods:embed` or align host configuration.',
+        details: {
+          host: provider_signature,
+          stored: stored_config.provider_signature,
+          stored_at: stored_config.created_at.iso8601
+        }
+      )
+    end
+
+    class << self
+      private
+
+      def validate_schema_version!(version)
+        return if version == SCHEMA_VERSION_SUPPORTED
+
+        raise Woods::MCP::UnsupportedArtifact.new(
+          "woods.json schema_version #{version} is not supported (supported: #{SCHEMA_VERSION_SUPPORTED})",
+          details: { found: version, supported: SCHEMA_VERSION_SUPPORTED }
+        )
+      end
+
+      def parse_provider(raw)
+        data = normalize_keys(raw)
+        {
+          class: data[:class].to_s,
+          model: data[:model].to_s,
+          dimension: data[:dimension].to_i,
+          host: data[:host],
+          num_ctx: data[:num_ctx],
+          read_timeout: data[:read_timeout]
+        }.compact
+      end
+
+      def parse_stores(raw)
+        data = normalize_keys(raw)
+        {
+          vector_store: data[:vector_store]&.to_sym,
+          metadata_store: data[:metadata_store]&.to_sym,
+          graph_store: data[:graph_store]&.to_sym
+        }
+      end
+
+      def parse_time(value)
+        value ? Time.parse(value.to_s) : Time.now.utc
+      end
+
+      def normalize_keys(hash)
+        hash.transform_keys(&:to_sym)
+      end
+
+      def resolve_provider_class(provider)
+        case provider
+        when :openai then 'Woods::Embedding::Provider::OpenAI'
+        when :ollama then 'Woods::Embedding::Provider::Ollama'
+        when String  then provider
+        when Class   then provider.name
+        when nil     then ''
+        else provider.to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/woods/storage/inapplicable_backend.rb
+++ b/lib/woods/storage/inapplicable_backend.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Woods
+  class Error < StandardError; end unless defined?(Woods::Error)
+
+  module Storage
+    # Raised when a Snapshotter is applied to a persistent backend adapter
+    # (e.g. pgvector, Qdrant, SQLite). Snapshotters only operate on in-memory
+    # stores; persistent adapters manage their own durability.
+    #
+    # Named so that tests can assert it rather than catching a bare {Woods::Error}.
+    class InapplicableBackend < Woods::Error; end
+  end
+end

--- a/lib/woods/storage/snapshotter.rb
+++ b/lib/woods/storage/snapshotter.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'woods/storage/snapshotter/vector'
+require 'woods/storage/snapshotter/metadata'
+
+module Woods
+  module Storage
+    # Namespace for the Snapshotter pair that persists and hydrates in-memory
+    # storage adapters to/from disk.
+    #
+    # Two adapters live here:
+    # - {Snapshotter::Vector} — handles {VectorStore::InMemory} round-trips via +pack("e*")+.
+    # - {Snapshotter::Metadata} — handles {MetadataStore::InMemory} round-trips via MessagePack.
+    #
+    # Persistent backends (pgvector, Qdrant, SQLite) never touch the Snapshotter.
+    # Passing one to {Snapshotter::Vector.dump} or {Snapshotter::Metadata.dump} raises
+    # {InapplicableBackend} immediately.
+    #
+    # PR 2 ships stub implementations: +load_or_empty+ always returns an empty store
+    # and +dump+ is a validated no-op. PR 3 wires in the real serialization paths.
+    module Snapshotter
+    end
+  end
+end

--- a/lib/woods/storage/snapshotter/metadata.rb
+++ b/lib/woods/storage/snapshotter/metadata.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'pathname'
+require 'woods/storage/metadata_store'
+require 'woods/mcp/errors'
+
+module Woods
+  module Storage
+    module Snapshotter
+      # Stub implementation of the metadata store snapshotter for PR 2.
+      #
+      # +load_or_empty+ always returns a fresh {MetadataStore::InMemory} — the real
+      # MessagePack read path is wired in PR 3.
+      #
+      # +dump+ is a validated no-op — the real write path (+metadata.msgpack+) is
+      # wired in PR 3.
+      #
+      # Input validation IS load-bearing even for stubs:
+      # - Raises {InapplicableBackend} if +store+ does not respond to both +#each_entry+
+      #   and +#bulk_load+ (the persistence seam contract).
+      # - Raises +ArgumentError+ if +dump_dir+ is not under +artifact.dumps_root+.
+      #
+      # @see Snapshotter::Vector companion class for vector stores
+      module Metadata
+        # Returns an empty in-memory metadata store.
+        #
+        # PR 3 will replace this stub with a real MessagePack read of +metadata.msgpack+
+        # from +artifact.latest_dump_path+. Callers must not assume the store is populated.
+        #
+        # @param artifact [Woods::IndexArtifact] the artifact layout object
+        # @param resolved_config [#dimension, nil] reserved for PR 3 dimension validation
+        # @return [Woods::Storage::MetadataStore::InMemory]
+        def self.load_or_empty(artifact, resolved_config: nil) # rubocop:disable Lint/UnusedMethodArgument
+          MetadataStore::InMemory.new
+        end
+
+        # No-op dump — validates inputs then returns without writing anything.
+        #
+        # PR 3 will replace the body with real MessagePack serialization.
+        #
+        # @param store [#each_entry, #bulk_load] an in-memory MetadataStore adapter
+        # @param artifact [Woods::IndexArtifact] the artifact layout object
+        # @param dump_dir [Pathname, String] target directory; must be under +artifact.dumps_root+
+        # @return [void]
+        # @raise [Woods::Storage::InapplicableBackend] if +store+ lacks +#each_entry+ or +#bulk_load+
+        # @raise [ArgumentError] if +dump_dir+ is not under +artifact.dumps_root+
+        def self.dump(store, artifact, dump_dir)
+          validate_store!(store)
+          validate_dump_dir!(artifact, dump_dir)
+          # no-op: real write path wired in PR 3
+        end
+
+        class << self
+          private
+
+          def validate_store!(store)
+            return if store.respond_to?(:each_entry) && store.respond_to?(:bulk_load)
+
+            raise InapplicableBackend,
+                  "backend #{store.class} is already durable — Snapshotter should not have been invoked"
+          end
+
+          def validate_dump_dir!(artifact, dump_dir)
+            dump_path = Pathname.new(dump_dir.to_s).expand_path
+            root = artifact.dumps_root.expand_path
+
+            return if dump_path.to_s.start_with?("#{root}/") || dump_path == root
+
+            raise ArgumentError,
+                  "dump_dir #{dump_path} is not under artifact.dumps_root #{root}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/woods/storage/snapshotter/vector.rb
+++ b/lib/woods/storage/snapshotter/vector.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'pathname'
+require 'woods/storage/vector_store'
+require 'woods/mcp/errors'
+
+module Woods
+  module Storage
+    module Snapshotter
+      # Stub implementation of the vector store snapshotter for PR 2.
+      #
+      # +load_or_empty+ always returns a fresh {VectorStore::InMemory} — the real
+      # pack("e*") read path is wired in PR 3.
+      #
+      # +dump+ is a validated no-op — the real write path (+vectors.bin+ + +vectors.idx+)
+      # is wired in PR 3.
+      #
+      # Input validation IS load-bearing even for stubs:
+      # - Raises {InapplicableBackend} if +store+ does not respond to both +#each_entry+
+      #   and +#bulk_load+ (the persistence seam contract).
+      # - Raises +ArgumentError+ if +dump_dir+ is not under +artifact.dumps_root+.
+      #
+      # @see Snapshotter::Metadata companion class for metadata stores
+      module Vector
+        # Returns an empty in-memory vector store.
+        #
+        # PR 3 will replace this stub with a real read of +vectors.bin+ from
+        # +artifact.latest_dump_path+. Callers must not assume the store is populated.
+        #
+        # @param artifact [Woods::IndexArtifact] the artifact layout object
+        # @param resolved_config [#dimension, nil] reserved for PR 3 dimension validation
+        # @return [Woods::Storage::VectorStore::InMemory]
+        def self.load_or_empty(artifact, resolved_config: nil) # rubocop:disable Lint/UnusedMethodArgument
+          VectorStore::InMemory.new
+        end
+
+        # No-op dump — validates inputs then returns without writing anything.
+        #
+        # PR 3 will replace the body with real +pack("e*")+ + header + idx writes.
+        #
+        # @param store [#each_entry, #bulk_load] an in-memory VectorStore adapter
+        # @param artifact [Woods::IndexArtifact] the artifact layout object
+        # @param dump_dir [Pathname, String] target directory; must be under +artifact.dumps_root+
+        # @return [void]
+        # @raise [Woods::Storage::InapplicableBackend] if +store+ lacks +#each_entry+ or +#bulk_load+
+        # @raise [ArgumentError] if +dump_dir+ is not under +artifact.dumps_root+
+        def self.dump(store, artifact, dump_dir)
+          validate_store!(store)
+          validate_dump_dir!(artifact, dump_dir)
+          # no-op: real write path wired in PR 3
+        end
+
+        class << self
+          private
+
+          def validate_store!(store)
+            return if store.respond_to?(:each_entry) && store.respond_to?(:bulk_load)
+
+            raise InapplicableBackend,
+                  "backend #{store.class} is already durable — Snapshotter should not have been invoked"
+          end
+
+          def validate_dump_dir!(artifact, dump_dir)
+            dump_path = Pathname.new(dump_dir.to_s).expand_path
+            root = artifact.dumps_root.expand_path
+
+            return if dump_path.to_s.start_with?("#{root}/") || dump_path == root
+
+            raise ArgumentError,
+                  "dump_dir #{dump_path} is not under artifact.dumps_root #{root}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/index_artifact_spec.rb
+++ b/spec/index_artifact_spec.rb
@@ -1,0 +1,285 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+require 'json'
+require 'woods'
+require 'woods/index_artifact'
+
+RSpec.describe Woods::IndexArtifact do
+  subject(:artifact) { described_class.new(tmpdir) }
+
+  let(:tmpdir) { Dir.mktmpdir }
+
+  after { FileUtils.rm_rf(tmpdir) }
+
+  describe '#output_dir' do
+    it 'returns a Pathname equal to the constructor argument' do
+      expect(artifact.output_dir).to eq(Pathname.new(tmpdir))
+    end
+  end
+
+  describe '#config_path' do
+    it 'returns a Pathname under output_dir named woods.json' do
+      expect(artifact.config_path).to eq(Pathname.new(tmpdir).join('woods.json'))
+    end
+  end
+
+  describe '#dumps_root' do
+    it 'returns a Pathname named dumps under output_dir' do
+      expect(artifact.dumps_root).to eq(Pathname.new(tmpdir).join('dumps'))
+    end
+  end
+
+  describe '#latest_pointer_path' do
+    it 'returns a Pathname for dumps/latest (may not exist)' do
+      expect(artifact.latest_pointer_path).to eq(Pathname.new(tmpdir).join('dumps', 'latest'))
+    end
+  end
+
+  describe '#fresh?' do
+    context 'when neither woods.json nor dumps/latest exists' do
+      it 'returns true' do
+        expect(artifact.fresh?).to be(true)
+      end
+    end
+
+    context 'when woods.json exists but dumps/latest does not' do
+      before { artifact.write_config('schema_version' => 1) }
+
+      it 'returns false — artifact is non-fresh once config is written' do
+        expect(artifact.fresh?).to be(false)
+      end
+    end
+
+    context 'when dumps/latest exists but woods.json does not' do
+      before do
+        FileUtils.mkdir_p(artifact.dumps_root)
+        File.write(artifact.latest_pointer_path, '2026-04-23T03-42-17Z')
+      end
+
+      it 'returns false — presence of the pointer alone marks the artifact non-fresh' do
+        expect(artifact.fresh?).to be(false)
+      end
+    end
+
+    context 'when both woods.json and dumps/latest exist' do
+      before do
+        artifact.write_config('schema_version' => 1)
+        FileUtils.mkdir_p(artifact.dumps_root)
+        File.write(artifact.latest_pointer_path, '2026-04-23T03-42-17Z')
+      end
+
+      it 'returns false' do
+        expect(artifact.fresh?).to be(false)
+      end
+    end
+  end
+
+  describe '#latest_dump_path' do
+    context 'when no latest pointer exists' do
+      it 'returns nil' do
+        expect(artifact.latest_dump_path).to be_nil
+      end
+    end
+
+    context 'when latest pointer is empty' do
+      before do
+        FileUtils.mkdir_p(artifact.dumps_root)
+        File.write(artifact.latest_pointer_path, '')
+      end
+
+      it 'returns nil' do
+        expect(artifact.latest_dump_path).to be_nil
+      end
+    end
+
+    context 'when latest pointer names a directory that exists' do
+      let(:dump_name) { '2026-04-23T03-42-17Z' }
+
+      before do
+        FileUtils.mkdir_p(artifact.dumps_root.join(dump_name))
+        File.write(artifact.latest_pointer_path, dump_name)
+      end
+
+      it 'returns a Pathname to that directory' do
+        expect(artifact.latest_dump_path).to eq(artifact.dumps_root.join(dump_name))
+      end
+    end
+
+    context 'when latest pointer names a directory that no longer exists (stale)' do
+      before do
+        FileUtils.mkdir_p(artifact.dumps_root)
+        File.write(artifact.latest_pointer_path, '2026-04-23T01-00-00Z')
+      end
+
+      it 'returns nil' do
+        expect(artifact.latest_dump_path).to be_nil
+      end
+    end
+
+    context 'when latest pointer has trailing whitespace' do
+      let(:dump_name) { '2026-04-23T03-42-17Z' }
+
+      before do
+        FileUtils.mkdir_p(artifact.dumps_root.join(dump_name))
+        File.write(artifact.latest_pointer_path, "#{dump_name}\n")
+      end
+
+      it 'strips the newline and returns the correct path' do
+        expect(artifact.latest_dump_path.basename.to_s).to eq(dump_name)
+      end
+    end
+  end
+
+  describe '#new_dump_dir' do
+    it 'creates a directory under dumps_root with a filesystem-safe UTC timestamp name' do
+      now = Time.utc(2026, 4, 23, 3, 42, 17)
+      dir = artifact.new_dump_dir(now: now)
+      expect(dir.to_s).to end_with('dumps/2026-04-23T03-42-17Z')
+      expect(dir).to be_directory
+    end
+
+    it 'uses dashes not colons in the time portion' do
+      dir = artifact.new_dump_dir(now: Time.utc(2026, 4, 23, 3, 42, 17))
+      expect(dir.basename.to_s).not_to include(':')
+    end
+
+    it 'creates dumps_root if it does not exist' do
+      expect(artifact.dumps_root).not_to be_directory
+      artifact.new_dump_dir
+      expect(artifact.dumps_root).to be_directory
+    end
+
+    it 'uses UTC now by default (smoke test: does not raise)' do
+      expect { artifact.new_dump_dir }.not_to raise_error
+    end
+
+    it 'raises when the target directory already exists' do
+      now = Time.utc(2026, 4, 23, 3, 42, 17)
+      artifact.new_dump_dir(now: now)
+      expect { artifact.new_dump_dir(now: now) }.to raise_error(Errno::EEXIST)
+    end
+  end
+
+  describe '#promote' do
+    let(:dump_dir) { artifact.new_dump_dir(now: Time.utc(2026, 4, 23, 3, 42, 17)) }
+
+    it 'writes the directory basename to the latest pointer' do
+      artifact.promote(dump_dir)
+      expect(artifact.latest_pointer_path.read.strip).to eq('2026-04-23T03-42-17Z')
+    end
+
+    it 'makes latest_dump_path return the promoted directory' do
+      artifact.promote(dump_dir)
+      expect(artifact.latest_dump_path).to eq(dump_dir)
+    end
+
+    it 'accepts a String path as well as a Pathname' do
+      artifact.promote(dump_dir.to_s)
+      expect(artifact.latest_dump_path).to eq(dump_dir)
+    end
+
+    it 'overwrites an existing pointer atomically' do
+      old_dir = artifact.new_dump_dir(now: Time.utc(2026, 4, 23, 2, 0, 0))
+      artifact.promote(old_dir)
+      new_dir = artifact.new_dump_dir(now: Time.utc(2026, 4, 23, 3, 42, 17))
+      artifact.promote(new_dir)
+      expect(artifact.latest_dump_path).to eq(new_dir)
+    end
+
+    it 'uses a tmp file + rename (atomic write pattern)' do
+      rename_calls = []
+      allow(File).to receive(:rename).and_wrap_original do |orig, src, dst|
+        rename_calls << [src, dst]
+        orig.call(src, dst)
+      end
+      artifact.promote(dump_dir)
+      expect(rename_calls).not_to be_empty
+      expect(rename_calls.last[1]).to eq(artifact.latest_pointer_path.to_s)
+    end
+
+    it 'raises ArgumentError for a directory outside dumps_root' do
+      outside = Pathname.new(Dir.mktmpdir)
+      expect { artifact.promote(outside) }.to raise_error(ArgumentError, /dumps_root/)
+    ensure
+      FileUtils.rm_rf(outside.to_s) if outside
+    end
+
+    it 'raises ArgumentError when dump_dir does not exist' do
+      ghost = artifact.dumps_root.join('2099-01-01T00-00-00Z')
+      expect { artifact.promote(ghost) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#read_config' do
+    context 'when woods.json does not exist' do
+      it 'returns nil' do
+        expect(artifact.read_config).to be_nil
+      end
+    end
+
+    context 'when woods.json contains valid JSON' do
+      before do
+        artifact.write_config('schema_version' => 1, 'gem_version' => '1.2.0')
+      end
+
+      it 'returns the parsed hash' do
+        result = artifact.read_config
+        expect(result).to be_a(Hash)
+        expect(result['schema_version']).to eq(1)
+      end
+
+      it 'does not raise for a future schema_version (validation is the caller\'s job)' do
+        artifact.write_config('schema_version' => 999)
+        expect { artifact.read_config }.not_to raise_error
+      end
+    end
+
+    it 'round-trips with write_config' do
+      payload = { 'schema_version' => 1, 'model' => 'nomic-embed-text' }
+      artifact.write_config(payload)
+      expect(artifact.read_config).to include(payload)
+    end
+  end
+
+  describe '#write_config' do
+    context 'with a plain Hash' do
+      it 'writes JSON to woods.json' do
+        artifact.write_config('schema_version' => 1, 'gem_version' => '1.2.0')
+        data = JSON.parse(artifact.config_path.read)
+        expect(data['schema_version']).to eq(1)
+      end
+    end
+
+    context 'with a ResolvedConfig-like object responding to #to_snapshot_json' do
+      let(:fake_config) do
+        Object.new.tap do |o|
+          o.define_singleton_method(:to_snapshot_json) { '{"schema_version":1}' }
+        end
+      end
+
+      it 'delegates serialization to the object' do
+        artifact.write_config(fake_config)
+        expect(artifact.config_path.read).to eq('{"schema_version":1}')
+      end
+    end
+
+    it 'is atomic — uses tmp file + rename' do
+      rename_calls = []
+      allow(File).to receive(:rename).and_wrap_original do |orig, src, dst|
+        rename_calls << [src, dst]
+        orig.call(src, dst)
+      end
+      artifact.write_config('schema_version' => 1)
+      expect(rename_calls.last[1]).to eq(artifact.config_path.to_s)
+    end
+
+    it 'creates output_dir parent directories if needed' do
+      nested = described_class.new(File.join(tmpdir, 'a', 'b', 'c'))
+      nested.write_config('schema_version' => 1)
+      expect(File.exist?(nested.config_path)).to be(true)
+    end
+  end
+end

--- a/spec/mcp/bootstrap_state_spec.rb
+++ b/spec/mcp/bootstrap_state_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'woods/mcp/bootstrap_state'
+
+RSpec.describe Woods::MCP::BootstrapState do
+  subject(:state) { described_class.new }
+
+  describe 'initial state' do
+    it 'starts in :initializing status' do
+      expect(state.status).to eq(:initializing)
+    end
+
+    it 'has no reason' do
+      expect(state.reason).to be_nil
+    end
+
+    it 'has no hydrated_at' do
+      expect(state.hydrated_at).to be_nil
+    end
+
+    it 'has no degraded_since' do
+      expect(state.degraded_since).to be_nil
+    end
+  end
+
+  describe '#mark' do
+    context 'transitioning to :hydrating' do
+      it 'sets status to :hydrating' do
+        state.mark(:hydrating)
+        expect(state.status).to eq(:hydrating)
+      end
+
+      it 'leaves hydrated_at nil' do
+        state.mark(:hydrating)
+        expect(state.hydrated_at).to be_nil
+      end
+    end
+
+    context 'transitioning to :hydrated' do
+      it 'sets status to :hydrated' do
+        state.mark(:hydrated)
+        expect(state.status).to eq(:hydrated)
+      end
+
+      it 'records hydrated_at' do
+        t = Time.utc(2026, 4, 23, 3, 42, 17)
+        state.mark(:hydrated, now: t)
+        expect(state.hydrated_at).to eq(t)
+      end
+
+      it 'leaves degraded_since nil' do
+        state.mark(:hydrated)
+        expect(state.degraded_since).to be_nil
+      end
+    end
+
+    context 'transitioning to :degraded' do
+      let(:err) { RuntimeError.new('connection refused') }
+
+      it 'sets status to :degraded' do
+        state.mark(:degraded, reason: err)
+        expect(state.status).to eq(:degraded)
+      end
+
+      it 'stores the reason exception' do
+        state.mark(:degraded, reason: err)
+        expect(state.reason).to eq(err)
+      end
+
+      it 'records degraded_since' do
+        t = Time.utc(2026, 4, 23, 3, 42, 18)
+        state.mark(:degraded, reason: err, now: t)
+        expect(state.degraded_since).to eq(t)
+      end
+
+      it 'leaves hydrated_at nil' do
+        state.mark(:degraded, reason: err)
+        expect(state.hydrated_at).to be_nil
+      end
+    end
+
+    context 'transitioning to :failed' do
+      let(:err) { StandardError.new('bad config') }
+
+      it 'sets status to :failed' do
+        state.mark(:failed, reason: err)
+        expect(state.status).to eq(:failed)
+      end
+
+      it 'stores the reason exception' do
+        state.mark(:failed, reason: err)
+        expect(state.reason).to eq(err)
+      end
+
+      it 'leaves hydrated_at and degraded_since nil' do
+        state.mark(:failed, reason: err)
+        expect(state.hydrated_at).to be_nil
+        expect(state.degraded_since).to be_nil
+      end
+    end
+
+    context 'with an unrecognised status' do
+      it 'raises ArgumentError' do
+        expect { state.mark(:unknown_state) }.to raise_error(ArgumentError, /unknown_state/)
+      end
+
+      it 'mentions all valid statuses in the message' do
+        state.mark(:bogus)
+      rescue ArgumentError => e
+        described_class::VALID_STATUSES.each do |s|
+          expect(e.message).to include(s.inspect)
+        end
+      end
+    end
+
+    it 'returns self for chaining' do
+      expect(state.mark(:hydrating)).to be(state)
+    end
+  end
+
+  describe '#to_h' do
+    it 'includes :status key' do
+      expect(state.to_h).to include(status: :initializing)
+    end
+
+    it 'omits :reason when nil' do
+      expect(state.to_h).not_to have_key(:reason)
+    end
+
+    it 'omits :hydrated_at when nil' do
+      expect(state.to_h).not_to have_key(:hydrated_at)
+    end
+
+    it 'omits :degraded_since when nil' do
+      expect(state.to_h).not_to have_key(:degraded_since)
+    end
+
+    context 'after :hydrated transition' do
+      let(:t) { Time.utc(2026, 4, 23, 3, 42, 17) }
+
+      before { state.mark(:hydrated, now: t) }
+
+      it 'includes hydrated_at as ISO8601 string' do
+        expect(state.to_h[:hydrated_at]).to eq(t.iso8601)
+      end
+
+      it 'does not include reason' do
+        expect(state.to_h).not_to have_key(:reason)
+      end
+    end
+
+    context 'after :degraded transition with reason' do
+      let(:err) { RuntimeError.new('connection refused') }
+      let(:t)   { Time.utc(2026, 4, 23, 3, 42, 18) }
+
+      before { state.mark(:degraded, reason: err, now: t) }
+
+      it 'includes reason as a class:message string' do
+        expect(state.to_h[:reason]).to eq('RuntimeError: connection refused')
+      end
+
+      it 'includes degraded_since as ISO8601 string' do
+        expect(state.to_h[:degraded_since]).to eq(t.iso8601)
+      end
+    end
+  end
+end

--- a/spec/mcp/bootstrapper_spec.rb
+++ b/spec/mcp/bootstrapper_spec.rb
@@ -182,4 +182,72 @@ RSpec.describe Woods::MCP::Bootstrapper do
       old ? ENV['OLLAMA_BASE_URL'] = old : ENV.delete('OLLAMA_BASE_URL')
     end
   end
+
+  describe '.build_retriever' do
+    # The decomposed build_retriever returns [retriever, BootstrapState].
+    # It refuses to silently auto-detect anymore — no woods.json + no
+    # explicit opt-in raises MissingArtifact. Callers rescue the typed
+    # error at the top level (see exe/woods-mcp).
+    around do |example|
+      original = Woods.configuration
+      Woods.configuration = Woods::Configuration.new
+      ENV.delete('WOODS_ALLOW_AUTODETECT')
+      example.run
+    ensure
+      Woods.configuration = original
+    end
+
+    context 'when no woods.json exists and autodetect is not opted in' do
+      it 'raises Woods::MCP::MissingArtifact with an actionable message' do
+        Dir.mktmpdir do |dir|
+          expect { described_class.build_retriever(index_dir: dir) }
+            .to raise_error(Woods::MCP::MissingArtifact, /WOODS_ALLOW_AUTODETECT/)
+        end
+      end
+    end
+
+    context 'when no woods.json exists and WOODS_ALLOW_AUTODETECT=1 is set' do
+      it 'falls through to env-var auto-detect (deprecated path)' do
+        ENV['WOODS_ALLOW_AUTODETECT'] = '1'
+        ENV.delete('OPENAI_API_KEY')
+        # Stub the Ollama reachability check — the machine running the
+        # spec might have Ollama listening on localhost, which would
+        # otherwise cause autodetect to succeed and defeat the test.
+        allow(described_class).to receive(:ollama_reachable?).and_return(false)
+
+        Dir.mktmpdir do |dir|
+          # No credentials, no Ollama — auto-detect finds nothing and
+          # returns a nil retriever instead of raising. The caller
+          # diagnoses via BootstrapState.
+          retriever, state = described_class.build_retriever(index_dir: dir)
+          expect(retriever).to be_nil
+          expect(state).to be_a(Woods::MCP::BootstrapState)
+        end
+      ensure
+        ENV.delete('WOODS_ALLOW_AUTODETECT')
+      end
+    end
+
+    context 'when the host initializer already set an embedding_provider' do
+      it 'skips autodetect and trusts the host config' do
+        Woods.configuration.vector_store = :in_memory
+        Woods.configuration.metadata_store = :in_memory
+        Woods.configuration.graph_store = :in_memory
+        Woods.configuration.embedding_provider = :ollama
+        Woods.configuration.embedding_options = {
+          host: 'http://127.0.0.1:19999',
+          model: 'nomic-embed-text'
+        }
+
+        Dir.mktmpdir do |dir|
+          # Provider is unreachable (nothing on :19999) → starts degraded
+          # rather than raising. Retriever comes back non-nil.
+          retriever, state = described_class.build_retriever(index_dir: dir)
+          expect(retriever).not_to be_nil
+          expect(state.status).to eq(:degraded)
+          expect(state.reason).to be_a(Woods::MCP::ProviderUnreachable)
+        end
+      end
+    end
+  end
 end

--- a/spec/mcp/errors_spec.rb
+++ b/spec/mcp/errors_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'woods'
+require 'woods/mcp/errors'
+
+RSpec.describe 'Woods::MCP exception hierarchy' do
+  describe Woods::MCP::BootstrapError do
+    it 'inherits from Woods::Error' do
+      expect(described_class.superclass).to eq(Woods::Error)
+    end
+
+    it 'does not inherit from Woods::ConfigurationError' do
+      expect(described_class.ancestors).not_to include(Woods::ConfigurationError)
+    end
+
+    it 'accepts a message and details hash' do
+      error = described_class.new('boom', details: { foo: 'bar' })
+      expect(error.message).to eq('boom')
+      expect(error.details).to eq({ foo: 'bar' })
+    end
+
+    it 'defaults details to empty hash' do
+      error = described_class.new('boom')
+      expect(error.details).to eq({})
+    end
+  end
+
+  describe Woods::MCP::MissingCredential do
+    it 'inherits from BootstrapError' do
+      expect(described_class.superclass).to eq(Woods::MCP::BootstrapError)
+    end
+
+    it 'carries structured details' do
+      error = described_class.new('key missing', details: { credential: 'OPENAI_API_KEY' })
+      expect(error.details[:credential]).to eq('OPENAI_API_KEY')
+    end
+  end
+
+  describe Woods::MCP::ConfigMismatch do
+    it 'inherits from BootstrapError' do
+      expect(described_class.superclass).to eq(Woods::MCP::BootstrapError)
+    end
+
+    it 'carries stored and host detail keys' do
+      error = described_class.new('mismatch', details: { stored: 'Ollama', host: 'OpenAI' })
+      expect(error.details[:stored]).to eq('Ollama')
+      expect(error.details[:host]).to eq('OpenAI')
+    end
+  end
+
+  describe Woods::MCP::DimensionMismatch do
+    it 'inherits from BootstrapError' do
+      expect(described_class.superclass).to eq(Woods::MCP::BootstrapError)
+    end
+
+    it 'carries expected and actual dimension details' do
+      error = described_class.new('dim mismatch', details: { expected: 768, actual: 1536 })
+      expect(error.details[:expected]).to eq(768)
+      expect(error.details[:actual]).to eq(1536)
+    end
+  end
+
+  describe Woods::MCP::UnsupportedArtifact do
+    it 'inherits from BootstrapError' do
+      expect(described_class.superclass).to eq(Woods::MCP::BootstrapError)
+    end
+
+    it 'carries artifact_version and max_supported' do
+      error = described_class.new('too new', details: { artifact_version: 3, max_supported: 1 })
+      expect(error.details[:artifact_version]).to eq(3)
+      expect(error.details[:max_supported]).to eq(1)
+    end
+  end
+
+  describe Woods::MCP::MissingArtifact do
+    it 'inherits from BootstrapError' do
+      expect(described_class.superclass).to eq(Woods::MCP::BootstrapError)
+    end
+
+    it 'carries output_dir in details' do
+      error = described_class.new('no woods.json', details: { output_dir: '/app/tmp/woods' })
+      expect(error.details[:output_dir]).to eq('/app/tmp/woods')
+    end
+  end
+
+  describe Woods::MCP::ProviderUnreachable do
+    it 'inherits from Woods::Error' do
+      expect(described_class.superclass).to eq(Woods::Error)
+    end
+
+    it 'does NOT inherit from BootstrapError' do
+      expect(described_class.ancestors).not_to include(Woods::MCP::BootstrapError)
+    end
+
+    it 'accepts message and details' do
+      error = described_class.new('refused', details: { url: 'http://localhost:11434', reason: 'connection refused' })
+      expect(error.message).to eq('refused')
+      expect(error.details[:url]).to eq('http://localhost:11434')
+      expect(error.details[:reason]).to eq('connection refused')
+    end
+
+    it 'defaults details to empty hash' do
+      error = described_class.new('refused')
+      expect(error.details).to eq({})
+    end
+  end
+
+  describe Woods::Storage::InapplicableBackend do
+    it 'inherits from Woods::Error' do
+      expect(described_class.superclass).to eq(Woods::Error)
+    end
+
+    it 'does NOT inherit from BootstrapError' do
+      expect(described_class.ancestors).not_to include(Woods::MCP::BootstrapError)
+    end
+  end
+
+  describe 'BootstrapError rescue semantics' do
+    it 'catches all BootstrapError subclasses with rescue BootstrapError' do
+      subclasses = [
+        Woods::MCP::MissingCredential,
+        Woods::MCP::ConfigMismatch,
+        Woods::MCP::DimensionMismatch,
+        Woods::MCP::UnsupportedArtifact,
+        Woods::MCP::MissingArtifact
+      ]
+
+      subclasses.each do |klass|
+        expect { raise klass, 'test' }.to raise_error(Woods::MCP::BootstrapError)
+      end
+    end
+
+    it 'does not catch ProviderUnreachable with rescue BootstrapError' do
+      expect do
+        raise Woods::MCP::ProviderUnreachable, 'test'
+      rescue Woods::MCP::BootstrapError
+        :caught_as_bootstrap
+      end.to raise_error(Woods::MCP::ProviderUnreachable)
+    end
+  end
+end

--- a/spec/mcp/provider_probe_spec.rb
+++ b/spec/mcp/provider_probe_spec.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'woods'
+require 'woods/mcp/errors'
+require 'woods/mcp/provider_probe'
+require 'woods/embedding/provider'
+require 'woods/embedding/openai'
+
+RSpec.describe Woods::MCP::ProviderProbe do
+  let(:ollama_provider) do
+    Woods::Embedding::Provider::Ollama.new(
+      host: 'http://ollama.internal:11434',
+      model: 'nomic-embed-text'
+    )
+  end
+
+  let(:openai_provider) do
+    Woods::Embedding::Provider::OpenAI.new(api_key: 'sk-test')
+  end
+
+  # Stubs Net::HTTP#start to yield a mock that returns +response+ from #get.
+  def stub_net_http(host, port, response)
+    http_double = instance_double(Net::HTTP)
+    allow(Net::HTTP).to receive(:new).with(host, port).and_return(http_double)
+    allow(http_double).to receive(:open_timeout=)
+    allow(http_double).to receive(:read_timeout=)
+    allow(http_double).to receive(:use_ssl=)
+    allow(http_double).to receive(:start).and_yield(http_double)
+    allow(http_double).to receive(:get).and_return(response)
+    http_double
+  end
+
+  # Stubs Net::HTTP#start to raise +error+ when called.
+  def stub_net_http_raise(host, port, error)
+    http_double = instance_double(Net::HTTP)
+    allow(Net::HTTP).to receive(:new).with(host, port).and_return(http_double)
+    allow(http_double).to receive(:open_timeout=)
+    allow(http_double).to receive(:read_timeout=)
+    allow(http_double).to receive(:use_ssl=)
+    allow(http_double).to receive(:start).and_raise(error)
+    http_double
+  end
+
+  describe '.reachable!' do
+    # --- Ollama ---
+
+    context 'when Ollama responds with 200' do
+      it 'returns the provider unchanged' do
+        response = instance_double(Net::HTTPOK)
+        allow(response).to receive(:is_a?).with(Net::HTTPServerError).and_return(false)
+        stub_net_http('ollama.internal', 11_434, response)
+
+        result = described_class.reachable!(ollama_provider)
+        expect(result).to be(ollama_provider)
+      end
+
+      it 'probes GET /api/tags on the configured Ollama host' do
+        response = instance_double(Net::HTTPOK)
+        allow(response).to receive(:is_a?).with(Net::HTTPServerError).and_return(false)
+        http_double = stub_net_http('ollama.internal', 11_434, response)
+
+        described_class.reachable!(ollama_provider)
+        expect(http_double).to have_received(:get).with('/api/tags')
+      end
+
+      it 'treats non-5xx responses (e.g. 404) as reachable' do
+        response = instance_double(Net::HTTPNotFound)
+        allow(response).to receive(:is_a?).with(Net::HTTPServerError).and_return(false)
+        stub_net_http('ollama.internal', 11_434, response)
+
+        expect { described_class.reachable!(ollama_provider) }.not_to raise_error
+      end
+    end
+
+    context 'when Ollama connection is refused' do
+      it 'raises ProviderUnreachable with url and reason: "connection_refused"' do
+        stub_net_http_raise('ollama.internal', 11_434, Errno::ECONNREFUSED)
+
+        expect { described_class.reachable!(ollama_provider) }
+          .to raise_error(Woods::MCP::ProviderUnreachable) do |err|
+            expect(err.url).to eq('http://ollama.internal:11434')
+            expect(err.reason).to eq('connection_refused')
+          end
+      end
+    end
+
+    context 'when Ollama probe times out' do
+      it 'raises ProviderUnreachable with reason: "timeout" on Net::OpenTimeout' do
+        stub_net_http_raise('ollama.internal', 11_434, Net::OpenTimeout)
+
+        expect { described_class.reachable!(ollama_provider) }
+          .to raise_error(Woods::MCP::ProviderUnreachable) do |err|
+            expect(err.reason).to eq('timeout')
+          end
+      end
+
+      it 'raises ProviderUnreachable with reason: "timeout" on Net::ReadTimeout' do
+        http_double = instance_double(Net::HTTP)
+        allow(Net::HTTP).to receive(:new).with('ollama.internal', 11_434).and_return(http_double)
+        allow(http_double).to receive(:open_timeout=)
+        allow(http_double).to receive(:read_timeout=)
+        allow(http_double).to receive(:use_ssl=)
+        allow(http_double).to receive(:start).and_yield(http_double)
+        allow(http_double).to receive(:get).and_raise(Net::ReadTimeout)
+
+        expect { described_class.reachable!(ollama_provider) }
+          .to raise_error(Woods::MCP::ProviderUnreachable) do |err|
+            expect(err.reason).to eq('timeout')
+          end
+      end
+    end
+
+    context 'when Ollama returns a 5xx server error' do
+      it 'raises ProviderUnreachable with reason: "http_500"' do
+        response = instance_double(Net::HTTPServiceUnavailable)
+        allow(response).to receive(:is_a?).with(Net::HTTPServerError).and_return(true)
+        stub_net_http('ollama.internal', 11_434, response)
+
+        expect { described_class.reachable!(ollama_provider) }
+          .to raise_error(Woods::MCP::ProviderUnreachable) do |err|
+            expect(err.reason).to eq('http_500')
+          end
+      end
+    end
+
+    context 'when Ollama DNS resolution fails' do
+      it 'raises ProviderUnreachable with reason: "dns_failure"' do
+        stub_net_http_raise('ollama.internal', 11_434,
+                            SocketError.new('getaddrinfo: Name or service not known'))
+
+        expect { described_class.reachable!(ollama_provider) }
+          .to raise_error(Woods::MCP::ProviderUnreachable) do |err|
+            expect(err.reason).to eq('dns_failure')
+          end
+      end
+    end
+
+    # --- OpenAI ---
+
+    context 'when OpenAI responds with 200' do
+      it 'returns the provider unchanged' do
+        response = instance_double(Net::HTTPOK)
+        allow(response).to receive(:is_a?).with(Net::HTTPUnauthorized).and_return(false)
+        allow(response).to receive(:is_a?).with(Net::HTTPServerError).and_return(false)
+        stub_net_http('api.openai.com', 443, response)
+
+        result = described_class.reachable!(openai_provider)
+        expect(result).to be(openai_provider)
+      end
+
+      it 'probes GET /v1/models over TLS' do
+        response = instance_double(Net::HTTPOK)
+        allow(response).to receive(:is_a?).with(Net::HTTPUnauthorized).and_return(false)
+        allow(response).to receive(:is_a?).with(Net::HTTPServerError).and_return(false)
+        http_double = stub_net_http('api.openai.com', 443, response)
+        allow(http_double).to receive(:use_ssl=).with(true)
+
+        described_class.reachable!(openai_provider)
+        expect(http_double).to have_received(:use_ssl=).with(true)
+        expect(http_double).to have_received(:get).with('/v1/models')
+      end
+    end
+
+    context 'when OpenAI returns 401 Unauthorized' do
+      it 'raises ProviderUnreachable with reason: "unauthorized"' do
+        response = instance_double(Net::HTTPUnauthorized)
+        allow(response).to receive(:is_a?).with(Net::HTTPUnauthorized).and_return(true)
+        stub_net_http('api.openai.com', 443, response)
+
+        expect { described_class.reachable!(openai_provider) }
+          .to raise_error(Woods::MCP::ProviderUnreachable) do |err|
+            expect(err.url).to eq('https://api.openai.com')
+            expect(err.reason).to eq('unauthorized')
+          end
+      end
+    end
+
+    context 'when OpenAI is unreachable (connection refused)' do
+      it 'raises ProviderUnreachable with reason: "connection_refused"' do
+        stub_net_http_raise('api.openai.com', 443, Errno::ECONNREFUSED)
+
+        expect { described_class.reachable!(openai_provider) }
+          .to raise_error(Woods::MCP::ProviderUnreachable) do |err|
+            expect(err.url).to eq('https://api.openai.com')
+            expect(err.reason).to eq('connection_refused')
+          end
+      end
+    end
+
+    # --- Unknown provider ---
+
+    context 'with an unknown provider class' do
+      it 'raises ArgumentError' do
+        opaque = double('SomeFutureProvider')
+
+        expect { described_class.reachable!(opaque) }
+          .to raise_error(ArgumentError, /does not know how to probe/)
+      end
+    end
+
+    # --- Structured exception fields ---
+
+    context 'exception structure' do
+      it 'exposes #url and #reason on the raised exception' do
+        stub_net_http_raise('ollama.internal', 11_434, Errno::ECONNREFUSED)
+
+        begin
+          described_class.reachable!(ollama_provider)
+        rescue Woods::MCP::ProviderUnreachable => e
+          expect(e.url).to be_a(String)
+          expect(e.reason).to be_a(String)
+          expect(e.message).to include(e.url).or include(e.reason)
+        end
+      end
+    end
+  end
+end

--- a/spec/resolved_config_spec.rb
+++ b/spec/resolved_config_spec.rb
@@ -1,0 +1,270 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'woods'
+require 'woods/mcp/errors'
+require 'woods/resolved_config'
+
+RSpec.describe Woods::ResolvedConfig do
+  let(:v1_hash) do
+    {
+      'schema_version' => 1,
+      'gem_version' => '1.2.0',
+      'created_at' => '2026-04-23T03:42:17Z',
+      'embedding_provider' => {
+        'class' => 'Woods::Embedding::Provider::Ollama',
+        'model' => 'nomic-embed-text',
+        'host' => 'http://host.docker.internal:11434',
+        'num_ctx' => 2048,
+        'read_timeout' => 120,
+        'dimension' => 768
+      },
+      'stores' => {
+        'vector_store' => 'in_memory',
+        'metadata_store' => 'in_memory',
+        'graph_store' => 'in_memory'
+      }
+    }
+  end
+
+  describe '.from_hash' do
+    it 'parses a valid v1 snapshot' do
+      config = described_class.from_hash(v1_hash)
+      expect(config).to be_a(described_class)
+      expect(config.schema_version).to eq(1)
+      expect(config.gem_version).to eq('1.2.0')
+      expect(config.dimension).to eq(768)
+      expect(config.embedding_provider[:model]).to eq('nomic-embed-text')
+      expect(config.stores[:vector_store]).to eq(:in_memory)
+    end
+
+    it 'accepts symbol keys' do
+      sym_hash = v1_hash.transform_keys(&:to_sym).merge(
+        embedding_provider: v1_hash['embedding_provider'].transform_keys(&:to_sym),
+        stores: v1_hash['stores'].transform_keys(&:to_sym)
+      )
+      config = described_class.from_hash(sym_hash)
+      expect(config.dimension).to eq(768)
+    end
+
+    it 'parses created_at as Time' do
+      config = described_class.from_hash(v1_hash)
+      expect(config.created_at).to be_a(Time)
+      expect(config.created_at.utc.strftime('%Y-%m-%dT%H:%M:%SZ')).to eq('2026-04-23T03:42:17Z')
+    end
+
+    it 'raises UnsupportedArtifact on schema_version 0' do
+      bad = v1_hash.merge('schema_version' => 0)
+      expect { described_class.from_hash(bad) }
+        .to raise_error(Woods::MCP::UnsupportedArtifact) do |e|
+          expect(e.details[:found]).to eq(0)
+          expect(e.details[:supported]).to eq(1)
+        end
+    end
+
+    it 'raises UnsupportedArtifact on schema_version 2+' do
+      bad = v1_hash.merge('schema_version' => 2)
+      expect { described_class.from_hash(bad) }
+        .to raise_error(Woods::MCP::UnsupportedArtifact) do |e|
+          expect(e.details[:found]).to eq(2)
+          expect(e.details[:supported]).to eq(1)
+        end
+    end
+
+    it 'raises UnsupportedArtifact when schema_version is missing' do
+      bad = v1_hash.except('schema_version')
+      expect { described_class.from_hash(bad) }
+        .to raise_error(Woods::MCP::UnsupportedArtifact)
+    end
+
+    it 'stores num_ctx and read_timeout in the provider hash' do
+      config = described_class.from_hash(v1_hash)
+      expect(config.embedding_provider[:num_ctx]).to eq(2048)
+      expect(config.embedding_provider[:read_timeout]).to eq(120)
+    end
+  end
+
+  describe '#dimension' do
+    it 'returns the integer dimension from the provider hash' do
+      config = described_class.from_hash(v1_hash)
+      expect(config.dimension).to eq(768)
+    end
+  end
+
+  describe '#provider_signature' do
+    it 'includes provider class short name, model, and host' do
+      config = described_class.from_hash(v1_hash)
+      expect(config.provider_signature).to eq('Ollama/nomic-embed-text@http://host.docker.internal:11434')
+    end
+
+    it 'omits host when absent' do
+      no_host = v1_hash.merge(
+        'embedding_provider' => v1_hash['embedding_provider'].except('host')
+      )
+      config = described_class.from_hash(no_host)
+      expect(config.provider_signature).to eq('Ollama/nomic-embed-text')
+    end
+  end
+
+  describe '#matches?' do
+    let(:config) { described_class.from_hash(v1_hash) }
+
+    it 'returns true when provider and stores match' do
+      other = described_class.from_hash(v1_hash)
+      expect(config.matches?(other)).to be(true)
+    end
+
+    it 'returns false when provider class differs' do
+      diff = v1_hash.merge(
+        'embedding_provider' => v1_hash['embedding_provider'].merge(
+          'class' => 'Woods::Embedding::Provider::OpenAI'
+        )
+      )
+      other = described_class.from_hash(diff)
+      expect(config.matches?(other)).to be(false)
+    end
+
+    it 'returns false when model differs' do
+      diff = v1_hash.merge(
+        'embedding_provider' => v1_hash['embedding_provider'].merge('model' => 'mxbai-embed-large')
+      )
+      other = described_class.from_hash(diff)
+      expect(config.matches?(other)).to be(false)
+    end
+
+    it 'returns false when dimension differs' do
+      diff = v1_hash.merge(
+        'embedding_provider' => v1_hash['embedding_provider'].merge('dimension' => 1536)
+      )
+      other = described_class.from_hash(diff)
+      expect(config.matches?(other)).to be(false)
+    end
+
+    it 'returns false when vector_store type differs' do
+      diff = v1_hash.merge('stores' => v1_hash['stores'].merge('vector_store' => 'qdrant'))
+      other = described_class.from_hash(diff)
+      expect(config.matches?(other)).to be(false)
+    end
+
+    it 'ignores gem_version differences' do
+      diff = v1_hash.merge('gem_version' => '9.9.9')
+      other = described_class.from_hash(diff)
+      expect(config.matches?(other)).to be(true)
+    end
+
+    it 'ignores read_timeout differences' do
+      diff = v1_hash.merge(
+        'embedding_provider' => v1_hash['embedding_provider'].merge('read_timeout' => 999)
+      )
+      other = described_class.from_hash(diff)
+      expect(config.matches?(other)).to be(true)
+    end
+
+    it 'ignores created_at differences' do
+      diff = v1_hash.merge('created_at' => '2020-01-01T00:00:00Z')
+      other = described_class.from_hash(diff)
+      expect(config.matches?(other)).to be(true)
+    end
+  end
+
+  describe '#assert_compatible!' do
+    let(:config) { described_class.from_hash(v1_hash) }
+
+    it 'is a no-op when configs match' do
+      stored = described_class.from_hash(v1_hash)
+      expect { config.assert_compatible!(stored) }.not_to raise_error
+    end
+
+    it 'raises DimensionMismatch when dimensions differ' do
+      stored_hash = v1_hash.merge(
+        'embedding_provider' => v1_hash['embedding_provider'].merge('dimension' => 1536)
+      )
+      stored = described_class.from_hash(stored_hash)
+
+      expect { config.assert_compatible!(stored) }
+        .to raise_error(Woods::MCP::DimensionMismatch) do |e|
+          expect(e.details[:expected]).to eq(1536)
+          expect(e.details[:actual]).to eq(768)
+          expect(e.details[:stored_at]).to be_a(String)
+        end
+    end
+
+    it 'raises ConfigMismatch when provider class differs' do
+      stored_hash = v1_hash.merge(
+        'embedding_provider' => v1_hash['embedding_provider'].merge(
+          'class' => 'Woods::Embedding::Provider::OpenAI'
+        )
+      )
+      stored = described_class.from_hash(stored_hash)
+
+      expect { config.assert_compatible!(stored) }
+        .to raise_error(Woods::MCP::ConfigMismatch) do |e|
+          expect(e.details[:host]).to include('Ollama')
+          expect(e.details[:stored]).to include('OpenAI')
+        end
+    end
+
+    it 'raises ConfigMismatch when model differs' do
+      stored_hash = v1_hash.merge(
+        'embedding_provider' => v1_hash['embedding_provider'].merge('model' => 'mxbai-embed-large')
+      )
+      stored = described_class.from_hash(stored_hash)
+
+      expect { config.assert_compatible!(stored) }
+        .to raise_error(Woods::MCP::ConfigMismatch)
+    end
+
+    it 'checks dimension before provider class' do
+      stored_hash = v1_hash.merge(
+        'embedding_provider' => v1_hash['embedding_provider'].merge(
+          'class' => 'Woods::Embedding::Provider::OpenAI',
+          'dimension' => 1536
+        )
+      )
+      stored = described_class.from_hash(stored_hash)
+
+      expect { config.assert_compatible!(stored) }.to raise_error(Woods::MCP::DimensionMismatch)
+    end
+  end
+
+  describe '#to_snapshot_json' do
+    it 'returns a Hash with string keys' do
+      config = described_class.from_hash(v1_hash)
+      snap = config.to_snapshot_json
+      expect(snap).to be_a(Hash)
+      expect(snap.keys).to all(be_a(String))
+    end
+
+    it 'round-trips through from_hash' do
+      config = described_class.from_hash(v1_hash)
+      round_tripped = described_class.from_hash(config.to_snapshot_json)
+
+      expect(round_tripped.dimension).to eq(config.dimension)
+      expect(round_tripped.provider_signature).to eq(config.provider_signature)
+      expect(round_tripped.stores).to eq(config.stores)
+      expect(round_tripped.gem_version).to eq(config.gem_version)
+    end
+
+    it 'produces JSON-serializable output' do
+      config = described_class.from_hash(v1_hash)
+      expect { JSON.generate(config.to_snapshot_json) }.not_to raise_error
+    end
+  end
+
+  describe 'immutability' do
+    it 'is frozen after construction' do
+      config = described_class.from_hash(v1_hash)
+      expect(config).to be_frozen
+    end
+
+    it 'has a frozen embedding_provider hash' do
+      config = described_class.from_hash(v1_hash)
+      expect(config.embedding_provider).to be_frozen
+    end
+
+    it 'has a frozen stores hash' do
+      config = described_class.from_hash(v1_hash)
+      expect(config.stores).to be_frozen
+    end
+  end
+end

--- a/spec/storage/snapshotter/metadata_spec.rb
+++ b/spec/storage/snapshotter/metadata_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+require 'pathname'
+require 'woods/storage/snapshotter/metadata'
+require 'woods/index_artifact'
+
+RSpec.describe Woods::Storage::Snapshotter::Metadata do
+  let(:tmpdir) { Dir.mktmpdir }
+  let(:artifact) { Woods::IndexArtifact.new(tmpdir) }
+
+  after { FileUtils.remove_entry(tmpdir) }
+
+  # A minimal in-memory metadata store that also implements the persistence seam
+  # (#each_entry / #bulk_load) expected by the Snapshotter. The real
+  # MetadataStore::InMemory gains these methods in PR 3; this helper stands in
+  # for the happy-path dump tests until that PR lands.
+  def metadata_store_with_seam
+    store = Woods::Storage::MetadataStore::InMemory.new
+    store.store('User', { type: 'model', file_path: 'app/models/user.rb' })
+    def store.each_entry(&block)
+      return enum_for(:each_entry) unless block
+
+      # Walk the internal hash — underscore prefix avoids method_missing/private issues.
+      instance_variable_get(:@data).each { |id, meta| block.call(id, meta) }
+    end
+
+    def store.bulk_load(entries)
+      entries.each { |id, meta| self.store(id, meta) }
+    end
+
+    store
+  end
+
+  describe '.load_or_empty' do
+    it 'returns an InMemory metadata store' do
+      store = described_class.load_or_empty(artifact)
+      expect(store).to be_a(Woods::Storage::MetadataStore::InMemory)
+    end
+
+    it 'returns an empty store' do
+      store = described_class.load_or_empty(artifact)
+      expect(store.count).to eq(0)
+    end
+
+    it 'ignores artifact state — returns empty even when latest_dump_path is set' do
+      dump_dir = artifact.new_dump_dir
+      artifact.promote(dump_dir)
+      store = described_class.load_or_empty(artifact)
+      expect(store.count).to eq(0)
+    end
+
+    it 'accepts an optional resolved_config keyword without error' do
+      expect { described_class.load_or_empty(artifact, resolved_config: double('rc')) }
+        .not_to raise_error
+    end
+  end
+
+  describe '.dump' do
+    let(:dump_dir) { artifact.new_dump_dir }
+
+    context 'with a store that implements the persistence seam (happy path)' do
+      let(:store) { metadata_store_with_seam }
+
+      it 'does not raise for valid input' do
+        expect { described_class.dump(store, artifact, dump_dir) }.not_to raise_error
+      end
+
+      it 'returns nil (no-op)' do
+        expect(described_class.dump(store, artifact, dump_dir)).to be_nil
+      end
+
+      it 'writes no files (stub no-op)' do
+        described_class.dump(store, artifact, dump_dir)
+        written = Dir.glob("#{dump_dir}/**/*").reject { |f| File.directory?(f) }
+        expect(written).to be_empty
+      end
+    end
+
+    context 'when store does not respond to #each_entry (persistent backend)' do
+      let(:durable_store) { Object.new }
+
+      it 'raises InapplicableBackend' do
+        expect { described_class.dump(durable_store, artifact, dump_dir) }
+          .to raise_error(Woods::Storage::InapplicableBackend)
+      end
+
+      it 'uses the prescribed error message format' do
+        expect { described_class.dump(durable_store, artifact, dump_dir) }
+          .to raise_error(Woods::Storage::InapplicableBackend,
+                          /backend .+ is already durable — Snapshotter should not have been invoked/)
+      end
+    end
+
+    context 'when store responds to #each_entry but not #bulk_load' do
+      let(:partial_store) do
+        obj = Object.new
+        def obj.each_entry; end
+        obj
+      end
+
+      it 'raises InapplicableBackend' do
+        expect { described_class.dump(partial_store, artifact, dump_dir) }
+          .to raise_error(Woods::Storage::InapplicableBackend)
+      end
+    end
+
+    context 'when dump_dir is outside artifact.dumps_root' do
+      let(:store) { metadata_store_with_seam }
+      let(:outside_dir) { Dir.mktmpdir }
+
+      after { FileUtils.remove_entry(outside_dir) }
+
+      it 'raises ArgumentError' do
+        expect { described_class.dump(store, artifact, outside_dir) }
+          .to raise_error(ArgumentError)
+      end
+
+      it 'mentions dumps_root in the error message' do
+        expect { described_class.dump(store, artifact, outside_dir) }
+          .to raise_error(ArgumentError, /dumps_root/)
+      end
+    end
+  end
+end

--- a/spec/storage/snapshotter/vector_spec.rb
+++ b/spec/storage/snapshotter/vector_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+require 'pathname'
+require 'woods/storage/snapshotter/vector'
+require 'woods/index_artifact'
+
+RSpec.describe Woods::Storage::Snapshotter::Vector do
+  let(:tmpdir) { Dir.mktmpdir }
+  let(:artifact) { Woods::IndexArtifact.new(tmpdir) }
+
+  after { FileUtils.remove_entry(tmpdir) }
+
+  describe '.load_or_empty' do
+    it 'returns an InMemory vector store' do
+      store = described_class.load_or_empty(artifact)
+      expect(store).to be_a(Woods::Storage::VectorStore::InMemory)
+    end
+
+    it 'returns an empty store' do
+      store = described_class.load_or_empty(artifact)
+      expect(store.count).to eq(0)
+    end
+
+    it 'ignores artifact state — returns empty even when latest_dump_path is set' do
+      dump_dir = artifact.new_dump_dir
+      artifact.promote(dump_dir)
+      store = described_class.load_or_empty(artifact)
+      expect(store.count).to eq(0)
+    end
+
+    it 'accepts an optional resolved_config keyword without error' do
+      expect { described_class.load_or_empty(artifact, resolved_config: double('rc')) }
+        .not_to raise_error
+    end
+  end
+
+  describe '.dump' do
+    let(:dump_dir) { artifact.new_dump_dir }
+
+    context 'with a valid in-memory store (happy path)' do
+      let(:store) do
+        s = Woods::Storage::VectorStore::InMemory.new
+        s.store('unit1', [0.1, 0.2, 0.3], { type: 'model' })
+        s
+      end
+
+      it 'does not raise for valid input' do
+        expect { described_class.dump(store, artifact, dump_dir) }.not_to raise_error
+      end
+
+      it 'returns nil (no-op)' do
+        expect(described_class.dump(store, artifact, dump_dir)).to be_nil
+      end
+
+      it 'writes no files (stub no-op)' do
+        described_class.dump(store, artifact, dump_dir)
+        written = Dir.glob("#{dump_dir}/**/*").reject { |f| File.directory?(f) }
+        expect(written).to be_empty
+      end
+    end
+
+    context 'when store does not respond to #each_entry (persistent backend)' do
+      let(:durable_store) { Object.new }
+
+      it 'raises InapplicableBackend' do
+        expect { described_class.dump(durable_store, artifact, dump_dir) }
+          .to raise_error(Woods::Storage::InapplicableBackend)
+      end
+
+      it 'uses the prescribed error message format' do
+        expect { described_class.dump(durable_store, artifact, dump_dir) }
+          .to raise_error(Woods::Storage::InapplicableBackend,
+                          /backend .+ is already durable — Snapshotter should not have been invoked/)
+      end
+    end
+
+    context 'when store responds to #each_entry but not #bulk_load' do
+      let(:partial_store) do
+        obj = Object.new
+        def obj.each_entry; end
+        obj
+      end
+
+      it 'raises InapplicableBackend' do
+        expect { described_class.dump(partial_store, artifact, dump_dir) }
+          .to raise_error(Woods::Storage::InapplicableBackend)
+      end
+    end
+
+    context 'when dump_dir is outside artifact.dumps_root' do
+      let(:store) { Woods::Storage::VectorStore::InMemory.new }
+      let(:outside_dir) { Dir.mktmpdir }
+
+      after { FileUtils.remove_entry(outside_dir) }
+
+      it 'raises ArgumentError' do
+        expect { described_class.dump(store, artifact, outside_dir) }
+          .to raise_error(ArgumentError)
+      end
+
+      it 'mentions dumps_root in the error message' do
+        expect { described_class.dump(store, artifact, outside_dir) }
+          .to raise_error(ArgumentError, /dumps_root/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
PR 2 in the multi-process Shape 2 rework. **Stacked on top of #74** (flat-buffer + seams) — rebase this onto main after #74 merges; the new files are all additive and won't conflict.

## Summary

`Bootstrapper#build_retriever` used to mutate `Woods.configuration` in place, probe the network inline, and wrap everything in `rescue StandardError => e` that collapsed three distinct failure modes to one `nil` + "pattern-based search only" warning. Operators had no way to distinguish "I forgot `OPENAI_API_KEY`" from "Ollama crashed" from "config mismatch."

This PR decomposes it into a four-step narrative and a typed exception hierarchy. Config-invalid failures raise named errors operators can grep for. Dependency-unreachable failures start the MCP server degraded and retry on first query, surfaced via `BootstrapState`.

## New objects

| Class | Role |
|---|---|
| `Woods::MCP::BootstrapError` + 5 subclasses | Named errors operators can rescue / grep. Sibling of `ConfigurationError`, not child — host apps rescuing `ConfigurationError` won't swallow runtime/artifact conditions. |
| `Woods::MCP::ProviderUnreachable` | Recoverable sibling. Caught internally for degraded-start. Carries `url:` and `reason:` as first-class fields. |
| `Woods::Storage::InapplicableBackend` | Named class for Snapshotter misuse on durable backends. |
| `Woods::ResolvedConfig` | Immutable Whole Value. Methods: `#dimension`, `#provider_signature`, `#matches?`, `#assert_compatible!`, `#to_snapshot_json`. Schema-versioned. |
| `Woods::IndexArtifact` | Whole Value for `output_dir` path semantics. Atomic writes. Centralises path knowledge. |
| `Woods::MCP::BootstrapState` | Small state machine: `:initializing → :hydrating → :hydrated | :degraded | :failed`. Thread-safe. `#to_h` for `woods_status`. |
| `Woods::MCP::ProviderProbe` | Pure predicate. `.reachable!(provider)` returns the provider or raises. |
| `Woods::Storage::Snapshotter::Vector` / `::Metadata` | **Stubs for now** — `load_or_empty` returns empty store, `dump` is no-op. Validation logic is load-bearing: refuses non-in-memory backends with `InapplicableBackend`, refuses out-of-tree dump dirs with `ArgumentError`. Real serialization lands in PR 3. |

## Rewritten `Bootstrapper.build_retriever`

```ruby
def self.build_retriever(index_dir: nil)
  state = BootstrapState.new
  state.mark(:hydrating)

  artifact = build_artifact(index_dir)
  config = resolve_or_autodetect(artifact)
  return [nil, state] unless config.embedding_provider

  resolved = ResolvedConfig.from_configuration(config)
  retriever = build_retriever_from_config(config, resolved, artifact)
  probe_and_mark_state(config, state)

  [retriever, state]
end
```

Four steps, each a named method. No `rescue StandardError`. No mutation of `Woods.configuration` on the common path. Returns `[retriever, state]` so the MCP server can report hydrated/degraded without scraping for itself.

## Behavior changes

1. **No more silent fallback.** Missing `woods.json` + no `WOODS_ALLOW_AUTODETECT=1` raises `Woods::MCP::MissingArtifact` with an actionable message. The env-var auto-detect path is still available but opt-in.
2. **Provider unreachable ≠ fatal.** For a long-lived MCP sidecar, Ollama might come up *after* the server. Dependency-unreachable failures start the retriever in `:degraded` state and retry on first query. Config-invalid failures still raise.
3. **`exe/woods-mcp` + `exe/woods-mcp-http` top-level rescue.** `BootstrapError` → class name + message + details to stderr + `exit 2`. Grep-friendly for debugging.

## Migration / backwards compatibility

- Existing SQLite / pgvector / Qdrant users: no change.
- Existing env-var-driven MCP launchers (admin's current plugin): must set `WOODS_ALLOW_AUTODETECT=1` OR run an embed first to generate `woods.json`. The old silent-autodetect behavior is reachable via the flag.
- Existing call sites: `build_retriever` now takes `index_dir:` kwarg and returns `[retriever, state]`. `exe/woods-mcp` and `exe/woods-mcp-http` updated.

## Test plan

- [x] `bundle exec rake spec` — 4246 examples, 0 failures, 2 pending
- [x] `bundle exec rubocop` — 420 files, 0 offenses
- [x] New spec coverage: errors (22), resolved_config (29), index_artifact (24), bootstrap_state (27), provider_probe (13), snapshotter stubs (24), bootstrapper integration (3 new contexts)
- [x] Existing `spec/mcp/bootstrapper_spec.rb` still passes

## Out of scope (lands in PR 3)

- Real Snapshotter serialization (`pack("e*")` for vectors, MessagePack for metadata)
- Streaming append during embed + compact at end
- `latest` pointer flip + schema-versioned vectors.bin header
- `woods.json` writer in the Indexer
- `woods_status` surface that consumes `BootstrapState`