### PR TITLE
chore(specs): latency regression guard + exe/woods-mcp BootstrapError smoke

### DIFF
--- a/spec/mcp/cli_integration_spec.rb
+++ b/spec/mcp/cli_integration_spec.rb
@@ -100,5 +100,37 @@ RSpec.describe 'MCP CLI integration' do
         expect(err).to match(/No manifest\.json/)
       end
     end
+
+    # ── BootstrapError rescue — typed exception surface ────────────
+    # When build_retriever raises a typed BootstrapError, the
+    # top-level rescue in exe/woods-mcp must print the class name
+    # (grep-friendly for operators), the message, and exit with a
+    # distinct nonzero code (2) so ops tooling can distinguish "bad
+    # config" from "missing directory" (exit 1).
+    describe 'BootstrapError handling' do
+      it 'exits 2 with MissingArtifact class name when woods.json is absent and autodetect is not opted in' do
+        Dir.mktmpdir do |dir|
+          FileUtils.touch(File.join(dir, 'manifest.json')) # pass the dir-exists check
+          env = {
+            'BUNDLE_GEMFILE' => File.join(gem_root, 'Gemfile'),
+            'WOODS_ALLOW_AUTODETECT' => nil,
+            'OPENAI_API_KEY' => nil,
+            # Point Ollama at a dead port so the autodetect path — if it
+            # somehow fires — won't accidentally find a running local
+            # Ollama and obscure the test.
+            'OLLAMA_BASE_URL' => 'http://127.0.0.1:19999'
+          }
+
+          # The fixture has a manifest, so resolve_index_dir passes;
+          # build_retriever runs and hits MissingArtifact because there's
+          # no woods.json and autodetect isn't opted in.
+          _out, err, status = Open3.capture3(env, 'bundle', 'exec', 'ruby', ruby_bin, dir)
+
+          expect(status.exitstatus).to eq(2)
+          expect(err).to match(/MissingArtifact/)
+          expect(err).to match(/WOODS_ALLOW_AUTODETECT/)
+        end
+      end
+    end
   end
 end

--- a/spec/performance/vector_search_latency_spec.rb
+++ b/spec/performance/vector_search_latency_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'benchmark'
+require 'woods/storage/vector_store'
+
+# Wall-clock regression guard for the cosine kernel.
+#
+# The Phase 0 bench (bench/vector_query_and_serialization.rb) is the
+# full measurement harness; this spec is the lightweight version that
+# runs in CI and fails loud if a future change regresses the kernel
+# past a bound. Numbers are derived from the initial measurement
+# (Ruby 3.3 arm64-darwin23, admin-shape 12,771 × 768) with generous
+# headroom so it passes across Ruby versions and CI hardware.
+#
+# Tagged `:perf` — opt in with `rspec --tag perf`. Not in the default
+# run because wall-clock is jittery on shared runners; failures would
+# be noise. Intended to be invoked from a separate CI job against a
+# predictable box when we wire it in.
+RSpec.describe 'InMemory vector search latency', :perf do
+  it 'stays under 1500 ms for a 12 771-vector, 768-dim search' do
+    store = Woods::Storage::VectorStore::InMemory.new
+    rng = Random.new(42)
+    12_771.times do |i|
+      v = Array.new(768) { rng.rand(-1.0..1.0) }
+      mag = Math.sqrt(v.sum { |x| x * x })
+      v.map! { |x| x / mag } unless mag.zero?
+      store.store("Unit_#{i}", v, { type: i.even? ? 'model' : 'service' })
+    end
+    query = Array.new(768) { rng.rand(-1.0..1.0) }
+
+    # Warm inline caches and stabilise GC.
+    3.times { store.search(query, limit: 10) }
+    GC.start
+
+    elapsed = Benchmark.realtime { store.search(query, limit: 10) }
+
+    # Observed ~500 ms on a modern laptop; 1500 ms is ~3× headroom for
+    # shared CI runners without being so loose that a regression hides.
+    # If this starts failing, compare against bench/vector_query_and_serialization.rb
+    # to see whether it's a real slowdown or a noisy runner.
+    expect(elapsed).to be < 1.5
+  end
+
+  it 'stays within its allocation budget on a 1000-vector search' do
+    # Duplicates the allocation bound in spec/storage/vector_store_spec.rb
+    # — included here so the :perf suite can stand alone as a regression
+    # gate without depending on the full vector_store suite running.
+    store = Woods::Storage::VectorStore::InMemory.new
+    1000.times { |i| store.store("v_#{i}", Array.new(256) { rand(-1.0..1.0) }) }
+    query = Array.new(256) { rand(-1.0..1.0) }
+
+    3.times { store.search(query, limit: 10) }
+    GC.start
+
+    before = GC.stat(:total_allocated_objects)
+    store.search(query, limit: 10)
+    after = GC.stat(:total_allocated_objects)
+
+    expect(after - before).to be < 5000
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,12 @@ RSpec.configure do |config|
   config.order = :random
   Kernel.srand config.seed
 
+  # Perf-tagged specs (see spec/performance/) are wall-clock regression
+  # guards — measurably jittery on shared CI runners. Excluded from the
+  # default suite; opt in with `rspec --tag perf` from a dedicated job
+  # against a predictable box.
+  config.filter_run_excluding(perf: true) unless ENV['WOODS_RUN_PERF_SPECS']
+
   config.after(:each) do
     Woods::ModelNameCache.reset! if defined?(Woods::ModelNameCache) && Woods::ModelNameCache.respond_to?(:reset!)
   end


### PR DESCRIPTION
Closes two coverage gaps identified during the post-PR-2 plan audit. Both are small, test-only changes.

## Gap A — Wall-clock latency regression guard

The Phase 0 bench (`bench/vector_query_and_serialization.rb`) is a manual harness. A future regression in `cosine_similarity` or the flat-buffer backing representation would pass all existing tests silently.

Adds `spec/performance/vector_search_latency_spec.rb`:

- **12,771 × 768 full search completes in < 1500 ms.** ~3× headroom over the observed ~500 ms on a modern laptop. If it starts failing, compare against the bench to distinguish real slowdown from runner noise.
- **1,000-vector search stays within the 5000-allocation budget.** Duplicates the guard already in `vector_store_spec` so the `:perf` suite can stand alone as a regression gate without depending on the full vector_store suite running.

Tagged `:perf`. Excluded from the default suite via `spec_helper.filter_run_excluding(perf: true)`. Opt in with `rspec --tag perf` or `WOODS_RUN_PERF_SPECS=1`. Wall-clock is jittery on shared CI runners; we want these running from a dedicated performance job against predictable hardware, not polluting the normal signal.

## Gap C — `exe/woods-mcp` BootstrapError rescue smoke

PR #75 added a top-level `rescue Woods::MCP::BootstrapError` in `exe/woods-mcp` and `exe/woods-mcp-http` that prints the class name + message and exits 2, but no spec exercised the path.

Extends `spec/mcp/cli_integration_spec.rb` with a scenario that:

1. Creates a temp directory with a `manifest.json` (passes `resolve_index_dir`)
2. No `woods.json`, no `WOODS_ALLOW_AUTODETECT=1`, dead Ollama URL
3. Spawns `exe/woods-mcp`, expects exit status 2 and stderr matching `/MissingArtifact/` + `/WOODS_ALLOW_AUTODETECT/`

Grep-friendly output is the whole point of the typed error surface — this spec guards it.

## Gap B — deferred to PR 3

ConfigResolver extraction was the third gap. Deferred intentionally: the `woods.json` read path is what motivates the refactor, and that read path lands in PR 3. Doing the extraction now would just mean touching the Bootstrapper twice. Captured in the PR 3 plan.

## Test plan

- [x] `bundle exec rake spec` — 4247 examples, 0 failures, 2 pending (unchanged tiktoken pendings; perf specs auto-skipped by default)
- [x] `bundle exec rspec spec/performance/ --tag perf` — 2 examples, 0 failures
- [x] `bundle exec rubocop` — 421 files, 0 offenses