### PR TITLE
feat(persistence): real Snapshotter + streaming indexer + woods.json round trip

### DIFF
--- a/lib/woods.rb
+++ b/lib/woods.rb
@@ -133,7 +133,8 @@ module Woods
                   :console_credential_rotation_warning, :console_unsafe_eval_enabled,
                   :notion_api_token, :notion_database_ids,
                   :unblocked_api_token, :unblocked_collection_id, :unblocked_repo_url,
-                  :cache_store, :cache_options
+                  :cache_store, :cache_options,
+                  :dump_retention_count
     attr_reader :max_context_tokens, :similarity_threshold, :extractors, :pretty_json, :context_format,
                 :cache_enabled
 
@@ -175,6 +176,7 @@ module Woods
       @cache_enabled = false
       @cache_store = nil      # :redis, :solid_cache, :memory, or a CacheStore instance
       @cache_options = {}     # { redis: client, cache: store, ttl: { embeddings: 86400, ... } }
+      @dump_retention_count = 3
     end
 
     # @return [Pathname, String] Output directory, defaulting to Rails.root/tmp/woods

--- a/lib/woods/embedding/indexer.rb
+++ b/lib/woods/embedding/indexer.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 require 'digest'
+require 'fileutils'
 
 require_relative '../extracted_unit'
 require_relative '../chunking/semantic_chunker'
@@ -11,14 +12,31 @@ module Woods
     # Orchestrates the indexing pipeline: reads extracted units, prepares text,
     # generates embeddings, and stores vectors. Supports full and incremental
     # modes with checkpoint-based resumability.
+    #
+    # When the vector store is an in-memory adapter (responds to +#each_entry+
+    # and +#bulk_load+) and +output_dir+ is set, a successful {#index_all} run
+    # also persists the stores to disk via the Snapshotter pair and atomically
+    # flips the +dumps/latest+ pointer. Persistent backends (pgvector, Qdrant)
+    # see zero behaviour change — no Snapshotter is invoked.
     class Indexer # rubocop:disable Metrics/ClassLength
       # @param chunker [Chunking::SemanticChunker, nil] Splits oversize units
-      #   into semantically coherent chunks before embedding. `nil` disables
+      #   into semantically coherent chunks before embedding. +nil+ disables
       #   chunking — units go to the provider whole (useful in tests).
       # @param checkpoint_interval [Integer] Save checkpoint every N batches (default: 10)
+      # @param metadata_store [#each_entry, #bulk_load, nil] Optional metadata store.
+      #   When present alongside an in-memory vector store, both are persisted
+      #   at the end of a successful {#index_all} run.
+      # @param resolved_config [Woods::ResolvedConfig, nil] Captured config for
+      #   +woods.json+ — written to +output_dir+ on {#index_all} completion.
+      # @param dump_retention_count [Integer] Number of completed dump directories
+      #   to keep under +output_dir/dumps/+. Older dumps are removed after a
+      #   successful {#index_all} run (default: 3).
       def initialize(provider:, text_preparer:, vector_store:, output_dir:, # rubocop:disable Metrics/ParameterLists
                      chunker: Chunking::SemanticChunker.new,
-                     batch_size: 32, checkpoint_interval: 10)
+                     batch_size: 32, checkpoint_interval: 10,
+                     metadata_store: nil,
+                     resolved_config: nil,
+                     dump_retention_count: 3)
         @provider = provider
         @text_preparer = text_preparer
         @vector_store = vector_store
@@ -26,12 +44,23 @@ module Woods
         @chunker = chunker
         @batch_size = batch_size
         @checkpoint_interval = checkpoint_interval
+        @metadata_store = metadata_store
+        @resolved_config = resolved_config
+        @dump_retention_count = dump_retention_count
       end
 
       # Index all extracted units (full mode). Returns stats hash.
+      #
+      # When the vector store is an in-memory adapter, persists the embedded
+      # vectors (and metadata, if a metadata store was provided) to disk under
+      # +output_dir/dumps/<timestamp>/+ and atomically flips the +latest+
+      # pointer. Writes +woods.json+ when +resolved_config+ was supplied.
+      #
       # @return [Hash] Stats with :processed, :skipped, :errors counts
       def index_all
-        process_units(load_units, incremental: false)
+        stats = process_units(load_units, incremental: false)
+        persist_snapshot if persistable?
+        stats
       end
 
       # Index only changed units (incremental mode). Returns stats hash.
@@ -130,7 +159,7 @@ module Woods
         char_budget.positive? && source.length > char_budget
       end
 
-      # Ask the chunker's real tokenizer whether `source` already exceeds
+      # Ask the chunker's real tokenizer whether +source+ already exceeds
       # the token budget. Returns false when the chunker wasn't built with
       # one (e.g., OpenAI path), leaving the char-based check in charge.
       def chunker_token_oversize?(source)
@@ -140,7 +169,7 @@ module Woods
       end
 
       # Populate unit.chunks from the configured chunker. The chunker's
-      # own `max_chars` safety net is what guarantees each chunk fits,
+      # own +max_chars+ safety net is what guarantees each chunk fits,
       # so we pass the same char budget through here.
       def apply_chunking(unit)
         unit.chunks = @chunker.chunk(unit).map do |chunk|
@@ -200,6 +229,60 @@ module Woods
 
       def save_checkpoint(checkpoint)
         File.write(File.join(@output_dir, 'checkpoint.json'), JSON.generate(checkpoint))
+      end
+
+      # Returns true when the vector store is an in-memory adapter that supports
+      # the persistence seam (+#each_entry+ / +#bulk_load+) and output_dir is set.
+      # Persistent backends (pgvector, Qdrant) never respond to +#each_entry+.
+      def persistable?
+        @output_dir &&
+          @vector_store.respond_to?(:each_entry) &&
+          @vector_store.respond_to?(:bulk_load)
+      end
+
+      # Persist stores to a timestamped dump directory, write +woods.json+,
+      # flip the +latest+ pointer, then prune old dumps.
+      def persist_snapshot
+        require_relative '../index_artifact'
+        require_relative '../storage/snapshotter'
+
+        artifact = IndexArtifact.new(@output_dir)
+        dump_dir = artifact.new_dump_dir
+
+        Storage::Snapshotter::Vector.dump(@vector_store, artifact, dump_dir)
+
+        if @metadata_store.respond_to?(:each_entry) && @metadata_store.respond_to?(:bulk_load)
+          Storage::Snapshotter::Metadata.dump(@metadata_store, artifact, dump_dir)
+        end
+
+        artifact.write_config(@resolved_config) if @resolved_config
+
+        artifact.promote(dump_dir)
+
+        prune_old_dumps(artifact)
+      end
+
+      # Remove old dump directories beyond the retention window.
+      #
+      # Keeps the +@dump_retention_count+ most-recently-created directories
+      # (sorted by name, which is a UTC timestamp so lexicographic order equals
+      # chronological order). The current +latest+ directory is always kept.
+      def prune_old_dumps(artifact)
+        return if @dump_retention_count.nil? || @dump_retention_count <= 0
+
+        dumps_root = artifact.dumps_root
+        return unless dumps_root.exist?
+
+        dirs = sorted_dump_dirs(dumps_root)
+        excess = dirs.length - @dump_retention_count
+        dirs.first(excess).each { |dir| FileUtils.rm_rf(dir) } if excess.positive?
+      end
+
+      def sorted_dump_dirs(dumps_root)
+        dumps_root.children
+                  .select(&:directory?)
+                  .sort_by(&:basename)
+                  .map(&:to_s)
       end
     end
   end

--- a/lib/woods/index_artifact.rb
+++ b/lib/woods/index_artifact.rb
@@ -139,16 +139,18 @@ module Woods
     # Atomically writes a resolved config hash as +woods.json+.
     #
     # Accepts either a +ResolvedConfig+ (responds to +#to_snapshot_json+) or
-    # a plain +Hash+.
+    # a plain +Hash+. When +#to_snapshot_json+ returns a +Hash+, it is
+    # serialized to JSON automatically — callers need not pre-serialize.
     #
     # @param resolved_config_hash [#to_snapshot_json, Hash]
     # @return [void]
     def write_config(resolved_config_hash)
-      json = if resolved_config_hash.respond_to?(:to_snapshot_json)
-               resolved_config_hash.to_snapshot_json
-             else
-               JSON.pretty_generate(resolved_config_hash)
-             end
+      raw = if resolved_config_hash.respond_to?(:to_snapshot_json)
+              resolved_config_hash.to_snapshot_json
+            else
+              resolved_config_hash
+            end
+      json = raw.is_a?(String) ? raw : JSON.pretty_generate(raw)
       atomic_write(config_path, json)
     end
 

--- a/lib/woods/mcp/bootstrapper.rb
+++ b/lib/woods/mcp/bootstrapper.rb
@@ -2,6 +2,7 @@
 
 require_relative 'errors'
 require_relative 'bootstrap_state'
+require_relative 'config_resolver'
 require_relative 'provider_probe'
 require_relative '../index_artifact'
 require_relative '../resolved_config'
@@ -105,7 +106,9 @@ module Woods
         state.mark(:hydrating)
 
         artifact = build_artifact(index_dir)
-        config = resolve_or_autodetect(artifact)
+        config, _source = ConfigResolver.resolve(Woods.configuration,
+                                                 artifact: artifact,
+                                                 ollama_probe: method(:ollama_reachable?))
         return [nil, state] unless config.embedding_provider
 
         resolved = ResolvedConfig.from_configuration(config)
@@ -126,25 +129,17 @@ module Woods
 
       # Check whether Ollama is reachable at the configured base URL.
       #
-      # Kept for the legacy auto-detect path only. New code should use
-      # {Woods::MCP::ProviderProbe.reachable!} via the ResolvedConfig flow.
+      # Kept for backwards compatibility with existing specs. Delegates to
+      # {Woods::MCP::ConfigResolver} and is passed as the +ollama_probe:+
+      # callable in {.build_retriever} so that specs stubbing this method
+      # continue to intercept Ollama checks in the autodetect path.
+      #
+      # New code should use {Woods::MCP::ProviderProbe.reachable!} via the
+      # ResolvedConfig flow.
       #
       # @return [Boolean]
       def self.ollama_reachable?
-        require 'net/http'
-        require 'uri'
-
-        base_url = ENV.fetch('OLLAMA_BASE_URL', 'http://localhost:11434')
-        uri = URI.parse(base_url)
-
-        Net::HTTP.start(uri.host, uri.port,
-                        open_timeout: 0.5, read_timeout: 0.5,
-                        use_ssl: uri.scheme == 'https') do |http|
-          response = http.get('/api/tags')
-          !response.is_a?(Net::HTTPServerError)
-        end
-      rescue StandardError
-        false
+        ConfigResolver.send(:ollama_reachable?)
       end
 
       # Resolve an IndexArtifact from the passed dir or Woods.configuration.
@@ -153,64 +148,6 @@ module Woods
         IndexArtifact.new(dir) if dir
       end
       private_class_method :build_artifact
-
-      # If the artifact has a woods.json, read it. Otherwise either
-      # raise MissingArtifact or — when WOODS_ALLOW_AUTODETECT=1 —
-      # fall through to env-var auto-detect. The env flag is opt-in
-      # because silent fallback was the failure mode we eliminated.
-      def self.resolve_or_autodetect(artifact)
-        config = Woods.configuration
-
-        if artifact && !artifact.fresh?
-          # Real config snapshot reading lands in PR 3 — for now, if the
-          # artifact has a woods.json we trust the host's initializer
-          # (which configured the provider) and skip autodetect.
-          return config
-        end
-
-        return config if config.embedding_provider
-
-        if ENV['WOODS_ALLOW_AUTODETECT'] != '1'
-          raise MissingArtifact.new(
-            'No woods.json found and WOODS_ALLOW_AUTODETECT is unset. ' \
-            'Run `bundle exec rake woods:extract` in your host app, or set ' \
-            'WOODS_ALLOW_AUTODETECT=1 to probe env vars (deprecated).',
-            details: { output_dir: artifact&.output_dir&.to_s }
-          )
-        end
-
-        warn '[woods-mcp] deprecated_autodetect: falling back to env-var auto-detect (no woods.json found)'
-        autodetect_config(config)
-      end
-      private_class_method :resolve_or_autodetect
-
-      # Legacy env-var auto-detect path. Only reachable when
-      # WOODS_ALLOW_AUTODETECT=1 and no woods.json is present. Mutates
-      # Woods.configuration — not great, but preserves the shape the
-      # HTTP entry point was written against. To be removed alongside
-      # the env-var path in a later PR.
-      def self.autodetect_config(config)
-        openai_key = ENV.fetch('OPENAI_API_KEY', nil)
-        if openai_key
-          config.vector_store = :in_memory
-          config.metadata_store = :in_memory
-          config.graph_store = :in_memory
-          config.embedding_provider = :openai
-          config.embedding_options = { api_key: openai_key }
-        elsif ollama_reachable?
-          config.vector_store = :in_memory
-          config.metadata_store = :in_memory
-          config.graph_store = :in_memory
-          config.embedding_provider = :ollama
-          config.embedding_options = {
-            host: ENV.fetch('OLLAMA_BASE_URL', 'http://localhost:11434'),
-            model: ENV.fetch('OLLAMA_EMBED_MODEL', 'nomic-embed-text')
-          }
-        end
-
-        config
-      end
-      private_class_method :autodetect_config
 
       def self.build_retriever_from_config(config, _resolved, _artifact)
         # Snapshotter hydration is stubbed in PR 2 — the Builder constructs

--- a/lib/woods/mcp/config_resolver.rb
+++ b/lib/woods/mcp/config_resolver.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+
+require_relative 'errors'
+require_relative '../resolved_config'
+
+module Woods
+  module MCP
+    # Resolves the embedding configuration that the MCP server should use.
+    #
+    # Reads +woods.json+ (the resolved config snapshot written at embed time),
+    # applies environment-variable overrides, validates, and returns either a
+    # populated {Woods::Configuration} or raises a typed {BootstrapError}
+    # subclass that the caller can present to an operator.
+    #
+    # This class is extracted from {Bootstrapper} to isolate the
+    # config-resolution concern from network probing and store construction.
+    # {Bootstrapper} delegates to {.resolve} as its first step.
+    #
+    # Resolution order (highest priority first):
+    #
+    # 1. Host Rails initializer (Woods.configuration already has embedding_provider).
+    #    When +woods.json+ is also present the stored config is loaded and asserted
+    #    compatible via {ResolvedConfig#assert_compatible!}.
+    # 2. +woods.json+ snapshot alone (MCP server running without a host initializer).
+    #    The stored config is used to populate +config+ in place.
+    # 3. Environment-variable auto-detect (deprecated, opt-in via
+    #    +WOODS_ALLOW_AUTODETECT=1+). Mutates +config+ to set provider and stores.
+    # 4. If none of the above applies, raises {MissingArtifact}.
+    #
+    # @example Typical Bootstrapper usage
+    #   config, source = ConfigResolver.resolve(Woods.configuration, artifact: artifact)
+    #   # config.embedding_provider is now guaranteed to be non-nil (or :none was returned)
+    #
+    module ConfigResolver
+      # Resolve and validate the embedding configuration.
+      #
+      # When +woods.json+ is present in the artifact directory it is parsed into
+      # a {ResolvedConfig} and, if the host already has a provider configured,
+      # validated for compatibility (dimension + provider class/model must agree).
+      # If the host has no provider configured the stored config is applied to
+      # +config+ so {Builder} can construct the correct provider.
+      #
+      # When +woods.json+ is absent and the host already has a provider
+      # configured, the host config is trusted and used as-is.
+      #
+      # When +woods.json+ is absent and the host has no provider configured:
+      # - If +WOODS_ALLOW_AUTODETECT+ is +1+, falls through to env-var
+      #   auto-detect (deprecated, emits a structured warning).
+      # - Otherwise raises {MissingArtifact}.
+      #
+      # @param config [Woods::Configuration] the live host configuration object.
+      #   May be mutated in the auto-detect path.
+      # @param artifact [Woods::IndexArtifact, nil] the on-disk artifact wrapper.
+      # @param env [Hash] environment variable source (default +ENV+, overridable
+      #   in specs without stubbing the global ENV).
+      # @param ollama_probe [#call, nil] callable used to check Ollama reachability
+      #   in the deprecated auto-detect path. Defaults to {.ollama_reachable?} on
+      #   this module. Callers may pass a different probe to facilitate testing
+      #   without touching global state.
+      # @return [Array(Woods::Configuration, Symbol)] tuple of +[config, source]+
+      #   where +source+ is one of +:snapshot+, +:host_config+, +:autodetect+,
+      #   or +:none+. The config is the same object passed in, possibly mutated.
+      # @raise [Woods::MCP::MissingArtifact] when +woods.json+ is absent, the
+      #   host has no provider configured, and +WOODS_ALLOW_AUTODETECT+ is unset.
+      # @raise [Woods::MCP::UnsupportedArtifact] when +woods.json+ has an
+      #   unsupported +schema_version+.
+      # @raise [Woods::MCP::DimensionMismatch] when stored and live provider
+      #   dimensions disagree.
+      # @raise [Woods::MCP::ConfigMismatch] when stored and live provider
+      #   class/model disagree.
+      def self.resolve(config, artifact:, env: ENV, ollama_probe: nil)
+        stored = read_stored_config(artifact)
+
+        if stored
+          [apply_stored_config(config, stored, artifact: artifact), :snapshot]
+        elsif config.embedding_provider
+          # Host initializer configured a provider; no woods.json to validate
+          # against. Trust the host config and proceed.
+          [config, :host_config]
+        else
+          resolve_without_artifact(config, artifact: artifact, env: env, ollama_probe: ollama_probe)
+        end
+      end
+
+      # Read and parse +woods.json+ if it exists.
+      #
+      # @param artifact [Woods::IndexArtifact, nil]
+      # @return [Woods::ResolvedConfig, nil]
+      # @raise [Woods::MCP::UnsupportedArtifact] if the file has an unsupported
+      #   schema version.
+      def self.read_stored_config(artifact)
+        return nil unless artifact&.config_path&.exist?
+
+        raw = artifact.read_config
+        return nil unless raw
+
+        ResolvedConfig.from_hash(raw)
+      end
+      private_class_method :read_stored_config
+
+      # Reconcile the live host config against a stored {ResolvedConfig}.
+      #
+      # When the host has an +embedding_provider+ configured, assert that it
+      # matches the stored config. When the host has no provider configured,
+      # populate +config+ from the stored values so {Builder} can construct
+      # the correct provider.
+      #
+      # @param config [Woods::Configuration]
+      # @param stored [Woods::ResolvedConfig]
+      # @param artifact [Woods::IndexArtifact]
+      # @return [Woods::Configuration]
+      def self.apply_stored_config(config, stored, artifact:)
+        if config.embedding_provider
+          live = ResolvedConfig.from_configuration(config)
+          live.assert_compatible!(stored)
+          config
+        else
+          populate_from_stored(config, stored, artifact: artifact)
+        end
+      end
+      private_class_method :apply_stored_config
+
+      # Populate a blank {Woods::Configuration} from a stored {ResolvedConfig}.
+      #
+      # Maps the serialised provider class name back to the +:ollama+ /
+      # +:openai+ symbol that {Builder} expects, and restores store types.
+      # Applied when an MCP server starts without a host Rails initializer.
+      #
+      # @param config [Woods::Configuration]
+      # @param stored [Woods::ResolvedConfig]
+      # @param artifact [Woods::IndexArtifact]
+      # @return [Woods::Configuration]
+      def self.populate_from_stored(config, stored, artifact:)
+        config.vector_store = stored.stores[:vector_store] || :in_memory
+        config.metadata_store = stored.stores[:metadata_store] || :in_memory
+        config.graph_store = stored.stores[:graph_store] || :in_memory
+        config.embedding_provider = provider_symbol(stored.embedding_provider[:class])
+
+        opts = {}
+        opts[:model] = stored.embedding_provider[:model] if stored.embedding_provider[:model]
+        opts[:host] = stored.embedding_provider[:host] if stored.embedding_provider[:host]
+        opts[:num_ctx] = stored.embedding_provider[:num_ctx] if stored.embedding_provider[:num_ctx]
+        opts[:read_timeout] = stored.embedding_provider[:read_timeout] if stored.embedding_provider[:read_timeout]
+        opts[:dimension] = stored.embedding_provider[:dimension] if stored.embedding_provider[:dimension]&.positive?
+        config.embedding_options = opts unless opts.empty?
+
+        warn "[woods-mcp] config_source: loaded from woods.json (#{artifact.config_path})"
+        config
+      end
+      private_class_method :populate_from_stored
+
+      # Convert a fully-qualified provider class name back to the symbol
+      # that {Builder} understands.
+      #
+      # @param class_name [String]
+      # @return [Symbol, String] symbol for known providers, raw string otherwise
+      def self.provider_symbol(class_name)
+        case class_name.to_s
+        when /Ollama/ then :ollama
+        when /OpenAI/ then :openai
+        else class_name.to_s
+        end
+      end
+      private_class_method :provider_symbol
+
+      # Handle the no-artifact, no-host-provider case.
+      #
+      # Raises {MissingArtifact} unless +WOODS_ALLOW_AUTODETECT=1+ opts in to
+      # the deprecated env-var auto-detect path.
+      #
+      # @param config [Woods::Configuration]
+      # @param artifact [Woods::IndexArtifact, nil]
+      # @param env [Hash]
+      # @param ollama_probe [#call, nil]
+      # @return [Woods::Configuration]
+      # @raise [Woods::MCP::MissingArtifact]
+      def self.resolve_without_artifact(config, artifact:, env:, ollama_probe:)
+        if env['WOODS_ALLOW_AUTODETECT'] != '1'
+          raise MissingArtifact.new(
+            'No woods.json found and WOODS_ALLOW_AUTODETECT is unset. ' \
+            'Run `bundle exec rake woods:extract` in your host app, or set ' \
+            'WOODS_ALLOW_AUTODETECT=1 to probe env vars (deprecated).',
+            details: { output_dir: artifact&.output_dir&.to_s }
+          )
+        end
+
+        warn '[woods-mcp] deprecated_autodetect: falling back to env-var auto-detect (no woods.json found)'
+        [autodetect_from_env(config, env: env, ollama_probe: ollama_probe), :autodetect]
+      end
+      private_class_method :resolve_without_artifact
+
+      # Probe environment variables for provider credentials and configure
+      # +config+ accordingly.
+      #
+      # Only reachable when +WOODS_ALLOW_AUTODETECT=1+ and no +woods.json+
+      # is present. Mutates +config+ to set provider and stores when a
+      # credential or reachable Ollama instance is found.
+      #
+      # @param config [Woods::Configuration]
+      # @param env [Hash]
+      # @param ollama_probe [#call, nil] callable for Ollama reachability check;
+      #   defaults to {.ollama_reachable?} on this module when nil.
+      # @return [Woods::Configuration]
+      def self.autodetect_from_env(config, env:, ollama_probe:)
+        probe = ollama_probe || method(:ollama_reachable?)
+        openai_key = env.fetch('OPENAI_API_KEY', nil)
+        if openai_key
+          config.vector_store = :in_memory
+          config.metadata_store = :in_memory
+          config.graph_store = :in_memory
+          config.embedding_provider = :openai
+          config.embedding_options = { api_key: openai_key }
+        elsif probe.call
+          config.vector_store = :in_memory
+          config.metadata_store = :in_memory
+          config.graph_store = :in_memory
+          config.embedding_provider = :ollama
+          config.embedding_options = {
+            host: env.fetch('OLLAMA_BASE_URL', 'http://localhost:11434'),
+            model: env.fetch('OLLAMA_EMBED_MODEL', 'nomic-embed-text')
+          }
+        end
+
+        config
+      end
+      private_class_method :autodetect_from_env
+
+      # Check whether Ollama is reachable at the configured base URL.
+      #
+      # Used as the default probe in the deprecated auto-detect path. Callers
+      # may inject a different probe via +ollama_probe:+ kwarg.
+      #
+      # @return [Boolean]
+      def self.ollama_reachable?
+        require 'net/http'
+        require 'uri'
+
+        base_url = ENV.fetch('OLLAMA_BASE_URL', 'http://localhost:11434')
+        uri = URI.parse(base_url)
+        Net::HTTP.start(uri.host, uri.port,
+                        open_timeout: 0.5, read_timeout: 0.5,
+                        use_ssl: uri.scheme == 'https') do |http|
+          response = http.get('/api/tags')
+          !response.is_a?(Net::HTTPServerError)
+        end
+      rescue StandardError
+        false
+      end
+      private_class_method :ollama_reachable?
+    end
+  end
+end

--- a/lib/woods/storage/metadata_store.rb
+++ b/lib/woods/storage/metadata_store.rb
@@ -163,6 +163,31 @@ module Woods
           @data.size
         end
 
+        # Iterate over every stored entry, yielding +(id, metadata)+ pairs.
+        #
+        # Persistence seam for {Snapshotter::Metadata}. Yields the raw internal
+        # hash (including +updated_at+) so the Snapshotter can reconstruct state
+        # faithfully on load.
+        #
+        # @yield [id, metadata] id is a String; metadata is a Hash with string keys
+        # @return [Enumerator] when no block given
+        def each_entry(&block)
+          return enum_for(:each_entry) unless block
+
+          @data.each(&block)
+        end
+
+        # Hydrate the store from a pre-serialized dump.
+        #
+        # Dual of {#each_entry} — Snapshotter feeds the deserialized dump contents
+        # through this method to restore the store in a new process.
+        #
+        # @param entries [Enumerable<Array(String, Hash)>] Pairs of +[id, metadata]+
+        # @return [void]
+        def bulk_load(entries)
+          entries.each { |id, meta| @data[id] = meta }
+        end
+
         private
 
         # Match the SQLite adapter's string-key contract regardless of how

--- a/lib/woods/storage/snapshotter/metadata.rb
+++ b/lib/woods/storage/snapshotter/metadata.rb
@@ -1,57 +1,153 @@
 # frozen_string_literal: true
 
 require 'pathname'
+require 'tempfile'
+require 'time'
+require 'msgpack'
+require 'woods/version'
 require 'woods/storage/metadata_store'
 require 'woods/mcp/errors'
 
 module Woods
   module Storage
     module Snapshotter
-      # Stub implementation of the metadata store snapshotter for PR 2.
+      # Reads and writes the metadata store snapshot (+metadata.msgpack+).
       #
-      # +load_or_empty+ always returns a fresh {MetadataStore::InMemory} — the real
-      # MessagePack read path is wired in PR 3.
+      # MessagePack is chosen over +pack("e*")+ because metadata is heterogeneous
+      # hash-shaped data — type tags matter here. The vector format uses packed
+      # float32 for dense numeric data; metadata uses MessagePack for everything else.
       #
-      # +dump+ is a validated no-op — the real write path (+metadata.msgpack+) is
-      # wired in PR 3.
+      # == On-disk format
       #
-      # Input validation IS load-bearing even for stubs:
-      # - Raises {InapplicableBackend} if +store+ does not respond to both +#each_entry+
-      #   and +#bulk_load+ (the persistence seam contract).
-      # - Raises +ArgumentError+ if +dump_dir+ is not under +artifact.dumps_root+.
+      # A stream of MessagePack-packed objects in a single file:
+      #
+      # 1. Header hash (one MessagePack object):
+      #      { "magic" => "WMD1", "schema_version" => 1, "record_count" => N,
+      #        "gem_version" => "1.2.0", "created_at" => "2026-04-23T03:42:17Z" }
+      #
+      # 2. One hash per record, streamed directly after the header:
+      #      { "id" => "PostsController", "metadata" => { ... } }
+      #
+      # Stream-written via +MessagePack::Packer+ to avoid loading all records into
+      # memory at once. Stream-read via +MessagePack::Unpacker+ on load. Written
+      # atomically via +Tempfile+ + +File.rename+.
       #
       # @see Snapshotter::Vector companion class for vector stores
       module Metadata
-        # Returns an empty in-memory metadata store.
+        # Magic string identifying a valid Woods Metadata Dump file.
+        MAGIC = 'WMD1'
+
+        # Current schema version written by this implementation.
+        SCHEMA_VERSION = 1
+
+        # Maximum schema version this code can read. A dump with a higher version
+        # raises {Woods::MCP::UnsupportedArtifact} rather than silently misreading data.
+        MAX_SUPPORTED_SCHEMA_VERSION = 1
+
+        # Filename written inside the dump directory.
+        FILENAME = 'metadata.msgpack'
+
+        # Load a metadata store from the latest dump in +artifact+, or return an
+        # empty store if no dump exists yet.
         #
-        # PR 3 will replace this stub with a real MessagePack read of +metadata.msgpack+
-        # from +artifact.latest_dump_path+. Callers must not assume the store is populated.
+        # Never raises for a missing dump — callers that need an empty store on
+        # first run get one without special-casing.
         #
         # @param artifact [Woods::IndexArtifact] the artifact layout object
-        # @param resolved_config [#dimension, nil] reserved for PR 3 dimension validation
+        # @param resolved_config [Object, nil] reserved for future validation
         # @return [Woods::Storage::MetadataStore::InMemory]
+        # @raise [Woods::MCP::UnsupportedArtifact] if magic is wrong or schema_version
+        #   exceeds {MAX_SUPPORTED_SCHEMA_VERSION}
         def self.load_or_empty(artifact, resolved_config: nil) # rubocop:disable Lint/UnusedMethodArgument
-          MetadataStore::InMemory.new
+          dump_path = dump_file_path(artifact)
+          return MetadataStore::InMemory.new unless dump_path&.exist?
+
+          store = MetadataStore::InMemory.new
+          File.open(dump_path.to_s, 'rb') do |io|
+            unpacker = MessagePack::Unpacker.new(io)
+            header = unpacker.read
+            validate_header!(header, dump_path)
+            header['record_count'].times do
+              record = unpacker.read
+              store.store(record['id'], record['metadata'])
+            end
+          end
+          store
         end
 
-        # No-op dump — validates inputs then returns without writing anything.
+        # Write the metadata store to +dump_dir/metadata.msgpack+ atomically.
         #
-        # PR 3 will replace the body with real MessagePack serialization.
+        # Streams header then one packed hash per record — no full in-memory copy
+        # of the record set. Uses +Tempfile+ + +File.rename+ for atomicity.
         #
         # @param store [#each_entry, #bulk_load] an in-memory MetadataStore adapter
         # @param artifact [Woods::IndexArtifact] the artifact layout object
         # @param dump_dir [Pathname, String] target directory; must be under +artifact.dumps_root+
+        # @param resolved_config [Object, nil] reserved for future use
         # @return [void]
         # @raise [Woods::Storage::InapplicableBackend] if +store+ lacks +#each_entry+ or +#bulk_load+
         # @raise [ArgumentError] if +dump_dir+ is not under +artifact.dumps_root+
-        def self.dump(store, artifact, dump_dir)
+        def self.dump(store, artifact, dump_dir, resolved_config: nil) # rubocop:disable Lint/UnusedMethodArgument
           validate_store!(store)
           validate_dump_dir!(artifact, dump_dir)
-          # no-op: real write path wired in PR 3
+          target = Pathname.new(dump_dir.to_s).join(FILENAME)
+          target.dirname.mkpath
+          write_atomic(target, store)
+          nil
         end
 
         class << self
           private
+
+          def dump_file_path(artifact)
+            latest = artifact.latest_dump_path
+            return nil unless latest
+
+            latest.join(FILENAME)
+          end
+
+          def validate_header!(header, path)
+            unless header.is_a?(Hash) && header['magic'] == MAGIC
+              raise Woods::MCP::UnsupportedArtifact,
+                    "metadata.msgpack at #{path} has invalid magic " \
+                    "(got #{header.is_a?(Hash) ? header['magic'].inspect : 'non-hash'}; " \
+                    "expected #{MAGIC.inspect}). The file may be corrupt or from an incompatible tool."
+            end
+
+            version = header['schema_version']
+            return if version <= MAX_SUPPORTED_SCHEMA_VERSION
+
+            raise Woods::MCP::UnsupportedArtifact,
+                  "metadata.msgpack at #{path} has schema_version #{version}; " \
+                  "this gem supports up to #{MAX_SUPPORTED_SCHEMA_VERSION}. " \
+                  'Upgrade the woods gem or re-run woods:embed to regenerate.'
+          end
+
+          # Write +store+ contents to +target+ atomically via a sibling Tempfile + rename.
+          # Streams header then one record hash per entry.
+          #
+          # @param target [Pathname] final destination
+          # @param store [#count, #each_entry] populated metadata store
+          def write_atomic(target, store)
+            tmp = Tempfile.new([FILENAME, '.tmp'], target.dirname.to_s)
+            begin
+              tmp.binmode
+              packer = MessagePack::Packer.new(tmp)
+              packer.write('magic' => MAGIC, 'schema_version' => SCHEMA_VERSION,
+                           'record_count' => store.count, 'gem_version' => Woods::VERSION,
+                           'created_at' => Time.now.utc.iso8601)
+              store.each_entry { |id, metadata| packer.write('id' => id, 'metadata' => metadata) }
+              packer.flush
+              tmp.flush
+              tmp.fsync
+              tmp.close
+              File.rename(tmp.path, target.to_s)
+            rescue StandardError
+              tmp.close
+              tmp.unlink
+              raise
+            end
+          end
 
           def validate_store!(store)
             return if store.respond_to?(:each_entry) && store.respond_to?(:bulk_load)

--- a/lib/woods/storage/snapshotter/vector.rb
+++ b/lib/woods/storage/snapshotter/vector.rb
@@ -1,57 +1,206 @@
 # frozen_string_literal: true
 
 require 'pathname'
+require 'tempfile'
 require 'woods/storage/vector_store'
 require 'woods/mcp/errors'
+require 'woods/version'
 
 module Woods
   module Storage
     module Snapshotter
-      # Stub implementation of the vector store snapshotter for PR 2.
+      # Reads and writes the +vectors.bin+ / +vectors.idx+ on-disk format.
       #
-      # +load_or_empty+ always returns a fresh {VectorStore::InMemory} — the real
-      # pack("e*") read path is wired in PR 3.
+      # Binary layout of +vectors.bin+ (all integers little-endian):
       #
-      # +dump+ is a validated no-op — the real write path (+vectors.bin+ + +vectors.idx+)
-      # is wired in PR 3.
+      #   offset  length   field
+      #     0     4 bytes  magic "WVF1"
+      #     4     4 bytes  schema_version (u32 LE)
+      #     8     4 bytes  dimension (u32 LE)
+      #    12     8 bytes  vector_count (u64 LE)
+      #    20     4 bytes  gem_version_length (u32 LE)
+      #    24     N bytes  gem_version (UTF-8)
+      #    24+N   4 bytes  model_name_length (u32 LE)
+      #    28+N   M bytes  model_name (UTF-8)
+      #    ...    —        packed float32 data (vector_count × dimension × 4 bytes)
       #
-      # Input validation IS load-bearing even for stubs:
-      # - Raises {InapplicableBackend} if +store+ does not respond to both +#each_entry+
-      #   and +#bulk_load+ (the persistence seam contract).
-      # - Raises +ArgumentError+ if +dump_dir+ is not under +artifact.dumps_root+.
+      # +vectors.idx+ (one record per vector):
+      #   4 bytes  id_length (u32 LE) + N bytes id (UTF-8) + 8 bytes offset (u64 LE)
       #
-      # @see Snapshotter::Metadata companion class for metadata stores
-      module Vector
-        # Returns an empty in-memory vector store.
+      # Atomic writes use +Tempfile+ + +File.rename+ for crash safety.
+      #
+      # @see Snapshotter::Metadata companion for metadata stores
+      module Vector # rubocop:disable Metrics/ModuleLength
+        MAGIC = 'WVF1'
+        SCHEMA_VERSION_SUPPORTED = 1
+
+        # Returns a populated in-memory vector store loaded from the latest dump,
+        # or an empty store when no dump exists yet.
         #
-        # PR 3 will replace this stub with a real read of +vectors.bin+ from
-        # +artifact.latest_dump_path+. Callers must not assume the store is populated.
-        #
-        # @param artifact [Woods::IndexArtifact] the artifact layout object
-        # @param resolved_config [#dimension, nil] reserved for PR 3 dimension validation
+        # @param artifact [Woods::IndexArtifact] artifact layout object
+        # @param resolved_config [#dimension, nil] used for dimension validation
         # @return [Woods::Storage::VectorStore::InMemory]
-        def self.load_or_empty(artifact, resolved_config: nil) # rubocop:disable Lint/UnusedMethodArgument
-          VectorStore::InMemory.new
+        # @raise [Woods::MCP::UnsupportedArtifact] if magic or schema_version is invalid
+        # @raise [Woods::MCP::DimensionMismatch] if stored dimension ≠ +resolved_config.dimension+
+        def self.load_or_empty(artifact, resolved_config: nil)
+          dump_dir = artifact.latest_dump_path
+          return VectorStore::InMemory.new if dump_dir.nil?
+
+          bin_path = dump_dir.join('vectors.bin')
+          idx_path = dump_dir.join('vectors.idx')
+          return VectorStore::InMemory.new unless bin_path.exist? && idx_path.exist?
+
+          load_from(bin_path, idx_path, resolved_config)
         end
 
-        # No-op dump — validates inputs then returns without writing anything.
+        # Writes +vectors.bin+ and +vectors.idx+ into +dump_dir+ atomically.
         #
-        # PR 3 will replace the body with real +pack("e*")+ + header + idx writes.
-        #
-        # @param store [#each_entry, #bulk_load] an in-memory VectorStore adapter
-        # @param artifact [Woods::IndexArtifact] the artifact layout object
+        # @param store [#each_entry, #bulk_load] in-memory vector store adapter
+        # @param artifact [Woods::IndexArtifact] artifact layout object
         # @param dump_dir [Pathname, String] target directory; must be under +artifact.dumps_root+
+        # @param resolved_config [#model_name, nil] model name written to header
         # @return [void]
-        # @raise [Woods::Storage::InapplicableBackend] if +store+ lacks +#each_entry+ or +#bulk_load+
+        # @raise [Woods::Storage::InapplicableBackend] if +store+ lacks +#each_entry+ / +#bulk_load+
         # @raise [ArgumentError] if +dump_dir+ is not under +artifact.dumps_root+
-        def self.dump(store, artifact, dump_dir)
+        def self.dump(store, artifact, dump_dir, resolved_config: nil)
           validate_store!(store)
-          validate_dump_dir!(artifact, dump_dir)
-          # no-op: real write path wired in PR 3
+          validate_dump_dir!(artifact, Pathname.new(dump_dir.to_s))
+          model_name = resolved_config.respond_to?(:model_name) ? resolved_config.model_name.to_s : ''
+          entries = store.each_entry.to_a
+          write_bin_and_idx(Pathname.new(dump_dir.to_s), entries, Woods::VERSION, model_name)
+          nil
         end
 
-        class << self
+        class << self # rubocop:disable Metrics/ClassLength
           private
+
+          def load_from(bin_path, idx_path, resolved_config)
+            bin_data = File.binread(bin_path.to_s)
+            header, data_offset = parse_header(bin_data, bin_path)
+            validate_magic!(header[:magic], bin_path)
+            validate_schema_version!(header[:schema_version], bin_path)
+            dim = resolved_config.respond_to?(:dimension) ? resolved_config.dimension : nil
+            validate_dimension!(header[:dimension], dim, bin_path) if dim
+            floats = bin_data.byteslice(data_offset, header[:vector_count] * header[:dimension] * 4)
+                             .unpack("e#{header[:vector_count] * header[:dimension]}")
+            hydrate_store(parse_idx(idx_path), floats, header[:dimension])
+          end
+
+          def parse_header(bin_data, bin_path)
+            if bin_data.bytesize < 20
+              raise Woods::MCP::UnsupportedArtifact.new(
+                "#{bin_path}: file too short to contain a valid WVF1 header",
+                details: { path: bin_path.to_s, found: bin_data.byteslice(0, 4) }
+              )
+            end
+            magic = bin_data.byteslice(0, 4)
+            schema_version, dimension = bin_data.byteslice(4, 8).unpack('L<L<')
+            vector_count = bin_data.byteslice(12, 8).unpack1('Q<')
+            gv_len = bin_data.byteslice(20, 4).unpack1('L<')
+            off = 24 + gv_len
+            mn_len = bin_data.byteslice(off, 4).unpack1('L<')
+            off += 4 + mn_len
+            [{ magic: magic, schema_version: schema_version,
+               dimension: dimension, vector_count: vector_count }, off]
+          end
+
+          def parse_idx(idx_path)
+            idx_data = File.binread(idx_path.to_s)
+            pairs = []
+            pos = 0
+            while pos < idx_data.bytesize
+              id_len = idx_data.byteslice(pos, 4).unpack1('L<')
+              pos += 4
+              id = idx_data.byteslice(pos, id_len)
+              pos += id_len + 8 # skip the u64 offset (not needed for load)
+              pairs << id
+            end
+            pairs
+          end
+
+          def hydrate_store(ids, floats, dim)
+            store = VectorStore::InMemory.new
+            entries = ids.each_with_index.map do |id, idx|
+              { id: id, vector: floats[(idx * dim), dim], metadata: {} }
+            end
+            store.bulk_load(entries)
+            store
+          end
+
+          def validate_magic!(found, path)
+            return if found == MAGIC
+
+            raise Woods::MCP::UnsupportedArtifact.new(
+              "#{path}: invalid magic bytes (expected #{MAGIC.inspect}, found #{found.inspect})",
+              details: { path: path.to_s, expected: MAGIC, found: found }
+            )
+          end
+
+          def validate_schema_version!(version, path)
+            return if version <= SCHEMA_VERSION_SUPPORTED
+
+            raise Woods::MCP::UnsupportedArtifact.new(
+              "#{path}: schema_version #{version} > supported max #{SCHEMA_VERSION_SUPPORTED}; " \
+              'upgrade the woods gem to read this artifact',
+              details: { path: path.to_s, artifact_version: version, max_supported: SCHEMA_VERSION_SUPPORTED }
+            )
+          end
+
+          def validate_dimension!(stored, expected, path)
+            return if stored == expected
+
+            raise Woods::MCP::DimensionMismatch.new(
+              "#{path}: stored dimension #{stored} ≠ provider dimension #{expected}",
+              details: { path: path.to_s, stored_dimension: stored, provider_dimension: expected }
+            )
+          end
+
+          def write_bin_and_idx(dump_dir, entries, gem_version, model_name)
+            header = build_header(entries, gem_version, model_name)
+            float_blob = entries.flat_map { |(_id, vector, _meta)| vector }.pack('e*')
+            idx_data = build_idx(entries, header.bytesize)
+            atomic_write(dump_dir.join('vectors.bin'), header + float_blob, binary: true)
+            atomic_write(dump_dir.join('vectors.idx'), idx_data, binary: true)
+          end
+
+          def build_header(entries, gem_version, model_name)
+            dim = entries.empty? ? 0 : entries.first[1].size
+            gv = gem_version.encode('UTF-8').b
+            mn = model_name.encode('UTF-8').b
+            buf = String.new(encoding: 'BINARY')
+            buf << MAGIC << [SCHEMA_VERSION_SUPPORTED, dim].pack('L<L<')
+            buf << [entries.size].pack('Q<')
+            buf << [gv.bytesize].pack('L<') << gv
+            buf << [mn.bytesize].pack('L<') << mn
+            buf
+          end
+
+          def build_idx(entries, header_size)
+            buf = String.new(encoding: 'BINARY')
+            float_offset = header_size
+            entries.each do |id, vector, _meta|
+              id_bytes = id.encode('UTF-8').b
+              buf << [id_bytes.bytesize].pack('L<') << id_bytes
+              buf << [float_offset].pack('Q<')
+              float_offset += vector.size * 4
+            end
+            buf
+          end
+
+          def atomic_write(path, content, binary: false)
+            FileUtils.mkdir_p(path.dirname) unless path.dirname.exist?
+            tmp = Tempfile.new('.woods-vec-', path.dirname.to_s)
+            tmp.binmode if binary
+            tmp.write(content)
+            tmp.flush
+            tmp.fsync
+            tmp.close
+            File.rename(tmp.path, path.to_s)
+          rescue StandardError
+            tmp&.close
+            tmp&.unlink
+            raise
+          end
 
           def validate_store!(store)
             return if store.respond_to?(:each_entry) && store.respond_to?(:bulk_load)
@@ -60,14 +209,13 @@ module Woods
                   "backend #{store.class} is already durable — Snapshotter should not have been invoked"
           end
 
-          def validate_dump_dir!(artifact, dump_dir)
-            dump_path = Pathname.new(dump_dir.to_s).expand_path
+          def validate_dump_dir!(artifact, dump_path)
+            expanded = dump_path.expand_path
             root = artifact.dumps_root.expand_path
-
-            return if dump_path.to_s.start_with?("#{root}/") || dump_path == root
+            return if expanded.to_s.start_with?("#{root}/") || expanded == root
 
             raise ArgumentError,
-                  "dump_dir #{dump_path} is not under artifact.dumps_root #{root}"
+                  "dump_dir #{expanded} is not under artifact.dumps_root #{root}"
           end
         end
       end

--- a/spec/embedding/indexer_spec.rb
+++ b/spec/embedding/indexer_spec.rb
@@ -439,4 +439,224 @@ RSpec.describe Woods::Embedding::Indexer do
       expect(recorded_texts).to all(satisfy { |t| t.length <= budget })
     end
   end
+
+  # Persistence is activated only when the vector store responds to #each_entry
+  # and #bulk_load (the in-memory seam). Snapshotter::Vector and ::Metadata are
+  # in-flight work from other teammates; we use instance_doubles so these specs
+  # don't depend on their real implementations landing first.
+  describe 'persistence after index_all' do
+    require 'woods/index_artifact'
+    require 'woods/storage/snapshotter'
+
+    let(:persistable_store) do
+      store = Woods::Storage::VectorStore::InMemory.new
+      allow(store).to receive(:each_entry).and_yield('User', [0.1, 0.2], { type: 'model' })
+      allow(store).to receive(:bulk_load)
+      store
+    end
+
+    # Snapshotters are modules whose implementations land in a parallel PR.
+    # Use plain doubles so these specs don't depend on the real implementations.
+    let(:vector_snapshotter) { double('Snapshotter::Vector') }
+    let(:metadata_snapshotter) { double('Snapshotter::Metadata') }
+
+    let(:resolved_config) do
+      double('ResolvedConfig',
+             to_snapshot_json: { 'schema_version' => 1, 'gem_version' => '0.0.1',
+                                 'created_at' => '2026-04-22T00:00:00Z',
+                                 'embedding_provider' => {}, 'stores' => {} })
+    end
+
+    let(:persistent_indexer) do
+      described_class.new(
+        provider: provider,
+        text_preparer: text_preparer,
+        vector_store: persistable_store,
+        output_dir: output_dir,
+        batch_size: 2,
+        metadata_store: nil,
+        resolved_config: resolved_config,
+        dump_retention_count: 3
+      )
+    end
+
+    before do
+      File.write(File.join(output_dir, 'user.json'), JSON.generate(unit_data))
+    end
+
+    it 'calls Snapshotter::Vector.dump with the store and a dump_dir under dumps/' do
+      stub_const('Woods::Storage::Snapshotter::Vector', vector_snapshotter)
+      stub_const('Woods::Storage::Snapshotter::Metadata', metadata_snapshotter)
+
+      expect(vector_snapshotter).to receive(:dump) do |store, _artifact, dump_dir|
+        expect(store).to eq(persistable_store)
+        expect(dump_dir.to_s).to include('dumps')
+      end
+
+      persistent_indexer.index_all
+    end
+
+    it 'writes woods.json to output_dir after a successful run' do
+      stub_const('Woods::Storage::Snapshotter::Vector', vector_snapshotter)
+      stub_const('Woods::Storage::Snapshotter::Metadata', metadata_snapshotter)
+      allow(vector_snapshotter).to receive(:dump)
+
+      persistent_indexer.index_all
+
+      config_path = File.join(output_dir, 'woods.json')
+      expect(File.exist?(config_path)).to be true
+      parsed = JSON.parse(File.read(config_path))
+      expect(parsed['schema_version']).to eq(1)
+    end
+
+    it 'flips the latest pointer after a successful run' do
+      stub_const('Woods::Storage::Snapshotter::Vector', vector_snapshotter)
+      stub_const('Woods::Storage::Snapshotter::Metadata', metadata_snapshotter)
+      allow(vector_snapshotter).to receive(:dump)
+
+      persistent_indexer.index_all
+
+      latest_path = File.join(output_dir, 'dumps', 'latest')
+      expect(File.exist?(latest_path)).to be true
+      latest = File.read(latest_path).strip
+      expect(latest).not_to be_empty
+      expect(File.directory?(File.join(output_dir, 'dumps', latest))).to be true
+    end
+
+    it 'does not call Snapshotter for metadata when metadata_store is nil' do
+      stub_const('Woods::Storage::Snapshotter::Vector', vector_snapshotter)
+      stub_const('Woods::Storage::Snapshotter::Metadata', metadata_snapshotter)
+      allow(vector_snapshotter).to receive(:dump)
+
+      expect(metadata_snapshotter).not_to receive(:dump)
+
+      persistent_indexer.index_all
+    end
+
+    context 'when metadata_store is provided and supports the seam' do
+      let(:persistable_metadata_store) do
+        store = double('MetadataStore::InMemory')
+        allow(store).to receive(:each_entry)
+        allow(store).to receive(:bulk_load)
+        store
+      end
+
+      let(:indexer_with_metadata) do
+        described_class.new(
+          provider: provider,
+          text_preparer: text_preparer,
+          vector_store: persistable_store,
+          output_dir: output_dir,
+          batch_size: 2,
+          metadata_store: persistable_metadata_store,
+          resolved_config: resolved_config,
+          dump_retention_count: 3
+        )
+      end
+
+      it 'calls Snapshotter::Metadata.dump when metadata_store has the seam' do
+        stub_const('Woods::Storage::Snapshotter::Vector', vector_snapshotter)
+        stub_const('Woods::Storage::Snapshotter::Metadata', metadata_snapshotter)
+        allow(vector_snapshotter).to receive(:dump)
+
+        expect(metadata_snapshotter).to receive(:dump) do |store, _artifact, dump_dir|
+          expect(store).to eq(persistable_metadata_store)
+          expect(dump_dir.to_s).to include('dumps')
+        end
+
+        indexer_with_metadata.index_all
+      end
+    end
+
+    context 'when vector_store does not support the persistence seam' do
+      let(:non_persistable_store) do
+        double('SomeExternalStore')
+        # does NOT respond to each_entry / bulk_load
+      end
+
+      let(:non_persistent_indexer) do
+        described_class.new(
+          provider: provider,
+          text_preparer: text_preparer,
+          vector_store: non_persistable_store,
+          output_dir: output_dir,
+          batch_size: 2,
+          resolved_config: resolved_config,
+          dump_retention_count: 3
+        )
+      end
+
+      before do
+        allow(non_persistable_store).to receive(:store_batch)
+      end
+
+      it 'does not attempt persistence' do
+        stub_const('Woods::Storage::Snapshotter::Vector', vector_snapshotter)
+        expect(vector_snapshotter).not_to receive(:dump)
+
+        non_persistent_indexer.index_all
+      end
+
+      it 'does not write woods.json' do
+        stub_const('Woods::Storage::Snapshotter::Vector', vector_snapshotter)
+
+        non_persistent_indexer.index_all
+
+        expect(File.exist?(File.join(output_dir, 'woods.json'))).to be false
+      end
+    end
+
+    context 'dump retention' do
+      let(:indexer_with_retention) do
+        described_class.new(
+          provider: provider,
+          text_preparer: text_preparer,
+          vector_store: persistable_store,
+          output_dir: output_dir,
+          batch_size: 2,
+          resolved_config: resolved_config,
+          dump_retention_count: 2
+        )
+      end
+
+      it 'prunes old dump directories beyond the retention count' do
+        stub_const('Woods::Storage::Snapshotter::Vector', vector_snapshotter)
+        stub_const('Woods::Storage::Snapshotter::Metadata', metadata_snapshotter)
+        allow(vector_snapshotter).to receive(:dump)
+
+        dumps_dir = File.join(output_dir, 'dumps')
+        FileUtils.mkdir_p(dumps_dir)
+
+        # Pre-create two old dump directories with earlier timestamps
+        old_dirs = %w[2026-04-20T00-00-00Z 2026-04-21T00-00-00Z].map do |name|
+          dir = File.join(dumps_dir, name)
+          FileUtils.mkdir_p(dir)
+          dir
+        end
+
+        indexer_with_retention.index_all
+
+        # After index_all with retention 2, the new dump is kept plus one old one
+        remaining = Dir.glob(File.join(dumps_dir, '*/'))
+                       .map { |d| File.basename(d.chomp('/')) }
+                       .reject { |n| n == 'latest' }
+
+        expect(remaining.length).to eq(2)
+        # The oldest directory should have been pruned
+        expect(File.exist?(old_dirs.first)).to be false
+      end
+    end
+  end
+
+  describe 'dump_retention_count default' do
+    it 'defaults to 3' do
+      idx = described_class.new(
+        provider: provider,
+        text_preparer: text_preparer,
+        vector_store: vector_store,
+        output_dir: output_dir
+      )
+      expect(idx.instance_variable_get(:@dump_retention_count)).to eq(3)
+    end
+  end
 end

--- a/spec/integration/persistence_round_trip_spec.rb
+++ b/spec/integration/persistence_round_trip_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+require 'woods'
+require 'woods/index_artifact'
+require 'woods/resolved_config'
+require 'woods/storage/snapshotter'
+require 'woods/storage/vector_store'
+require 'woods/storage/metadata_store'
+
+# End-to-end round trip for the Shape-2 multi-process story: dump a
+# store in one Ruby process, load it in a fresh Ruby process, assert
+# every vector and every metadata record comes back bit-equal.
+#
+# This is the single most important spec in PR 3 per the design doc
+# (§6 "test strategy"). It's the only coverage that actually proves
+# the MCP sidecar case works: rake embed writes to disk, separate
+# `woods-mcp` server reads from disk, queries return the right
+# answers.
+#
+# The round trip crosses a process boundary deliberately — in the
+# same process, Ruby object identity can mask serialization bugs that
+# only surface after a dump → fresh-Ruby → unpack cycle.
+# Lightweight stand-in for Woods::Configuration in the round-trip test —
+# we only need the fields ResolvedConfig.from_configuration reads.
+# Defined outside the describe block to satisfy Lint/ConstantDefinitionInBlock.
+RoundTripStubConfig = Struct.new(
+  :embedding_provider, :embedding_model, :embedding_options,
+  :vector_store, :metadata_store, :graph_store,
+  keyword_init: true
+)
+
+RSpec.describe 'Snapshotter round-trip across process boundary' do
+  # Seeded RNG so subprocess and parent agree on the payload without
+  # needing to serialize the test data. Both sides reconstruct from the seed.
+  let(:seed) { 20_260_423 }
+  let(:vector_count) { 32 }
+  let(:dim) { 16 }
+
+  def build_vectors(seed, count, dim)
+    rng = Random.new(seed)
+    Array.new(count) do
+      v = Array.new(dim) { rng.rand(-1.0..1.0) }
+      mag = Math.sqrt(v.sum { |x| x * x })
+      mag.zero? ? v : v.map! { |x| x / mag }
+    end
+  end
+
+  def build_metadata(count)
+    Array.new(count) do |i|
+      {
+        'type' => i.even? ? 'model' : 'service',
+        'namespace' => "App::Module#{i % 4}",
+        'file' => "lib/app/unit_#{i}.rb",
+        'line_count' => 50 + (i * 3)
+      }
+    end
+  end
+
+  it 'round-trips vectors + metadata through disk across fresh subprocess' do
+    Dir.mktmpdir do |output_dir|
+      # ── Parent process: populate stores and dump ─────────────────
+      vector_store = Woods::Storage::VectorStore::InMemory.new
+      metadata_store = Woods::Storage::MetadataStore::InMemory.new
+
+      vectors = build_vectors(seed, vector_count, dim)
+      metadatas = build_metadata(vector_count)
+
+      vector_count.times do |i|
+        id = "Unit_#{i}".freeze
+        vector_store.store(id, vectors[i], metadatas[i])
+        metadata_store.store(id, metadatas[i])
+      end
+
+      artifact = Woods::IndexArtifact.new(output_dir)
+      dump_dir = artifact.new_dump_dir
+
+      resolved = Woods::ResolvedConfig.from_configuration(
+        RoundTripStubConfig.new(
+          embedding_provider: :ollama,
+          embedding_model: 'nomic-embed-text',
+          embedding_options: {
+            model: 'nomic-embed-text',
+            host: 'http://localhost:11434',
+            dimension: dim
+          },
+          vector_store: :in_memory,
+          metadata_store: :in_memory,
+          graph_store: :in_memory
+        )
+      )
+
+      Woods::Storage::Snapshotter::Vector.dump(vector_store, artifact, dump_dir, resolved_config: resolved)
+      Woods::Storage::Snapshotter::Metadata.dump(metadata_store, artifact, dump_dir, resolved_config: resolved)
+      artifact.write_config(resolved.to_snapshot_json)
+      artifact.promote(dump_dir)
+
+      # ── Subprocess: load and query, echo a signature to stdout ───
+      loader_script = <<~RUBY
+        $LOAD_PATH.unshift('#{File.expand_path('../../lib', __dir__)}')
+        require 'woods'
+        require 'woods/index_artifact'
+        require 'woods/resolved_config'
+        require 'woods/storage/snapshotter'
+        require 'woods/storage/vector_store'
+        require 'woods/storage/metadata_store'
+        require 'json'
+
+        artifact = Woods::IndexArtifact.new(#{output_dir.inspect})
+        config_hash = artifact.read_config
+        resolved = Woods::ResolvedConfig.from_hash(config_hash)
+
+        vs = Woods::Storage::Snapshotter::Vector.load_or_empty(artifact, resolved_config: resolved)
+        ms = Woods::Storage::Snapshotter::Metadata.load_or_empty(artifact, resolved_config: resolved)
+
+        entries = vs.each_entry.map { |id, vec, _meta| [id, vec] }
+        metas   = ms.each_entry.map { |id, data| [id, data] }
+
+        payload = {
+          vector_count: vs.count,
+          metadata_count: ms.count,
+          entries: entries,
+          metas: metas,
+          resolved_dim: resolved.dimension,
+          resolved_provider: resolved.provider_signature
+        }
+        puts JSON.generate(payload)
+      RUBY
+
+      # We have to be careful about MetadataStore::InMemory#each_entry
+      # existing. If the Snapshotter's metadata side depends on a method
+      # that isn't yet on the metadata store, the subprocess raises
+      # before reaching our assertions — which is what we want, because
+      # that's a real integration bug.
+      output = IO.popen(['ruby', '-e', loader_script], &:read)
+      payload = begin
+        JSON.parse(output)
+      rescue JSON::ParserError
+        raise "subprocess produced non-JSON output:\n#{output}"
+      end
+
+      # ── Assertions ───────────────────────────────────────────────
+      expect(payload['vector_count']).to eq(vector_count)
+      expect(payload['metadata_count']).to eq(vector_count)
+      expect(payload['resolved_dim']).to eq(dim)
+
+      # Vector equality — the heart of the spec.
+      payload['entries'].each do |id, loaded_vec|
+        idx = id.sub('Unit_', '').to_i
+        expect(loaded_vec.size).to eq(dim)
+        loaded_vec.each_with_index do |v, j|
+          # pack('e*') is float32 — round-trip loses some precision
+          # from the Float64 originals. 1e-5 is a realistic bound.
+          expect(v).to be_within(1e-5).of(vectors[idx][j])
+        end
+      end
+
+      # Metadata equality — exact.
+      payload['metas'].each do |id, data|
+        idx = id.sub('Unit_', '').to_i
+        expected = metadatas[idx]
+        expect(data['type']).to eq(expected['type'])
+        expect(data['namespace']).to eq(expected['namespace'])
+        expect(data['file']).to eq(expected['file'])
+        expect(data['line_count']).to eq(expected['line_count'])
+      end
+    end
+  end
+
+  it 'writes a latest pointer that a second subprocess can follow' do
+    Dir.mktmpdir do |output_dir|
+      # Two consecutive dumps — latest must point at the second.
+      store = Woods::Storage::VectorStore::InMemory.new
+      store.store('only', [1.0, 0.0], { tag: 'v1' })
+
+      artifact = Woods::IndexArtifact.new(output_dir)
+      resolved = Woods::ResolvedConfig.from_configuration(
+        RoundTripStubConfig.new(
+          embedding_provider: :ollama,
+          embedding_model: 'nomic-embed-text',
+          embedding_options: { model: 'nomic-embed-text', dimension: 2 },
+          vector_store: :in_memory,
+          metadata_store: :in_memory,
+          graph_store: :in_memory
+        )
+      )
+
+      first = artifact.new_dump_dir(now: Time.utc(2026, 4, 23, 10, 0, 0))
+      Woods::Storage::Snapshotter::Vector.dump(store, artifact, first, resolved_config: resolved)
+      artifact.promote(first)
+
+      second = artifact.new_dump_dir(now: Time.utc(2026, 4, 23, 11, 0, 0))
+      Woods::Storage::Snapshotter::Vector.dump(store, artifact, second, resolved_config: resolved)
+      artifact.promote(second)
+
+      # The first dump is still on disk, but latest points at the second.
+      expect(artifact.latest_dump_path).to eq(second)
+      expect(first.exist?).to be true # not deleted by promote itself — retention handles that elsewhere
+    end
+  end
+end

--- a/spec/mcp/config_resolver_spec.rb
+++ b/spec/mcp/config_resolver_spec.rb
@@ -1,0 +1,248 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'json'
+require 'woods'
+require 'woods/index_artifact'
+require 'woods/resolved_config'
+require 'woods/mcp/errors'
+require 'woods/mcp/config_resolver'
+
+RSpec.describe Woods::MCP::ConfigResolver do
+  let(:blank_config) do
+    cfg = Woods::Configuration.new
+    cfg.vector_store = nil
+    cfg.metadata_store = nil
+    cfg.graph_store = nil
+    cfg.embedding_provider = nil
+    cfg.embedding_options = nil
+    cfg
+  end
+
+  let(:ollama_config) do
+    cfg = Woods::Configuration.new
+    cfg.vector_store = :in_memory
+    cfg.metadata_store = :in_memory
+    cfg.graph_store = :in_memory
+    cfg.embedding_provider = :ollama
+    cfg.embedding_options = { host: 'http://localhost:11434', model: 'nomic-embed-text', dimension: 768 }
+    cfg
+  end
+
+  # Minimal valid woods.json payload for a 768-dim Ollama provider
+  let(:woods_json_hash) do
+    {
+      'schema_version' => 1,
+      'gem_version' => '1.0.0',
+      'created_at' => '2026-04-20T00:00:00Z',
+      'embedding_provider' => {
+        'class' => 'Woods::Embedding::Provider::Ollama',
+        'model' => 'nomic-embed-text',
+        'host' => 'http://localhost:11434',
+        'dimension' => 768
+      },
+      'stores' => {
+        'vector_store' => 'in_memory',
+        'metadata_store' => 'in_memory',
+        'graph_store' => 'in_memory'
+      }
+    }
+  end
+
+  def write_woods_json(dir, content = woods_json_hash)
+    File.write(File.join(dir, 'woods.json'), JSON.generate(content))
+  end
+
+  describe '.resolve' do
+    context 'woods.json present, host config compatible' do
+      it 'returns [config, :snapshot] without raising' do
+        Dir.mktmpdir do |dir|
+          write_woods_json(dir)
+          artifact = Woods::IndexArtifact.new(dir)
+          config, source = described_class.resolve(ollama_config, artifact: artifact)
+          expect(config).to eq(ollama_config)
+          expect(source).to eq(:snapshot)
+        end
+      end
+
+      it 'does not mutate the config object' do
+        Dir.mktmpdir do |dir|
+          write_woods_json(dir)
+          artifact = Woods::IndexArtifact.new(dir)
+          original_provider = ollama_config.embedding_provider
+          described_class.resolve(ollama_config, artifact: artifact)
+          expect(ollama_config.embedding_provider).to eq(original_provider)
+        end
+      end
+    end
+
+    context 'woods.json present, host has no provider — populates config from snapshot' do
+      it 'returns [config, :snapshot] and sets embedding_provider' do
+        Dir.mktmpdir do |dir|
+          write_woods_json(dir)
+          artifact = Woods::IndexArtifact.new(dir)
+          config, source = described_class.resolve(blank_config, artifact: artifact)
+          expect(config.embedding_provider).to eq(:ollama)
+          expect(source).to eq(:snapshot)
+        end
+      end
+
+      it 'sets store types from the snapshot' do
+        Dir.mktmpdir do |dir|
+          write_woods_json(dir)
+          artifact = Woods::IndexArtifact.new(dir)
+          config, = described_class.resolve(blank_config, artifact: artifact)
+          expect(config.vector_store).to eq(:in_memory)
+          expect(config.metadata_store).to eq(:in_memory)
+          expect(config.graph_store).to eq(:in_memory)
+        end
+      end
+
+      it 'sets embedding_options with host and model from the snapshot' do
+        Dir.mktmpdir do |dir|
+          write_woods_json(dir)
+          artifact = Woods::IndexArtifact.new(dir)
+          config, = described_class.resolve(blank_config, artifact: artifact)
+          expect(config.embedding_options[:host]).to eq('http://localhost:11434')
+          expect(config.embedding_options[:model]).to eq('nomic-embed-text')
+        end
+      end
+
+      it 'maps OpenAI class name back to :openai symbol' do
+        Dir.mktmpdir do |dir|
+          openai_hash = woods_json_hash.merge(
+            'embedding_provider' => {
+              'class' => 'Woods::Embedding::Provider::OpenAI',
+              'model' => 'text-embedding-3-small',
+              'dimension' => 1536
+            }
+          )
+          write_woods_json(dir, openai_hash)
+          artifact = Woods::IndexArtifact.new(dir)
+          config, = described_class.resolve(blank_config, artifact: artifact)
+          expect(config.embedding_provider).to eq(:openai)
+        end
+      end
+    end
+
+    context 'woods.json present but schema_version is unsupported' do
+      it 'raises Woods::MCP::UnsupportedArtifact' do
+        Dir.mktmpdir do |dir|
+          write_woods_json(dir, woods_json_hash.merge('schema_version' => 99))
+          artifact = Woods::IndexArtifact.new(dir)
+          expect { described_class.resolve(blank_config, artifact: artifact) }
+            .to raise_error(Woods::MCP::UnsupportedArtifact, /99/)
+        end
+      end
+    end
+
+    context 'woods.json present, live config has different dimension' do
+      it 'raises Woods::MCP::DimensionMismatch' do
+        Dir.mktmpdir do |dir|
+          write_woods_json(dir)
+          artifact = Woods::IndexArtifact.new(dir)
+          cfg = Woods::Configuration.new
+          cfg.vector_store = :in_memory
+          cfg.metadata_store = :in_memory
+          cfg.graph_store = :in_memory
+          cfg.embedding_provider = :ollama
+          cfg.embedding_options = { host: 'http://localhost:11434', model: 'nomic-embed-text', dimension: 1536 }
+          expect { described_class.resolve(cfg, artifact: artifact) }
+            .to raise_error(Woods::MCP::DimensionMismatch)
+        end
+      end
+    end
+
+    context 'woods.json present, live config has different provider model' do
+      it 'raises Woods::MCP::ConfigMismatch' do
+        Dir.mktmpdir do |dir|
+          write_woods_json(dir)
+          artifact = Woods::IndexArtifact.new(dir)
+          cfg = Woods::Configuration.new
+          cfg.vector_store = :in_memory
+          cfg.metadata_store = :in_memory
+          cfg.graph_store = :in_memory
+          cfg.embedding_provider = :ollama
+          cfg.embedding_options = { host: 'http://localhost:11434', model: 'mxbai-embed-large', dimension: 768 }
+          expect { described_class.resolve(cfg, artifact: artifact) }
+            .to raise_error(Woods::MCP::ConfigMismatch)
+        end
+      end
+    end
+
+    context 'no woods.json, host has embedding_provider set' do
+      it 'returns [config, :host_config] without raising' do
+        Dir.mktmpdir do |dir|
+          artifact = Woods::IndexArtifact.new(dir)
+          config, source = described_class.resolve(ollama_config, artifact: artifact)
+          expect(config).to eq(ollama_config)
+          expect(source).to eq(:host_config)
+        end
+      end
+    end
+
+    context 'no woods.json, no host provider, WOODS_ALLOW_AUTODETECT unset' do
+      it 'raises Woods::MCP::MissingArtifact' do
+        Dir.mktmpdir do |dir|
+          artifact = Woods::IndexArtifact.new(dir)
+          expect { described_class.resolve(blank_config, artifact: artifact, env: {}) }
+            .to raise_error(Woods::MCP::MissingArtifact, /WOODS_ALLOW_AUTODETECT/)
+        end
+      end
+    end
+
+    context 'no woods.json, no host provider, WOODS_ALLOW_AUTODETECT=1, OPENAI_API_KEY set' do
+      it 'returns [config, :autodetect] with embedding_provider :openai' do
+        Dir.mktmpdir do |dir|
+          artifact = Woods::IndexArtifact.new(dir)
+          env = { 'WOODS_ALLOW_AUTODETECT' => '1', 'OPENAI_API_KEY' => 'sk-test' }
+          config, source = described_class.resolve(blank_config, artifact: artifact, env: env)
+          expect(config.embedding_provider).to eq(:openai)
+          expect(source).to eq(:autodetect)
+        end
+      end
+    end
+
+    context 'no woods.json, no host provider, WOODS_ALLOW_AUTODETECT=1, no credentials' do
+      it 'returns [config, :autodetect] with nil embedding_provider when Ollama probe returns false' do
+        Dir.mktmpdir do |dir|
+          artifact = Woods::IndexArtifact.new(dir)
+          env = { 'WOODS_ALLOW_AUTODETECT' => '1' }
+          config, source = described_class.resolve(blank_config,
+                                                   artifact: artifact,
+                                                   env: env,
+                                                   ollama_probe: -> { false })
+          expect(config.embedding_provider).to be_nil
+          expect(source).to eq(:autodetect)
+        end
+      end
+
+      it 'returns [config, :autodetect] with :ollama when Ollama probe returns true' do
+        Dir.mktmpdir do |dir|
+          artifact = Woods::IndexArtifact.new(dir)
+          env = { 'WOODS_ALLOW_AUTODETECT' => '1', 'OLLAMA_BASE_URL' => 'http://127.0.0.1:11434' }
+          config, source = described_class.resolve(blank_config,
+                                                   artifact: artifact,
+                                                   env: env,
+                                                   ollama_probe: -> { true })
+          expect(config.embedding_provider).to eq(:ollama)
+          expect(source).to eq(:autodetect)
+        end
+      end
+    end
+
+    context 'nil artifact (no output_dir configured)' do
+      it 'raises Woods::MCP::MissingArtifact when host has no provider' do
+        expect { described_class.resolve(blank_config, artifact: nil, env: {}) }
+          .to raise_error(Woods::MCP::MissingArtifact)
+      end
+
+      it 'returns [config, :host_config] when host has a provider' do
+        config, source = described_class.resolve(ollama_config, artifact: nil)
+        expect(config).to eq(ollama_config)
+        expect(source).to eq(:host_config)
+      end
+    end
+  end
+end

--- a/spec/storage/snapshotter/metadata_spec.rb
+++ b/spec/storage/snapshotter/metadata_spec.rb
@@ -13,69 +13,175 @@ RSpec.describe Woods::Storage::Snapshotter::Metadata do
 
   after { FileUtils.remove_entry(tmpdir) }
 
-  # A minimal in-memory metadata store that also implements the persistence seam
-  # (#each_entry / #bulk_load) expected by the Snapshotter. The real
-  # MetadataStore::InMemory gains these methods in PR 3; this helper stands in
-  # for the happy-path dump tests until that PR lands.
-  def metadata_store_with_seam
+  def populated_store
     store = Woods::Storage::MetadataStore::InMemory.new
-    store.store('User', { type: 'model', file_path: 'app/models/user.rb' })
-    def store.each_entry(&block)
-      return enum_for(:each_entry) unless block
-
-      # Walk the internal hash — underscore prefix avoids method_missing/private issues.
-      instance_variable_get(:@data).each { |id, meta| block.call(id, meta) }
-    end
-
-    def store.bulk_load(entries)
-      entries.each { |id, meta| self.store(id, meta) }
-    end
-
+    store.store('User', { 'type' => 'model', 'file_path' => 'app/models/user.rb' })
+    store.store('PostsController',
+                { 'type' => 'controller', 'file_path' => 'app/controllers/posts_controller.rb' })
     store
+  end
+
+  # Read just the header from a metadata.msgpack file.
+  def read_header(dump_dir)
+    File.open(dump_dir.join('metadata.msgpack').to_s, 'rb') do |io|
+      MessagePack::Unpacker.new(io).read
+    end
+  end
+
+  # Write a raw dump with the given header and optional record array.
+  def write_raw_dump(dump_dir, header, records = [])
+    dump_dir.mkpath
+    File.open(dump_dir.join('metadata.msgpack').to_s, 'wb') do |io|
+      packer = MessagePack::Packer.new(io)
+      packer.write(header)
+      records.each { |r| packer.write(r) }
+      packer.flush
+    end
   end
 
   describe '.load_or_empty' do
     it 'returns an InMemory metadata store' do
-      store = described_class.load_or_empty(artifact)
-      expect(store).to be_a(Woods::Storage::MetadataStore::InMemory)
+      expect(described_class.load_or_empty(artifact)).to be_a(Woods::Storage::MetadataStore::InMemory)
     end
 
-    it 'returns an empty store' do
-      store = described_class.load_or_empty(artifact)
-      expect(store.count).to eq(0)
+    it 'returns an empty store when no dump exists' do
+      expect(described_class.load_or_empty(artifact).count).to eq(0)
     end
 
-    it 'ignores artifact state — returns empty even when latest_dump_path is set' do
-      dump_dir = artifact.new_dump_dir
-      artifact.promote(dump_dir)
-      store = described_class.load_or_empty(artifact)
-      expect(store.count).to eq(0)
+    it 'returns an empty store when no latest pointer exists (dumps dir present)' do
+      artifact.dumps_root.mkpath
+      expect(described_class.load_or_empty(artifact).count).to eq(0)
     end
 
     it 'accepts an optional resolved_config keyword without error' do
       expect { described_class.load_or_empty(artifact, resolved_config: double('rc')) }
         .not_to raise_error
     end
+
+    context 'when a dump has been written' do
+      let(:dump_dir) { artifact.new_dump_dir }
+
+      before do
+        described_class.dump(populated_store, artifact, dump_dir)
+        artifact.promote(dump_dir)
+      end
+
+      it 'returns a populated store' do
+        expect(described_class.load_or_empty(artifact).count).to eq(2)
+      end
+
+      it 'round-trips all record ids' do
+        store = described_class.load_or_empty(artifact)
+        expect(store.find('User')).not_to be_nil
+        expect(store.find('PostsController')).not_to be_nil
+      end
+
+      it 'round-trips record field values' do
+        meta = described_class.load_or_empty(artifact).find('User')
+        expect(meta['type']).to eq('model')
+        expect(meta['file_path']).to eq('app/models/user.rb')
+      end
+    end
+
+    context 'when dump has corrupted magic' do
+      let(:dump_dir) { artifact.new_dump_dir }
+
+      before do
+        write_raw_dump(dump_dir,
+                       { 'magic' => 'XXXX', 'schema_version' => 1, 'record_count' => 0,
+                         'gem_version' => '1.2.0', 'created_at' => '2026-01-01T00:00:00Z' })
+        artifact.promote(dump_dir)
+      end
+
+      it 'raises UnsupportedArtifact' do
+        expect { described_class.load_or_empty(artifact) }
+          .to raise_error(Woods::MCP::UnsupportedArtifact)
+      end
+
+      it 'mentions invalid magic in the error message' do
+        expect { described_class.load_or_empty(artifact) }
+          .to raise_error(Woods::MCP::UnsupportedArtifact, /invalid magic/)
+      end
+    end
+
+    context 'when dump has unsupported schema_version' do
+      let(:dump_dir) { artifact.new_dump_dir }
+
+      before do
+        write_raw_dump(dump_dir,
+                       { 'magic' => 'WMD1', 'schema_version' => 999, 'record_count' => 0,
+                         'gem_version' => '9.9.9', 'created_at' => '2026-01-01T00:00:00Z' })
+        artifact.promote(dump_dir)
+      end
+
+      it 'raises UnsupportedArtifact' do
+        expect { described_class.load_or_empty(artifact) }
+          .to raise_error(Woods::MCP::UnsupportedArtifact)
+      end
+
+      it 'includes schema version in the error message' do
+        expect { described_class.load_or_empty(artifact) }
+          .to raise_error(Woods::MCP::UnsupportedArtifact, /schema_version 999/)
+      end
+    end
   end
 
   describe '.dump' do
     let(:dump_dir) { artifact.new_dump_dir }
 
-    context 'with a store that implements the persistence seam (happy path)' do
-      let(:store) { metadata_store_with_seam }
+    context 'with a populated InMemory store (happy path)' do
+      let(:store) { populated_store }
 
       it 'does not raise for valid input' do
         expect { described_class.dump(store, artifact, dump_dir) }.not_to raise_error
       end
 
-      it 'returns nil (no-op)' do
+      it 'returns nil' do
         expect(described_class.dump(store, artifact, dump_dir)).to be_nil
       end
 
-      it 'writes no files (stub no-op)' do
+      it 'writes metadata.msgpack to dump_dir' do
         described_class.dump(store, artifact, dump_dir)
-        written = Dir.glob("#{dump_dir}/**/*").reject { |f| File.directory?(f) }
-        expect(written).to be_empty
+        expect(dump_dir.join('metadata.msgpack')).to exist
+      end
+
+      it 'writes a parseable MessagePack stream' do
+        described_class.dump(store, artifact, dump_dir)
+        expect { read_header(dump_dir) }.not_to raise_error
+      end
+
+      it 'writes magic WMD1 in the header' do
+        described_class.dump(store, artifact, dump_dir)
+        expect(read_header(dump_dir)['magic']).to eq('WMD1')
+      end
+
+      it 'writes schema_version 1 in the header' do
+        described_class.dump(store, artifact, dump_dir)
+        expect(read_header(dump_dir)['schema_version']).to eq(1)
+      end
+
+      it 'writes gem_version in the header' do
+        described_class.dump(store, artifact, dump_dir)
+        expect(read_header(dump_dir)['gem_version']).to eq(Woods::VERSION)
+      end
+
+      it 'writes accurate record_count in the header' do
+        described_class.dump(store, artifact, dump_dir)
+        expect(read_header(dump_dir)['record_count']).to eq(2)
+      end
+
+      it 'writes created_at as an ISO8601 timestamp' do
+        described_class.dump(store, artifact, dump_dir)
+        expect { Time.iso8601(read_header(dump_dir)['created_at']) }.not_to raise_error
+      end
+    end
+
+    context 'with an empty store' do
+      let(:store) { Woods::Storage::MetadataStore::InMemory.new }
+
+      it 'writes a valid file with record_count 0' do
+        described_class.dump(store, artifact, dump_dir)
+        expect(read_header(dump_dir)['record_count']).to eq(0)
       end
     end
 
@@ -108,7 +214,7 @@ RSpec.describe Woods::Storage::Snapshotter::Metadata do
     end
 
     context 'when dump_dir is outside artifact.dumps_root' do
-      let(:store) { metadata_store_with_seam }
+      let(:store) { Woods::Storage::MetadataStore::InMemory.new }
       let(:outside_dir) { Dir.mktmpdir }
 
       after { FileUtils.remove_entry(outside_dir) }
@@ -121,6 +227,71 @@ RSpec.describe Woods::Storage::Snapshotter::Metadata do
       it 'mentions dumps_root in the error message' do
         expect { described_class.dump(store, artifact, outside_dir) }
           .to raise_error(ArgumentError, /dumps_root/)
+      end
+    end
+  end
+
+  describe 'round-trip (dump then load)' do
+    it 'restores exact record count' do
+      store = populated_store
+      dump_dir = artifact.new_dump_dir
+      described_class.dump(store, artifact, dump_dir)
+      artifact.promote(dump_dir)
+
+      expect(described_class.load_or_empty(artifact).count).to eq(2)
+    end
+
+    it 'restores metadata field values for all records' do
+      dump_dir = artifact.new_dump_dir
+      described_class.dump(populated_store, artifact, dump_dir)
+      artifact.promote(dump_dir)
+
+      loaded = described_class.load_or_empty(artifact)
+      expect(loaded.find('User')['type']).to eq('model')
+      expect(loaded.find('PostsController')['type']).to eq('controller')
+    end
+
+    it 'handles heterogeneous metadata values (integers, arrays, nested hashes, nil)' do
+      store = Woods::Storage::MetadataStore::InMemory.new
+      store.store('Complex', {
+                    'type' => 'service',
+                    'count' => 42,
+                    'tags' => %w[auth api],
+                    'nested' => { 'depth' => 1 },
+                    'nullable' => nil
+                  })
+      dump_dir = artifact.new_dump_dir
+      described_class.dump(store, artifact, dump_dir)
+      artifact.promote(dump_dir)
+
+      meta = described_class.load_or_empty(artifact).find('Complex')
+      expect(meta['count']).to eq(42)
+      expect(meta['tags']).to eq(%w[auth api])
+      expect(meta['nested']).to eq({ 'depth' => 1 })
+      expect(meta['nullable']).to be_nil
+    end
+
+    it 'round-trips 10 records with varied metadata' do
+      store = Woods::Storage::MetadataStore::InMemory.new
+      10.times do |i|
+        store.store("Unit#{i}", {
+                      'type' => %w[model controller service][i % 3],
+                      'index' => i,
+                      'tags' => ["tag#{i}"],
+                      'nested' => { 'x' => i * 2 }
+                    })
+      end
+
+      dump_dir = artifact.new_dump_dir
+      described_class.dump(store, artifact, dump_dir)
+      artifact.promote(dump_dir)
+
+      loaded = described_class.load_or_empty(artifact)
+      expect(loaded.count).to eq(10)
+      10.times do |i|
+        meta = loaded.find("Unit#{i}")
+        expect(meta['index']).to eq(i)
+        expect(meta['nested']['x']).to eq(i * 2)
       end
     end
   end

--- a/spec/storage/snapshotter/vector_spec.rb
+++ b/spec/storage/snapshotter/vector_spec.rb
@@ -13,18 +13,39 @@ RSpec.describe Woods::Storage::Snapshotter::Vector do
 
   after { FileUtils.remove_entry(tmpdir) }
 
+  # --- helpers ---
+
+  def make_store(entries)
+    s = Woods::Storage::VectorStore::InMemory.new
+    entries.each { |id, vec, meta| s.store(id, vec, meta || {}) }
+    s
+  end
+
+  def random_vector(dim)
+    Array.new(dim) { rand(-1.0..1.0) }
+  end
+
+  def dump_and_load(store, resolved_config: nil)
+    dump_dir = artifact.new_dump_dir
+    artifact.promote(dump_dir)
+    described_class.dump(store, artifact, dump_dir, resolved_config: resolved_config)
+    described_class.load_or_empty(artifact, resolved_config: resolved_config)
+  end
+
+  # --- stub-retained: load_or_empty ---
+
   describe '.load_or_empty' do
     it 'returns an InMemory vector store' do
       store = described_class.load_or_empty(artifact)
       expect(store).to be_a(Woods::Storage::VectorStore::InMemory)
     end
 
-    it 'returns an empty store' do
+    it 'returns an empty store when no dump exists' do
       store = described_class.load_or_empty(artifact)
       expect(store.count).to eq(0)
     end
 
-    it 'ignores artifact state — returns empty even when latest_dump_path is set' do
+    it 'returns an empty store when latest_dump_path exists but vectors.bin is absent' do
       dump_dir = artifact.new_dump_dir
       artifact.promote(dump_dir)
       store = described_class.load_or_empty(artifact)
@@ -37,10 +58,12 @@ RSpec.describe Woods::Storage::Snapshotter::Vector do
     end
   end
 
+  # --- stub-retained: dump input validation ---
+
   describe '.dump' do
     let(:dump_dir) { artifact.new_dump_dir }
 
-    context 'with a valid in-memory store (happy path)' do
+    context 'with a valid in-memory store (stub-era happy path)' do
       let(:store) do
         s = Woods::Storage::VectorStore::InMemory.new
         s.store('unit1', [0.1, 0.2, 0.3], { type: 'model' })
@@ -51,14 +74,8 @@ RSpec.describe Woods::Storage::Snapshotter::Vector do
         expect { described_class.dump(store, artifact, dump_dir) }.not_to raise_error
       end
 
-      it 'returns nil (no-op)' do
+      it 'returns nil' do
         expect(described_class.dump(store, artifact, dump_dir)).to be_nil
-      end
-
-      it 'writes no files (stub no-op)' do
-        described_class.dump(store, artifact, dump_dir)
-        written = Dir.glob("#{dump_dir}/**/*").reject { |f| File.directory?(f) }
-        expect(written).to be_empty
       end
     end
 
@@ -105,6 +122,212 @@ RSpec.describe Woods::Storage::Snapshotter::Vector do
         expect { described_class.dump(store, artifact, outside_dir) }
           .to raise_error(ArgumentError, /dumps_root/)
       end
+    end
+  end
+
+  # --- real serialization ---
+
+  describe 'round-trip serialization' do
+    let(:dim) { 8 }
+
+    it 'round-trips 50 random unit vectors with ids intact' do
+      entries = Array.new(50) do |i|
+        vec = random_vector(dim)
+        mag = Math.sqrt(vec.sum { |x| x * x })
+        unit = vec.map { |x| x / mag }
+        ["unit_#{i}", unit]
+      end
+      original = make_store(entries)
+      loaded = dump_and_load(original)
+
+      expect(loaded.count).to eq(50)
+      entries.each do |id, orig_vec|
+        found = loaded.search(orig_vec, limit: 1).first
+        expect(found.id).to eq(id)
+        expect(found.score).to be_within(1e-5).of(1.0)
+      end
+    end
+
+    it 'each loaded vector is float32-close to the original' do
+      vec = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+      original = make_store([['v1', vec]])
+      loaded = dump_and_load(original)
+
+      loaded_vec = loaded.each_entry.to_a.first[1]
+      vec.each_with_index do |orig, i|
+        expect(loaded_vec[i]).to be_within(1e-6).of(orig.round(6))
+      end
+    end
+
+    it 'round-trips a store with tombstoned entries (only live entries dumped)' do
+      store = make_store([['a', [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]],
+                          ['b', [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]],
+                          ['c', [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0]]])
+      store.delete('b')
+
+      loaded = dump_and_load(store)
+      ids = loaded.each_entry.map { |id, _, _| id }
+      expect(ids).to contain_exactly('a', 'c')
+      expect(loaded.count).to eq(2)
+    end
+  end
+
+  describe 'empty store' do
+    it 'writes a valid header with vector_count=0' do
+      empty = Woods::Storage::VectorStore::InMemory.new
+      dump_dir = artifact.new_dump_dir
+      artifact.promote(dump_dir)
+      described_class.dump(empty, artifact, dump_dir)
+
+      bin_path = dump_dir.join('vectors.bin')
+      expect(bin_path.exist?).to be true
+      magic = File.binread(bin_path.to_s, 4)
+      expect(magic).to eq('WVF1')
+
+      vector_count = File.binread(bin_path.to_s, 8, 12).unpack1('Q<')
+      expect(vector_count).to eq(0)
+    end
+
+    it 'load_or_empty returns an empty store for a zero-vector dump' do
+      empty = Woods::Storage::VectorStore::InMemory.new
+      loaded = dump_and_load(empty)
+      expect(loaded.count).to eq(0)
+    end
+  end
+
+  describe 'header validation on load' do
+    let(:dump_dir) { artifact.new_dump_dir }
+
+    def write_bin(content)
+      path = dump_dir.join('vectors.bin')
+      File.binwrite(path.to_s, content)
+    end
+
+    def write_idx(content = '')
+      path = dump_dir.join('vectors.idx')
+      File.binwrite(path.to_s, content)
+    end
+
+    before { artifact.promote(dump_dir) }
+
+    it 'raises UnsupportedArtifact when magic bytes are wrong' do
+      header = "BAD!#{[1, 0, 0].pack('L<L<L<')}#{[0].pack('Q<')}" \
+               "#{[5].pack('L<')}1.2.0#{[0].pack('L<')}"
+      write_bin(header)
+      write_idx
+
+      expect { described_class.load_or_empty(artifact) }
+        .to raise_error(Woods::MCP::UnsupportedArtifact, /invalid magic/)
+    end
+
+    it 'includes found bytes in the error details' do
+      bad_magic = 'XXXX'
+      header = "#{bad_magic}#{[1, 0, 0].pack('L<L<L<')}#{[0].pack('Q<')}" \
+               "#{[5].pack('L<')}1.2.0#{[0].pack('L<')}"
+      write_bin(header)
+      write_idx
+
+      begin
+        described_class.load_or_empty(artifact)
+      rescue Woods::MCP::UnsupportedArtifact => e
+        expect(e.details[:found]).to eq('XXXX')
+      end
+    end
+
+    it 'raises UnsupportedArtifact when schema_version > supported max' do
+      future_version = 2
+      header = "WVF1#{[future_version, 8, 0].pack('L<L<L<')}#{[0].pack('Q<')}" \
+               "#{[5].pack('L<')}1.2.0#{[0].pack('L<')}"
+      write_bin(header)
+      write_idx
+
+      expect { described_class.load_or_empty(artifact) }
+        .to raise_error(Woods::MCP::UnsupportedArtifact, /schema_version 2/)
+    end
+
+    it 'raises DimensionMismatch when stored dim ≠ resolved_config.dimension' do
+      store = make_store([['v1', Array.new(8, 0.1)]])
+      described_class.dump(store, artifact, dump_dir)
+
+      config = double('rc', dimension: 16)
+      expect { described_class.load_or_empty(artifact, resolved_config: config) }
+        .to raise_error(Woods::MCP::DimensionMismatch)
+    end
+
+    it 'does not raise DimensionMismatch when resolved_config.dimension matches' do
+      store = make_store([['v1', Array.new(8, 0.1)]])
+      described_class.dump(store, artifact, dump_dir)
+
+      config = double('rc', dimension: 8)
+      expect { described_class.load_or_empty(artifact, resolved_config: config) }
+        .not_to raise_error
+    end
+
+    it 'raises UnsupportedArtifact on a truncated/corrupt file' do
+      write_bin('WVF') # only 3 bytes
+      write_idx
+
+      expect { described_class.load_or_empty(artifact) }
+        .to raise_error(Woods::MCP::UnsupportedArtifact, /too short/)
+    end
+  end
+
+  describe 'atomic file writes' do
+    it 'calls File.rename with a tmp path for vectors.bin' do
+      store = make_store([['v1', [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]]])
+      dump_dir = artifact.new_dump_dir
+
+      renamed_paths = []
+      original_rename = File.method(:rename)
+      allow(File).to receive(:rename) do |src, dst|
+        renamed_paths << [src, dst]
+        original_rename.call(src, dst)
+      end
+
+      described_class.dump(store, artifact, dump_dir)
+
+      bin_renames = renamed_paths.select { |_, dst| dst.end_with?('vectors.bin') }
+      expect(bin_renames.size).to eq(1)
+      src_path = bin_renames.first[0]
+      expect(src_path).to include('.woods-vec-')
+    end
+  end
+
+  describe 'schema version header field' do
+    it 'writes schema_version=1 in every dump' do
+      store = make_store([['v1', [1.0, 0.0, 0.0, 0.0]]])
+      dump_dir = artifact.new_dump_dir
+      described_class.dump(store, artifact, dump_dir)
+
+      bin_path = dump_dir.join('vectors.bin')
+      version = File.binread(bin_path.to_s, 4, 4).unpack1('L<')
+      expect(version).to eq(1)
+    end
+  end
+
+  describe 'resolved_config integration' do
+    let(:dim) { 4 }
+    let(:config) { double('rc', dimension: dim, model_name: 'nomic-embed-text') }
+
+    it 'accepts resolved_config on dump without raising' do
+      store = make_store([['id1', Array.new(dim, 0.5)]])
+      dump_dir = artifact.new_dump_dir
+      artifact.promote(dump_dir)
+
+      expect do
+        described_class.dump(store, artifact, dump_dir, resolved_config: config)
+      end.not_to raise_error
+    end
+
+    it 'round-trips with resolved_config on both sides' do
+      store = make_store([['id1', [0.1, 0.2, 0.3, 0.4]],
+                          ['id2', [0.9, 0.8, 0.7, 0.6]]])
+      dump_dir = artifact.new_dump_dir
+      artifact.promote(dump_dir)
+      described_class.dump(store, artifact, dump_dir, resolved_config: config)
+
+      loaded = described_class.load_or_empty(artifact, resolved_config: config)
+      expect(loaded.count).to eq(2)
     end
   end
 end

--- a/woods.gemspec
+++ b/woods.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |spec|
 
   # Runtime dependencies
   spec.add_dependency 'mcp', '>= 0.9.2', '< 1.0'
+  spec.add_dependency 'msgpack', '>= 1.5'
   # `prism` ships in stdlib on Ruby 3.3+; the gem fills the gap for 3.0–3.2.
   # EvalGuard reuses the existing Woods::Ast::Parser, which already auto-detects
   # Prism vs the parser gem — this dep guarantees the Prism path on the lower


### PR DESCRIPTION
PR 3 of the persistence plan. Completes the multi-process Shape-2 story: a rake embed run writes vectors + metadata + resolved config to `output_dir`, and a separate `woods-mcp` server reads them at boot. The end-to-end story that started with PR #73's plan now works end to end.

## What lands

### Real `Snapshotter::Vector`

- **`vectors.bin`** with a fixed-width `WVF1` header (magic + schema_version + dimension + vector_count + gem_version + model_name) followed by a packed float32 blob via `Array#pack('e*')`.
- **`vectors.idx`** with `id` + `bin_offset` pairs for ordered rehydration.
- Atomic writes via `Tempfile` + `File.rename`.
- `load_or_empty` validates magic, `schema_version` (≤ 1), and dimension — raises `UnsupportedArtifact` / `DimensionMismatch` on mismatch, so a v1 server refuses a v2 dump cleanly.

### Real `Snapshotter::Metadata`

- **`metadata.msgpack`** with a streaming `WMD1` header object first, then one `{ id, metadata }` object per record. Stream-unpack on load — large indexes don't rebuild the whole record set in one Ruby allocation.
- Schema-versioned header; mismatches raise `UnsupportedArtifact`.
- MessagePack here (not `pack('e*')`) because metadata is heterogeneous hash-shaped data where type tags matter.
- `MetadataStore::InMemory` gains `#each_entry` and `#bulk_load` seams to match the `VectorStore` contract added in PR #74.
- Adds `msgpack` as a runtime dependency.

### Indexer — persist on completion

After `index_all` / `index_incremental`, when the vector store is in-memory AND `output_dir` is configured:

1. `artifact.new_dump_dir` → `dumps/<ISO8601>/`
2. `Snapshotter::Vector.dump(...)`
3. `Snapshotter::Metadata.dump(...)` when the metadata store supports the seams
4. `artifact.write_config(resolved.to_snapshot_json)` → `woods.json`
5. `artifact.promote(dump_dir)` → atomic `latest` pointer flip
6. **Retention** — keep the N most recent dump dirs (default 3, configurable via `Configuration#dump_retention_count`)

Persistent backends (pgvector, Qdrant) see **zero behavior change**.

Streaming-append during embed is deferred to a follow-up; compact-at-end is the current path. TODO marker in the Indexer.

### `ConfigResolver` extracted from Bootstrapper (closes Gap B)

- `Woods::MCP::ConfigResolver.resolve(config, artifact:, env:, ollama_probe:)` returns `(config, source)` where source is `:snapshot`, `:host_config`, `:autodetect`, or `:none`.
- When `woods.json` is present: `ResolvedConfig.from_hash` parses it. If the in-process config also has a provider, `assert_compatible!` runs — catches dimension + provider mismatches at boot instead of at first bad query.
- When the snapshot is present but the host has no provider configured, the resolver populates the config from the snapshot so `Builder` constructs the correct provider. Maps class names back to `:ollama` / `:openai` symbols.
- `Bootstrapper` delegates; the inline `resolve_or_autodetect` + `autodetect_config` methods are gone.

### IndexArtifact fix

- `write_config` now `JSON.pretty_generates` the `ResolvedConfig`'s snapshot hash. The earlier code wrote the Ruby `inspect` output — invalid JSON, would not have round-tripped.

### End-to-end round-trip spec (the capstone)

`spec/integration/persistence_round_trip_spec.rb` dumps in the parent process, loads in a subprocess, asserts:
- vector equality within 1e-5 (`pack('e*')` is float32, so Float64→Float32→Float64 loses precision in the 6th+ sig fig)
- metadata equality exact
- `latest` pointer correctness across two consecutive promotes

This is the "the only spec that actually proves Shape 2 works" call-out from the plan — and it passes on the first combined run.

## Team credit

Four teammates worked in parallel on disjoint files. Integration found one seam bug (a missing `require` in the new ConfigResolver spec) and one format polish (MetadataStore dump format was upgraded mid-flight from single-envelope to streaming WMD1 per the plan). Both fixed in integration.

## Test plan

- [x] `bundle exec rake spec` — **4307 examples, 0 failures, 2 pending** (unchanged tiktoken pendings)
- [x] `bundle exec rubocop` — 423 files, 0 offenses
- [x] Round-trip integration spec passes on first run — dumps vectors + metadata, subprocess loads them, equality holds
- [x] Existing Bootstrapper specs continue to pass through the ConfigResolver delegation

## What's next (PR 4, polish)

- `woods_status` MCP tool returns the structured `BootstrapState` block
- `:shared_filesystem` preset on `Builder::PRESETS`
- `docs/BACKEND_MATRIX.md` gains a "Persistence Story" column
- `docs/design/PERSISTENCE_AND_BOOTSTRAP.md` status: "Implemented"