### PR TITLE
feat(mcp): woods_status exposes BootstrapState + :shared_filesystem preset + docs

### DIFF
--- a/docs/BACKEND_MATRIX.md
+++ b/docs/BACKEND_MATRIX.md
@@ -8,6 +8,29 @@ The goal is that an agent or developer reading this document can make an informe
 
 ---
 
+## Persistence Story
+
+Every backend combination falls into one of three shapes based on how data survives process boundaries. The right shape depends on whether the embed process and the query process share a Ruby VM, a filesystem, or neither.
+
+| Shape | Vector store | Metadata store | Durability | Right preset |
+|---|---|---|---|---|
+| **Single-process** | `:in_memory` | `:in_memory` or `:sqlite` | Lives and dies with the Ruby VM | `:local` |
+| **Shared filesystem** | `:in_memory` + `Snapshotter` dump to `output_dir` | `:in_memory` + `Snapshotter` dump to `output_dir` | Process-local, hydrated from disk on MCP boot; dumps retained per `dump_retention_count` (default 3) | `:shared_filesystem` |
+| **Distributed** | `:pgvector`, `:qdrant` | `:sqlite` (or future `:mysql`/`:postgresql`) | Fully external; multiple processes read/write concurrently | `:postgresql`, `:production` |
+
+The shape determines the capability matrix:
+
+| Capability | Single-process | Shared filesystem | Distributed |
+|---|---|---|---|
+| Survives process restart | No | Yes (via dump) | Yes (backend) |
+| Multi-writer embedding | No | No (single writer assumed) | Yes (backend-dependent) |
+| Requires sqlite3 gem in host | With `:local` | No | With `:local`/`:postgresql`/`:production` |
+| Requires external service | No | No | Yes |
+| Cross-machine query | No | No | Yes |
+| `woods.json` schema-versioned config snapshot | — | Yes | Host config used directly |
+
+---
+
 ## Vector Stores
 
 ### pgvector (PostgreSQL Extension)

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -175,14 +175,47 @@ it. The `_index.json` manifest under `output_dir` is the durable
 metadata for the index MCP server, so this is a reasonable default
 for hosts that don't bundle `sqlite3`.
 
+## Deployment Shapes
+
+Woods supports three deployment shapes — pick the preset that matches yours.
+
+| Shape | When | Preset |
+|---|---|---|
+| **Single-process** | Embed + query in one Ruby VM (dev console, tests, `rails runner` scripts). Simplest. | `:local` |
+| **Shared filesystem** | Rake task runs `woods:embed`, separate `woods-mcp` server reads the dump. Common with MCP sidecars. | `:shared_filesystem` |
+| **Distributed** | Vectors live in an external service (pgvector / Qdrant) queried by both the embed process and the MCP server. Highest durability, highest ops cost. | `:postgresql` or `:production` |
+
+### Shape 2 setup (`:shared_filesystem`)
+
+```ruby
+Woods.configure_with_preset(:shared_filesystem) do |config|
+  config.output_dir = Rails.root.join('tmp/woods')
+  config.embedding_options = {
+    model: 'nomic-embed-text',
+    host:  ENV.fetch('WOODS_OLLAMA_URL', 'http://localhost:11434')
+  }
+end
+```
+
+The embed run writes `woods.json` + `dumps/<ISO8601>/vectors.bin` + `metadata.msgpack` under `output_dir`. The MCP server reads them at boot — no sqlite3 gem required, no pgvector/Qdrant service needed. Dump retention defaults to the last 3 (configurable via `config.dump_retention_count`).
+
+Requirements:
+- `output_dir` must be set and readable by both the embed process and the MCP server.
+- The MCP server must know the same `output_dir` (pass via `woods-mcp <DIR>` or set `WOODS_DIR`).
+
 ## Presets
 
 For quick setup, use named presets that configure storage + embedding together:
 
 ```ruby
-# Local development — no external services needed
+# Local development — no external services needed (requires sqlite3 gem)
 Woods.configure_with_preset(:local)
 # → in_memory vectors, SQLite metadata, in_memory graph, Ollama embeddings
+
+# Shared filesystem — rake embed → separate MCP server reads the dump.
+# No sqlite3 gem needed; works on MySQL/Postgres-only hosts.
+Woods.configure_with_preset(:shared_filesystem)
+# → in_memory everything + Snapshotter-based persistence via output_dir
 
 # PostgreSQL — requires pgvector extension and OpenAI API key
 Woods.configure_with_preset(:postgresql)

--- a/docs/design/PERSISTENCE_AND_BOOTSTRAP.md
+++ b/docs/design/PERSISTENCE_AND_BOOTSTRAP.md
@@ -1,8 +1,15 @@
 # Persistence, Bootstrap Flow, and Query Performance
 
-**Status:** Draft — pending sign-off.
+**Status:** Implemented — PRs #73, #74, #75, #76, #77, and the current status-surface PR.
 **Scope:** Fix multi-process (Shape 2) index serving end-to-end. Covers control-flow decomposition of `MCP::Bootstrapper`, on-disk persistence format for the in-memory stores, and the query-path allocation bug that shipped alongside them.
 **Non-goals:** Alternate durable backends beyond what already exists (pgvector, Qdrant, SQLite), distributed/sharded embedding, booting Rails inside `woods-mcp`, native C extensions.
+
+## Deferred to follow-ups
+
+Two plan items were explicitly scope-cut during implementation:
+
+- **Streaming append during embed** (§3.4). Compact-at-end is the current path. For admin's minutes-scale embed this is fine; worth revisiting at 10× scale when a crash at hour N of N+1 genuinely hurts. TODO marker in `Indexer#persist_snapshot`.
+- **Full woods-testbed integration spec.** The subprocess-based round-trip in `spec/integration/persistence_round_trip_spec.rb` proves the dump/load contract. A testbed-hosted end-to-end that boots `woods-mcp` and issues a semantic query against a real Ollama is a separate effort that needs the testbed repo wired in.
 
 ---
 

--- a/exe/woods-mcp
+++ b/exe/woods-mcp
@@ -25,7 +25,7 @@ JSON::Validator.use_multi_json = false if defined?(JSON::Validator) && JSON::Val
 
 begin
   index_dir = Woods::MCP::Bootstrapper.resolve_index_dir(ARGV)
-  retriever, _bootstrap_state = Woods::MCP::Bootstrapper.build_retriever(index_dir: index_dir)
+  retriever, bootstrap_state = Woods::MCP::Bootstrapper.build_retriever(index_dir: index_dir)
   snapshot_store = Woods::MCP::Bootstrapper.build_snapshot_store(index_dir)
 rescue Woods::MCP::BootstrapError => e
   warn "[woods-mcp] #{e.class.name.split('::').last}: #{e.message}"
@@ -33,7 +33,10 @@ rescue Woods::MCP::BootstrapError => e
   exit 2
 end
 
-server = Woods::MCP::Server.build(index_dir: index_dir, retriever: retriever, snapshot_store: snapshot_store)
+server = Woods::MCP::Server.build(
+  index_dir: index_dir, retriever: retriever, snapshot_store: snapshot_store,
+  bootstrap_state: bootstrap_state
+)
 
 # Pin protocol version for broad client compatibility (Claude Code, Cursor, etc.)
 if ENV['MCP_PROTOCOL_VERSION']

--- a/exe/woods-mcp-http
+++ b/exe/woods-mcp-http
@@ -24,7 +24,7 @@ require_relative '../lib/woods/embedding/indexer'
 
 begin
   index_dir = Woods::MCP::Bootstrapper.resolve_index_dir(ARGV)
-  retriever, _bootstrap_state = Woods::MCP::Bootstrapper.build_retriever(index_dir: index_dir)
+  retriever, bootstrap_state = Woods::MCP::Bootstrapper.build_retriever(index_dir: index_dir)
   snapshot_store = Woods::MCP::Bootstrapper.build_snapshot_store(index_dir)
 rescue Woods::MCP::BootstrapError => e
   warn "[woods-mcp-http] #{e.class.name.split('::').last}: #{e.message}"
@@ -46,7 +46,10 @@ if loopback && token.nil?
   warn '[woods-mcp-http] WARNING: running on loopback without a token; local processes can reach this server.'
 end
 
-server = Woods::MCP::Server.build(index_dir: index_dir, retriever: retriever, snapshot_store: snapshot_store)
+server = Woods::MCP::Server.build(
+  index_dir: index_dir, retriever: retriever, snapshot_store: snapshot_store,
+  bootstrap_state: bootstrap_state
+)
 transport = MCP::Server::Transports::StreamableHTTPTransport.new(server)
 server.transport = transport
 

--- a/lib/woods/builder.rb
+++ b/lib/woods/builder.rb
@@ -32,13 +32,23 @@ module Woods
   class Builder # rubocop:disable Metrics/ClassLength
     # Named presets mapping to default adapter types.
     #
-    # :local      — fully local, no external services required
-    # :postgresql — pgvector for vectors, OpenAI for embeddings
-    # :production — Qdrant for vectors, OpenAI for embeddings
+    # :local              — fully local, no external services required (requires sqlite3 gem)
+    # :shared_filesystem  — Shape 2: rake embed → separate MCP server reads from disk.
+    #                       All stores in-memory + persisted to output_dir via the
+    #                       Snapshotter. No sqlite3 gem needed. Requires output_dir set
+    #                       AND readable by both the embed process and the MCP server.
+    # :postgresql         — pgvector for vectors, OpenAI for embeddings
+    # :production         — Qdrant for vectors, OpenAI for embeddings
     PRESETS = {
       local: {
         vector_store: :in_memory,
         metadata_store: :sqlite,
+        graph_store: :in_memory,
+        embedding_provider: :ollama
+      },
+      shared_filesystem: {
+        vector_store: :in_memory,
+        metadata_store: :in_memory,
         graph_store: :in_memory,
         embedding_provider: :ollama
       },

--- a/lib/woods/mcp/server.rb
+++ b/lib/woods/mcp/server.rb
@@ -29,12 +29,17 @@ module Woods
         # @param retriever [Woods::Retriever, nil] Optional retriever for semantic search
         # @param operator [Hash, nil] Optional operator config with :status_reporter, :error_escalator, :pipeline_guard, :pipeline_lock
         # @param feedback_store [Woods::Feedback::Store, nil] Optional feedback store
+        # @param bootstrap_state [Woods::MCP::BootstrapState, nil] Optional state
+        #   from the bootstrap flow. When provided, woods_status reports the
+        #   hydrated/degraded/failed lifecycle plus the reason so operators can
+        #   diagnose "why is semantic search disabled" without reading the Ruby
+        #   source. Nil just means the caller didn't go through Bootstrapper.
         # @param warmup [Boolean] Pre-populate the index reader's caches during build,
         #   shifting first-tool-call latency to startup. Default: true. Pass false for
         #   tests or when startup time matters more than first-query latency.
         # @return [MCP::Server] Configured server ready for transport
         def build(index_dir:, retriever: nil, operator: nil, feedback_store: nil, snapshot_store: nil,
-                  response_format: nil, warmup: true)
+                  bootstrap_state: nil, response_format: nil, warmup: true)
           reader = IndexReader.new(index_dir)
           reader.warmup! if warmup
           config = Woods.configuration
@@ -104,7 +109,7 @@ module Woods
           define_feedback_tools(server, feedback_store, respond, respond_err, fb_missing)
           define_snapshot_tools(server, snapshot_store, respond, respond_err, snap_missing)
           define_notion_sync_tool(server, reader, index_dir, respond, respond_err)
-          define_woods_status_tool(server, reader, retriever, index_dir, respond)
+          define_woods_status_tool(server, reader, retriever, index_dir, bootstrap_state, respond)
           register_resource_handler(server, reader)
 
           server
@@ -1121,16 +1126,20 @@ module Woods
           ]
         end
 
-        def define_woods_status_tool(server, reader, retriever, index_dir, respond)
+        def define_woods_status_tool(server, reader, retriever, index_dir, bootstrap_state, respond)
           server.define_tool(
             name: 'woods_status',
             description: 'Diagnose whether the Woods index and server are healthy. Returns extraction metadata ' \
                          '(last run, unit counts, git SHA, staleness in seconds), retriever/embedding configuration, ' \
-                         'feature flags, and a ready flag. Call this first on cold connect to learn what the server knows.',
+                         'bootstrap state (hydrated / degraded / failed + reason), feature flags, and a ready flag. ' \
+                         'Call this first on cold connect to learn what the server knows.',
             input_schema: { type: 'object', properties: {} }
           ) do |server_context:|
             _ = server_context
-            status = Woods::MCP::Server.build_status(reader: reader, retriever: retriever, index_dir: index_dir)
+            status = Woods::MCP::Server.build_status(
+              reader: reader, retriever: retriever, index_dir: index_dir,
+              bootstrap_state: bootstrap_state
+            )
             respond.call(JSON.pretty_generate(status))
           end
         end
@@ -1140,7 +1149,7 @@ module Woods
         # Build the woods_status payload. Exposed at module level so specs (and future
         # console/unified-server entry points) can assemble the same shape without
         # reaching through the MCP::Server internals.
-        def build_status(reader:, retriever:, index_dir:)
+        def build_status(reader:, retriever:, index_dir:, bootstrap_state: nil)
           manifest = safe_manifest(reader)
           extracted_at = manifest && manifest['extracted_at']
           staleness = staleness_seconds(extracted_at)
@@ -1169,6 +1178,7 @@ module Woods
               configured: !retriever.nil?,
               class: retriever&.class&.name
             },
+            bootstrap: bootstrap_state&.to_h,
             features: {
               embedding_model: config.respond_to?(:embedding_model) ? config.embedding_model : nil,
               embedding_provider: config.respond_to?(:embedding_provider) ? presence(config.embedding_provider) : nil,

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -87,6 +87,34 @@ RSpec.describe Woods::Builder do
       end
     end
 
+    describe ':shared_filesystem preset' do
+      subject(:config) { described_class.preset_config(:shared_filesystem) }
+
+      # Shape 2 in the persistence plan: rake embed writes to output_dir,
+      # separate MCP server reads the dump. All stores :in_memory;
+      # persistence is via the Snapshotter, not SQLite. Works on MySQL
+      # and Postgres hosts that don't bundle the sqlite3 gem.
+      it 'returns a Configuration' do
+        expect(config).to be_a(Woods::Configuration)
+      end
+
+      it 'sets vector_store to :in_memory (persisted via Snapshotter)' do
+        expect(config.vector_store).to eq(:in_memory)
+      end
+
+      it 'sets metadata_store to :in_memory (no sqlite3 gem required)' do
+        expect(config.metadata_store).to eq(:in_memory)
+      end
+
+      it 'sets graph_store to :in_memory' do
+        expect(config.graph_store).to eq(:in_memory)
+      end
+
+      it 'sets embedding_provider to :ollama' do
+        expect(config.embedding_provider).to eq(:ollama)
+      end
+    end
+
     describe 'invalid preset' do
       it 'raises ArgumentError' do
         expect { described_class.preset_config(:invalid) }

--- a/spec/mcp/woods_status_spec.rb
+++ b/spec/mcp/woods_status_spec.rb
@@ -50,6 +50,47 @@ RSpec.describe 'woods_status tool' do
         :notion_configured, :console_mcp_enabled
       )
     end
+
+    it 'reports bootstrap=nil when no BootstrapState is passed (backwards compat)' do
+      expect(status[:bootstrap]).to be_nil
+    end
+
+    it 'surfaces BootstrapState when provided' do
+      require 'woods/mcp/bootstrap_state'
+      state = Woods::MCP::BootstrapState.new
+      state.mark(:hydrating)
+      state.mark(:hydrated)
+
+      s = Woods::MCP::Server.build_status(
+        reader: reader, retriever: nil, index_dir: fixture_dir,
+        bootstrap_state: state
+      )
+      expect(s[:bootstrap]).to include(status: :hydrated)
+      expect(s[:bootstrap][:hydrated_at]).not_to be_nil
+    end
+
+    it 'surfaces degraded state with reason class + message' do
+      require 'woods/mcp/bootstrap_state'
+      require 'woods/mcp/errors'
+      state = Woods::MCP::BootstrapState.new
+      state.mark(:hydrating)
+      reason = Woods::MCP::ProviderUnreachable.new(
+        url: 'http://host.docker.internal:11434',
+        reason: 'connection_refused'
+      )
+      state.mark(:degraded, reason: reason)
+
+      s = Woods::MCP::Server.build_status(
+        reader: reader, retriever: nil, index_dir: fixture_dir,
+        bootstrap_state: state
+      )
+      expect(s[:bootstrap][:status]).to eq(:degraded)
+      # BootstrapState.to_h formats reason as "<ClassName>: <message>"
+      # — a single human-readable line that's grep-friendly for operators.
+      expect(s[:bootstrap][:reason]).to include('Woods::MCP::ProviderUnreachable')
+      expect(s[:bootstrap][:reason]).to include('connection_refused')
+      expect(s[:bootstrap][:degraded_since]).not_to be_nil
+    end
   end
 
   describe 'missing-manifest resilience' do


### PR DESCRIPTION
PR 4 (polish) of the persistence plan. Closes out the multi-process Shape-2 effort that started with PR #73.

## What lands

### `BootstrapState` in `woods_status`

`Woods::MCP::Server.build` takes a new `bootstrap_state:` kwarg that flows through to the `woods_status` tool. The payload gains a top-level `bootstrap:` block:

```json
{
  "bootstrap": {
    "status": "degraded",
    "reason": "Woods::MCP::ProviderUnreachable: http://host.docker.internal:11434: connection_refused",
    "hydrated_at": null,
    "degraded_since": "2026-04-23T05:42:18Z"
  }
}
```

An operator SSH'd into a container at 2 am can now answer "why is semantic search disabled?" in one MCP call. `reason` is a grep-friendly `"<ClassName>: <message>"` string so logs + status can be cross-referenced by class.

Backwards-compatible: `bootstrap_state` defaults to nil. Callers that don't go through `Bootstrapper` (tests, console) still produce a valid status payload with `bootstrap: nil`.

`exe/woods-mcp` and `exe/woods-mcp-http` thread the state through from the `Bootstrapper`'s `[retriever, state]` return.

### `:shared_filesystem` preset

```ruby
Builder::PRESETS[:shared_filesystem] = {
  vector_store:   :in_memory,
  metadata_store: :in_memory,
  graph_store:    :in_memory,
  embedding_provider: :ollama
}
```

Shape 2 (rake embed → separate `woods-mcp` server reads the dump). All stores `:in_memory`; Snapshotter handles persistence via `output_dir`. No `sqlite3` gem required — works on MySQL- or Postgres-only hosts.

`:local` keeps its SQLite default — users who want metadata durability *inside* the embed process still get it.

### Docs

- **`docs/CONFIGURATION_REFERENCE.md`** — new "Deployment Shapes" section (single-process / shared filesystem / distributed) with a Shape 2 setup example; presets section now documents `:shared_filesystem`.
- **`docs/BACKEND_MATRIX.md`** — new "Persistence Story" section with a shape × capability table (survives process restart, multi-writer, sqlite3 required, external service required, cross-machine query, config snapshot) so readers can pick a backend without cross-referencing multiple sections.
- **`docs/design/PERSISTENCE_AND_BOOTSTRAP.md`** — status flipped to "Implemented"; explicit scope-cuts (streaming append, woods-testbed integration) documented as deferred follow-ups.

## Test plan

- [x] `bundle exec rake spec` — **4314 examples, 0 failures, 2 pending** (unchanged tiktoken pendings)
- [x] `bundle exec rubocop` — 424 files, 0 offenses
- [x] `woods_status` spec covers: bootstrap=nil when not passed, hydrated state surfaces `hydrated_at`, degraded state surfaces class-prefixed reason + `degraded_since`
- [x] `Builder` preset spec covers `:shared_filesystem` store/provider values

## What's deferred (follow-ups, not this PR)

- **Streaming append during embed.** Compact-at-end is the current path; a crash mid-embed discards the run. Revisit at 10× admin scale.
- **Full woods-testbed integration spec.** The subprocess round-trip in `spec/integration/persistence_round_trip_spec.rb` proves the dump/load contract. A testbed-hosted end-to-end that boots real `woods-mcp` against real Ollama is a separate effort that needs the testbed repo wired in.

Both are captured in the design doc's "Deferred to follow-ups" block.