### PR TITLE
fix(mcp): probe provider for Ollama dimension at embed time

### DIFF
--- a/lib/woods/mcp/bootstrapper.rb
+++ b/lib/woods/mcp/bootstrapper.rb
@@ -5,6 +5,7 @@ require_relative 'bootstrap_state'
 require_relative 'config_resolver'
 require_relative 'provider_probe'
 require_relative '../index_artifact'
+require_relative '../builder'
 require_relative '../resolved_config'
 require_relative '../storage/snapshotter'
 
@@ -111,7 +112,17 @@ module Woods
                                                  ollama_probe: method(:ollama_reachable?))
         return [nil, state] unless config.embedding_provider
 
-        resolved = ResolvedConfig.from_configuration(config)
+        # Build the provider once so {ResolvedConfig.from_configuration} can
+        # probe +provider.dimensions+ — without this, Ollama's runtime-only
+        # dimension never makes it into +resolved+ and the downstream
+        # Snapshotter.load_or_empty validation compares stored-vs-0.
+        #
+        # The probe is tolerant: if the provider is unreachable we still
+        # need a non-nil +resolved+ so the MCP server can start degraded
+        # (see the "provider unreachable" branch below). Snapshotter then
+        # surfaces a DimensionMismatch only if there's actually a stored
+        # artifact to validate against.
+        resolved = build_resolved_config(config)
         retriever = build_retriever_from_config(config, resolved, artifact)
         probe_and_mark_state(config, state)
         warn "[woods-mcp] semantic search: #{state.status} (#{config.embedding_provider})"
@@ -141,6 +152,18 @@ module Woods
       def self.ollama_reachable?
         ConfigResolver.send(:ollama_reachable?)
       end
+
+      # Build a ResolvedConfig from the live host config, probing the
+      # provider for its dimension when possible. A provider that can't
+      # be reached (Ollama down) falls back to the declared-only path so
+      # the MCP server can still come up degraded.
+      def self.build_resolved_config(config)
+        provider = Woods::Builder.new(config).build_embedding_provider
+        ResolvedConfig.from_configuration(config, provider: provider)
+      rescue StandardError
+        ResolvedConfig.from_configuration(config)
+      end
+      private_class_method :build_resolved_config
 
       # Resolve an IndexArtifact from the passed dir or Woods.configuration.
       def self.build_artifact(index_dir)

--- a/lib/woods/mcp/config_resolver.rb
+++ b/lib/woods/mcp/config_resolver.rb
@@ -111,7 +111,7 @@ module Woods
       # @return [Woods::Configuration]
       def self.apply_stored_config(config, stored, artifact:, env: ENV)
         if config.embedding_provider
-          live = ResolvedConfig.from_configuration(config)
+          live = live_resolved_config(config)
           live.assert_compatible!(stored)
           config
         else
@@ -119,6 +119,21 @@ module Woods
         end
       end
       private_class_method :apply_stored_config
+
+      # Build a ResolvedConfig from the live host config, probing the
+      # provider's dimension when possible. Tolerant of probe failures
+      # (unreachable Ollama): falls back to the declared-only path so
+      # {ResolvedConfig#assert_compatible!} surfaces a typed
+      # {DimensionMismatch} instead of a raw +Errno::ECONNREFUSED+
+      # escaping the caller's {BootstrapError} rescue.
+      def self.live_resolved_config(config)
+        require_relative '../builder'
+        provider = Woods::Builder.new(config).build_embedding_provider
+        ResolvedConfig.from_configuration(config, provider: provider)
+      rescue StandardError
+        ResolvedConfig.from_configuration(config)
+      end
+      private_class_method :live_resolved_config
 
       # Populate a blank {Woods::Configuration} from a stored {ResolvedConfig}.
       #

--- a/lib/woods/resolved_config.rb
+++ b/lib/woods/resolved_config.rb
@@ -64,16 +64,29 @@ module Woods
 
     # Capture the current {Woods::Configuration} as a {ResolvedConfig}.
     #
+    # The +provider:+ kwarg lets callers pass a live embedding provider so
+    # the dimension is discovered at runtime instead of being read from a
+    # declared-only field. This matters for Ollama — dimensions come from
+    # the model, not the config — and doesn't hurt OpenAI, whose provider
+    # exposes the same +#dimensions+ interface.
+    #
+    # When +provider:+ is omitted, dimension falls back to
+    # +config.embedding_options[:dimension]+ (useful for specs and for
+    # offline ResolvedConfig construction where no provider exists).
+    #
     # @param config [Woods::Configuration]
     # @param gem_version [String] Defaults to {Woods::VERSION}
+    # @param provider [#dimensions, nil] Optional live provider to probe
+    #   for dimension when +config.embedding_options[:dimension]+ is absent.
     # @return [ResolvedConfig]
-    def self.from_configuration(config, gem_version: nil) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+    def self.from_configuration(config, gem_version: nil, provider: nil) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
       require_relative 'version'
 
       opts = config.embedding_options || {}
-      dim = opts[:dimension] || opts['dimension']
+      declared_dim = opts[:dimension] || opts['dimension']
+      dim = declared_dim || (provider.respond_to?(:dimensions) ? provider.dimensions : nil)
 
-      provider = {
+      provider_hash = {
         class: resolve_provider_class(config.embedding_provider),
         model: (opts[:model] || opts['model'] || config.embedding_model).to_s,
         dimension: dim.to_i,
@@ -86,7 +99,7 @@ module Woods
         schema_version: SCHEMA_VERSION_SUPPORTED,
         gem_version: (gem_version || Woods::VERSION).to_s,
         created_at: Time.now.utc,
-        embedding_provider: provider,
+        embedding_provider: provider_hash,
         stores: {
           vector_store: config.vector_store,
           metadata_store: config.metadata_store,

--- a/lib/woods/tasks.rb
+++ b/lib/woods/tasks.rb
@@ -44,7 +44,7 @@ module Woods
         text_preparer: builder.build_text_preparer(provider),
         vector_store: builder.build_vector_store,
         metadata_store: config.metadata_store ? builder.build_metadata_store : nil,
-        resolved_config: build_resolved_config(config),
+        resolved_config: build_resolved_config(config, provider: provider),
         chunker: builder.build_chunker(provider),
         dump_retention_count: config.dump_retention_count,
         output_dir: ENV.fetch('WOODS_OUTPUT', config.output_dir)
@@ -55,10 +55,15 @@ module Woods
     # Returns nil if the configuration doesn't have enough to produce one
     # (pre-persistence-arc hosts) so the Indexer falls back to the legacy
     # dump-without-woods.json behaviour.
-    def build_resolved_config(config)
+    #
+    # Passes the live +provider+ so {ResolvedConfig.from_configuration} can
+    # probe +provider.dimensions+ — without this, Ollama snapshots record
+    # +dimension: 0+ and every subsequent MCP boot fails a spurious
+    # dimension-mismatch check against the real stored vectors.
+    def build_resolved_config(config, provider: nil)
       return nil unless config.embedding_provider
 
-      ResolvedConfig.from_configuration(config)
+      ResolvedConfig.from_configuration(config, provider: provider)
     rescue StandardError
       nil
     end

--- a/spec/mcp/config_resolver_spec.rb
+++ b/spec/mcp/config_resolver_spec.rb
@@ -174,6 +174,49 @@ RSpec.describe Woods::MCP::ConfigResolver do
       end
     end
 
+    context 'woods.json present, host omits declared dimension (Ollama case)' do
+      it 'probes the live provider and validates against stored dimension' do
+        Dir.mktmpdir do |dir|
+          write_woods_json(dir)
+          artifact = Woods::IndexArtifact.new(dir)
+          cfg = Woods::Configuration.new
+          cfg.vector_store = :in_memory
+          cfg.metadata_store = :in_memory
+          cfg.graph_store = :in_memory
+          cfg.embedding_provider = :ollama
+          cfg.embedding_options = { host: 'http://localhost:11434', model: 'nomic-embed-text' }
+
+          probe_provider = instance_double(Woods::Embedding::Provider::Ollama, dimensions: 768)
+          allow_any_instance_of(Woods::Builder).to receive(:build_embedding_provider).and_return(probe_provider)
+
+          expect { described_class.resolve(cfg, artifact: artifact) }.not_to raise_error
+        end
+      end
+
+      it 'falls back gracefully when the provider probe raises, surfacing a typed mismatch' do
+        Dir.mktmpdir do |dir|
+          write_woods_json(dir)
+          artifact = Woods::IndexArtifact.new(dir)
+          cfg = Woods::Configuration.new
+          cfg.vector_store = :in_memory
+          cfg.metadata_store = :in_memory
+          cfg.graph_store = :in_memory
+          cfg.embedding_provider = :ollama
+          cfg.embedding_options = { host: 'http://localhost:11434', model: 'nomic-embed-text' }
+
+          probe_provider = instance_double(Woods::Embedding::Provider::Ollama)
+          allow(probe_provider).to receive(:dimensions).and_raise(Errno::ECONNREFUSED)
+          allow_any_instance_of(Woods::Builder).to receive(:build_embedding_provider).and_return(probe_provider)
+
+          # Untyped network error must not escape — it's converted to a typed
+          # DimensionMismatch (0 vs stored 768) the caller's BootstrapError
+          # rescue can handle.
+          expect { described_class.resolve(cfg, artifact: artifact) }
+            .to raise_error(Woods::MCP::DimensionMismatch)
+        end
+      end
+    end
+
     context 'woods.json present, live config has different provider model' do
       it 'raises Woods::MCP::ConfigMismatch' do
         Dir.mktmpdir do |dir|

--- a/spec/resolved_config_spec.rb
+++ b/spec/resolved_config_spec.rb
@@ -267,4 +267,43 @@ RSpec.describe Woods::ResolvedConfig do
       expect(config.stores).to be_frozen
     end
   end
+
+  describe '.from_configuration' do
+    let(:host_config) do
+      instance_double(
+        Woods::Configuration,
+        embedding_provider: :ollama,
+        embedding_model: 'nomic-embed-text',
+        embedding_options: { host: 'http://ollama:11434' },
+        vector_store: :in_memory,
+        metadata_store: :in_memory,
+        graph_store: :in_memory
+      )
+    end
+
+    it 'probes the live provider for its dimension when declared config omits it' do
+      provider = instance_double(Woods::Embedding::Provider::Ollama, dimensions: 768)
+
+      resolved = described_class.from_configuration(host_config, provider: provider)
+
+      expect(resolved.dimension).to eq(768)
+    end
+
+    it 'prefers a declared dimension over the live provider probe' do
+      declared = host_config.embedding_options.merge(dimension: 1024)
+      allow(host_config).to receive(:embedding_options).and_return(declared)
+      provider = instance_double(Woods::Embedding::Provider::Ollama)
+
+      resolved = described_class.from_configuration(host_config, provider: provider)
+
+      expect(resolved.dimension).to eq(1024)
+      expect(provider).not_to have_received(:dimensions) if provider.respond_to?(:dimensions)
+    end
+
+    it 'falls back to zero when no provider is supplied and config omits dimension' do
+      resolved = described_class.from_configuration(host_config)
+
+      expect(resolved.dimension).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Ollama embeds were writing \`\"dimension\": 0\` to \`woods.json\` because \`ResolvedConfig.from_configuration\` only read dimension from declared config (which Ollama never sets — dimensions come from the model at runtime).
- Every subsequent \`woods-mcp\` boot then failed \`Snapshotter::Vector\`'s stored-vs-live dimension check against the real 768-dim vectors.
- Added an optional \`provider:\` kwarg to \`ResolvedConfig.from_configuration\` that probes \`provider.dimensions\`, and threaded the already-built provider through the three callers (\`tasks.rb\`, \`mcp/bootstrapper.rb\`, \`mcp/config_resolver.rb\`).

## Why this fix shape

OpenAI's provider exposes \`#dimensions\` via a static model→dim table (no network), so probing is free. Ollama's \`#dimensions\` memoizes after the first \`embed('test')\` call — at embed time the provider is about to be used anyway, so probing costs nothing. The \`Builder#build_embedding_provider\` already strips \`:dimension\` from provider kwargs via \`SNAPSHOT_ONLY_KEYS\`, so adding it back through the probe doesn't break provider construction.

In the MCP boot paths, probe failures (unreachable Ollama) fall back to the un-probed path so the outer layer surfaces a typed \`DimensionMismatch\` (caught by \`exe/woods-mcp\`'s \`BootstrapError\` rescue) rather than a raw \`Errno::ECONNREFUSED\`.

## Before / after

**Before** — \`woods.json\` after an Ollama embed:
\`\`\`json
{ \"embedding_provider\": { \"class\": \"Woods::Embedding::Provider::Ollama\", \"dimension\": 0 } }
\`\`\`
MCP boot: \`DimensionMismatch: stored 768 ≠ provider 0\`.

**After** — same embed:
\`\`\`json
{ \"embedding_provider\": { \"class\": \"Woods::Embedding::Provider::Ollama\", \"dimension\": 768 } }
\`\`\`
MCP boot: 642 vectors hydrated, retriever returned.

## Test plan

- [x] New spec: \`ResolvedConfig.from_configuration\` probes provider dimension when declared config omits it
- [x] New spec: declared dimension still wins over the probe when both are present
- [x] New spec: no provider + no declared dim → \`dimension: 0\` (unchanged fallback)
- [x] New spec: \`ConfigResolver.resolve\` probes and validates when host omits dimension (Ollama case)
- [x] New spec: unreachable provider at \`ConfigResolver\` time is converted to typed \`DimensionMismatch\`
- [x] Full gem suite: 4379 examples, 0 failures
- [x] End-to-end in \`woods-testbed\` (\`rails-8.0\`): re-ran \`woods:embed\`, confirmed \`woods.json\` records \`dimension: 768\`, confirmed \`Bootstrapper.build_retriever\` hydrates 642 vectors
- [x] Rubocop clean across 6 modified files