### PR TITLE
fix(mcp): codebase_retrieve empty + 7 follow-up agent-reported bugs

### DIFF
--- a/exe/woods-console-mcp
+++ b/exe/woods-console-mcp
@@ -16,6 +16,17 @@
 # tables, Layer 2 credential scanning, and Layer 3 column/EAV redaction are
 # all configured through Woods::Configuration — see docs/CONSOLE_MCP_SETUP.md.
 
+# Suppress json-schema MultiJSON deprecation notice that would otherwise pollute
+# stderr during MCP stdio transport. The deprecation fires the first time
+# +json-schema+ is required — must happen before any Woods require that could
+# transitively pull it in. MCP clients parsing stderr can't tolerate banners.
+begin
+  require 'json-schema'
+  JSON::Validator.use_multi_json = false if defined?(JSON::Validator) && JSON::Validator.respond_to?(:use_multi_json=)
+rescue LoadError
+  # json-schema isn't in every bundle.
+end
+
 require 'yaml'
 require 'woods'
 require_relative '../lib/woods/console/server'
@@ -29,10 +40,6 @@ end
 
 config_path = ENV.fetch('WOODS_CONSOLE_CONFIG', File.expand_path('~/.woods/console.yml'))
 config = File.exist?(config_path) ? YAML.safe_load_file(config_path) : {}
-
-# Suppress json-schema MultiJSON deprecation notice that would pollute stderr
-# during MCP stdio transport. The notice fires when multi_json is in the bundle.
-JSON::Validator.use_multi_json = false if defined?(JSON::Validator) && JSON::Validator.respond_to?(:use_multi_json=)
 
 server = Woods::Console::Server.build(config: config)
 transport = MCP::Server::Transports::StdioTransport.new(server)

--- a/exe/woods-mcp
+++ b/exe/woods-mcp
@@ -11,6 +11,20 @@
 # them via the Model Context Protocol (stdio transport).
 # Does NOT require Rails — only reads pre-extracted data.
 
+# Suppress json-schema MultiJSON deprecation notice that would otherwise pollute
+# stderr during MCP stdio transport. The deprecation fires the first time
+# +json-schema+ is required — earlier revisions set the flag *after* the
+# +require_relative '../lib/woods'+ chain, which lost the race. Any MCP client
+# that parses stderr would trip on the banner. Require +json-schema+ explicitly,
+# set the flag, *then* load Woods.
+begin
+  require 'json-schema'
+  JSON::Validator.use_multi_json = false if defined?(JSON::Validator) && JSON::Validator.respond_to?(:use_multi_json=)
+rescue LoadError
+  # json-schema isn't in every bundle — MCP clients without schema validation
+  # just don't see the deprecation notice either.
+end
+
 require_relative '../lib/woods'
 require_relative '../lib/woods/dependency_graph'
 require_relative '../lib/woods/graph_analyzer'
@@ -18,10 +32,6 @@ require_relative '../lib/woods/mcp/server'
 require_relative '../lib/woods/mcp/bootstrapper'
 require_relative '../lib/woods/embedding/text_preparer'
 require_relative '../lib/woods/embedding/indexer'
-
-# Suppress json-schema MultiJSON deprecation notice that would pollute stderr
-# during MCP stdio transport. The notice fires when multi_json is in the bundle.
-JSON::Validator.use_multi_json = false if defined?(JSON::Validator) && JSON::Validator.respond_to?(:use_multi_json=)
 
 begin
   index_dir = Woods::MCP::Bootstrapper.resolve_index_dir(ARGV)
@@ -33,9 +43,13 @@ rescue Woods::MCP::BootstrapError => e
   exit 2
 end
 
+retriever_reloader = lambda do
+  Woods::MCP::Bootstrapper.reload_stores!(retriever, index_dir: index_dir)
+end
+
 server = Woods::MCP::Server.build(
   index_dir: index_dir, retriever: retriever, snapshot_store: snapshot_store,
-  bootstrap_state: bootstrap_state
+  bootstrap_state: bootstrap_state, retriever_reloader: retriever_reloader
 )
 
 # Pin protocol version for broad client compatibility (Claude Code, Cursor, etc.)

--- a/exe/woods-mcp-http
+++ b/exe/woods-mcp-http
@@ -46,9 +46,13 @@ if loopback && token.nil?
   warn '[woods-mcp-http] WARNING: running on loopback without a token; local processes can reach this server.'
 end
 
+retriever_reloader = lambda do
+  Woods::MCP::Bootstrapper.reload_stores!(retriever, index_dir: index_dir)
+end
+
 server = Woods::MCP::Server.build(
   index_dir: index_dir, retriever: retriever, snapshot_store: snapshot_store,
-  bootstrap_state: bootstrap_state
+  bootstrap_state: bootstrap_state, retriever_reloader: retriever_reloader
 )
 transport = MCP::Server::Transports::StreamableHTTPTransport.new(server)
 server.transport = transport

--- a/exe/woods-mcp-http
+++ b/exe/woods-mcp-http
@@ -11,6 +11,15 @@
 # them via the Model Context Protocol (Streamable HTTP transport).
 # Requires the `rackup` gem and a Rack-compatible server (e.g., puma).
 
+# Suppress json-schema MultiJSON deprecation before any require chain that
+# could transitively load json-schema. See exe/woods-mcp for the full rationale.
+begin
+  require 'json-schema'
+  JSON::Validator.use_multi_json = false if defined?(JSON::Validator) && JSON::Validator.respond_to?(:use_multi_json=)
+rescue LoadError
+  # json-schema isn't in every bundle.
+end
+
 require 'rackup'
 require_relative '../lib/woods'
 require_relative '../lib/woods/dependency_graph'

--- a/lib/woods/builder.rb
+++ b/lib/woods/builder.rb
@@ -99,8 +99,13 @@ module Woods
     #
     # @param vector_store [Storage::VectorStore::Interface, nil]
     # @param metadata_store [Storage::MetadataStore::Interface, nil]
+    # @param graph_store [Storage::GraphStore::Interface, nil] Pre-populated
+    #   graph store. Without this, the retriever gets a fresh empty graph,
+    #   which silently degrades +:hybrid+ retrieval (graph expansion returns
+    #   no candidates). The Bootstrapper hydrates from +dependency_graph.json+
+    #   on disk and passes the populated store here.
     # @return [Retriever, Cache::CachedRetriever] A fully wired retriever
-    def build_retriever(vector_store: nil, metadata_store: nil)
+    def build_retriever(vector_store: nil, metadata_store: nil, graph_store: nil)
       provider = build_embedding_provider
       cache = build_cache_store
 
@@ -109,7 +114,7 @@ module Woods
       retriever = Retriever.new(
         vector_store: vector_store || build_vector_store,
         metadata_store: metadata_store || build_metadata_store,
-        graph_store: build_graph_store,
+        graph_store: graph_store || build_graph_store,
         embedding_provider: provider
       )
 

--- a/lib/woods/cache/cache_middleware.rb
+++ b/lib/woods/cache/cache_middleware.rb
@@ -154,6 +154,22 @@ module Woods
       def metadata_store = @retriever.metadata_store
       def graph_store    = @retriever.graph_store
 
+      # Invalidate every cached context result. Called from the MCP +reload+
+      # tool after the retriever's stores have been re-hydrated from a fresh
+      # embed — otherwise cached results from the old embedding run would
+      # linger until their TTL expires and contradict the new stores.
+      #
+      # Embedding caches (query → vector) are NOT cleared: the query-vector
+      # mapping is deterministic for a given provider+model and survives any
+      # index reload. Only context results (query → ranked units) go stale.
+      #
+      # @return [void]
+      def invalidate_context_cache!
+        @cache_store.clear(namespace: :context)
+      rescue StandardError => e
+        warn("[Woods] CachedRetriever context-cache invalidation failed: #{e.message}")
+      end
+
       # Execute the retrieval pipeline with context-level caching.
       #
       # On cache hit, returns a RetrievalResult reconstructed from cached data

--- a/lib/woods/cache/cache_middleware.rb
+++ b/lib/woods/cache/cache_middleware.rb
@@ -145,17 +145,31 @@ module Woods
         @context_ttl = context_ttl
       end
 
+      # Expose the wrapped stores so the MCP +reload+ tool and
+      # {Woods::MCP::Bootstrapper.reload_stores!} can re-hydrate caches in
+      # place regardless of whether caching is enabled. Without these
+      # delegations, reload is a silent no-op when +cache_enabled+ is true —
+      # the bootstrapper would see +nil+ stores on the wrapper and skip.
+      def vector_store   = @retriever.vector_store
+      def metadata_store = @retriever.metadata_store
+      def graph_store    = @retriever.graph_store
+
       # Execute the retrieval pipeline with context-level caching.
       #
       # On cache hit, returns a RetrievalResult reconstructed from cached data
       # without running any pipeline stages. On miss, delegates to the real
       # retriever and caches the serializable parts of the result.
       #
+      # Cache key includes +types:+ / +exclude_types:+ so a run with a
+      # narrower type filter doesn't return a broader-filter cached result.
+      #
       # @param query [String] Natural language query
       # @param budget [Integer] Token budget
+      # @param types [Array<String, Symbol>, nil] Include-only filter
+      # @param exclude_types [Array<String, Symbol>, nil] Additional exclusions
       # @return [Retriever::RetrievalResult]
-      def retrieve(query, budget: 8000)
-        key = context_key(query, budget)
+      def retrieve(query, budget: 8000, types: nil, exclude_types: nil)
+        key = context_key(query, budget, types: types, exclude_types: exclude_types)
         cached = @cache_store.read(key)
 
         if cached
@@ -170,7 +184,7 @@ module Woods
           )
         end
 
-        result = @retriever.retrieve(query, budget: budget)
+        result = @retriever.retrieve(query, budget: budget, types: types, exclude_types: exclude_types)
 
         begin
           @cache_store.write(key, serialize_result(result), ttl: @context_ttl)
@@ -185,11 +199,23 @@ module Woods
 
       # Build a cache key for a context result.
       #
+      # Includes the type filter kwargs so distinct filter combinations miss
+      # each other — a lookup with +types: ["service"]+ must not return a
+      # previously-cached broad result.
+      #
       # @param query [String]
       # @param budget [Integer]
+      # @param types [Array<String, Symbol>, nil]
+      # @param exclude_types [Array<String, Symbol>, nil]
       # @return [String]
-      def context_key(query, budget)
-        Cache.cache_key(:context, query, budget.to_s)
+      def context_key(query, budget, types: nil, exclude_types: nil)
+        Cache.cache_key(:context, query, budget.to_s, fingerprint(types), fingerprint(exclude_types))
+      end
+
+      def fingerprint(types)
+        return '' if types.nil? || types.empty?
+
+        types.map(&:to_s).sort.join(',')
       end
 
       # Serialize a RetrievalResult to a JSON-safe hash.

--- a/lib/woods/embedding/indexer.rb
+++ b/lib/woods/embedding/indexer.rb
@@ -104,6 +104,7 @@ module Woods
 
       def process_batch(batch, checkpoint, stats, incremental:)
         to_embed = batch.each_with_object([]) do |unit_data, items|
+          persist_unit_metadata(unit_data)
           if incremental && checkpoint[unit_data['identifier']] == unit_data['source_hash']
             stats[:skipped] += 1
             next
@@ -112,6 +113,20 @@ module Woods
         end
 
         embed_and_store(to_embed, checkpoint, stats)
+      end
+
+      # Persist a unit's metadata under its base identifier so retrieval can
+      # resolve vector-search hits back to their unit data. Without this,
+      # the metadata store is left empty at end of run — Snapshotter::Metadata
+      # dumps a header with record_count: 0 and every MCP +codebase_retrieve+
+      # call silently returns empty text, because ContextAssembler#find_batch
+      # misses every candidate identifier. No-op when metadata_store is nil
+      # (hosts that don't configure one). Stored under the base identifier,
+      # not the chunk-suffixed id — chunks are an embedding-side concern only.
+      def persist_unit_metadata(unit_data)
+        return unless @metadata_store
+
+        @metadata_store.store(unit_data['identifier'], unit_data)
       end
 
       def collect_embed_items(unit_data, items)

--- a/lib/woods/mcp/bootstrap_state.rb
+++ b/lib/woods/mcp/bootstrap_state.rb
@@ -35,11 +35,18 @@ module Woods
       # @return [Time, nil] set when status transitions to +:degraded+
       attr_reader :degraded_since
 
+      # @return [Woods::ResolvedConfig, nil] captured at embed time and read
+      #   back from +woods.json+ during boot. Used by +woods_status+ to report
+      #   the provider/model actually in play instead of the stale defaults on
+      #   {Woods.configuration}.
+      attr_accessor :resolved_config
+
       def initialize
         @status = :initializing
         @reason = nil
         @hydrated_at = nil
         @degraded_since = nil
+        @resolved_config = nil
       end
 
       # Transition to a new status.

--- a/lib/woods/mcp/bootstrapper.rb
+++ b/lib/woods/mcp/bootstrapper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'json'
+
 require_relative 'errors'
 require_relative 'bootstrap_state'
 require_relative 'config_resolver'
@@ -123,6 +125,7 @@ module Woods
         # surfaces a DimensionMismatch only if there's actually a stored
         # artifact to validate against.
         resolved = build_resolved_config(config)
+        state.resolved_config = resolved
         retriever = build_retriever_from_config(config, resolved, artifact)
         probe_and_mark_state(config, state)
         warn "[woods-mcp] semantic search: #{state.status} (#{config.embedding_provider})"
@@ -137,6 +140,76 @@ module Woods
         retriever, _state = build_retriever(index_dir: index_dir)
         retriever
       end
+
+      # Refresh a live retriever's in-memory stores from the latest dumps on
+      # disk. Used by the MCP +reload+ tool so agents can pick up a fresh embed
+      # run without restarting the process. The retriever instance is preserved
+      # (tool closures kept their reference) — only the stores are mutated.
+      #
+      # No-op when:
+      #   - +retriever+ is nil (no embedding provider configured)
+      #   - stores are durable (pgvector / Qdrant auto-refresh externally)
+      #   - +woods.json+ is absent (Shape-1 deployments don't use Snapshotter)
+      #
+      # @param retriever [Woods::Retriever, nil]
+      # @param index_dir [String, Pathname]
+      # @return [Hash] Stats — +{ vectors:, metadata:, graph: }+ record counts
+      # @raise [Woods::MCP::BootstrapError] surfaced from ConfigResolver / Snapshotter
+      def self.reload_stores!(retriever, index_dir:)
+        return { vectors: 0, metadata: 0, graph: 0 } unless retriever
+
+        artifact = build_artifact(index_dir)
+        config, _source = ConfigResolver.resolve(Woods.configuration,
+                                                 artifact: artifact,
+                                                 ollama_probe: method(:ollama_reachable?))
+        resolved = build_resolved_config(config)
+
+        vectors_count = refill_in_memory_vector_store(retriever, config, resolved, artifact)
+        metadata_count = refill_in_memory_metadata_store(retriever, config, resolved, artifact)
+        graph_count = refill_in_memory_graph_store(retriever, config, artifact)
+
+        { vectors: vectors_count, metadata: metadata_count, graph: graph_count }
+      end
+
+      def self.refill_in_memory_vector_store(retriever, config, resolved, artifact)
+        vs = retriever.instance_variable_get(:@vector_store) ||
+             retriever.instance_variable_get(:@executor)&.instance_variable_get(:@vector_store)
+        return 0 unless vs.respond_to?(:clear!) && vs.respond_to?(:bulk_load)
+
+        fresh = hydrated_vector_store(config, resolved, artifact)
+        return 0 unless fresh
+
+        vs.clear!
+        vs.bulk_load(fresh.each_entry.map { |id, vec, meta| { id: id, vector: vec, metadata: meta } })
+        vs.respond_to?(:count) ? vs.count : 0
+      end
+      private_class_method :refill_in_memory_vector_store
+
+      def self.refill_in_memory_metadata_store(retriever, config, resolved, artifact)
+        ms = retriever.instance_variable_get(:@metadata_store)
+        return 0 unless ms.respond_to?(:clear!) && ms.respond_to?(:bulk_load)
+
+        fresh = hydrated_metadata_store(config, resolved, artifact)
+        return 0 unless fresh
+
+        ms.clear!
+        ms.bulk_load(fresh.each_entry)
+        ms.respond_to?(:count) ? ms.count : 0
+      end
+      private_class_method :refill_in_memory_metadata_store
+
+      def self.refill_in_memory_graph_store(retriever, config, artifact)
+        executor = retriever.instance_variable_get(:@executor)
+        gs = executor&.instance_variable_get(:@graph_store)
+        return 0 unless gs.is_a?(Woods::Storage::GraphStore::Memory)
+
+        fresh = hydrated_graph_store(config, artifact)
+        return 0 unless fresh
+
+        gs.instance_variable_set(:@graph, fresh.instance_variable_get(:@graph))
+        1
+      end
+      private_class_method :refill_in_memory_graph_store
 
       # Check whether Ollama is reachable at the configured base URL.
       #
@@ -175,6 +248,7 @@ module Woods
       def self.build_retriever_from_config(config, resolved, artifact)
         vector_store = hydrated_vector_store(config, resolved, artifact)
         metadata_store = hydrated_metadata_store(config, resolved, artifact)
+        graph_store = hydrated_graph_store(config, artifact)
 
         # Cross-populate the vector store's per-entry metadata cache from
         # the metadata store. The WVF1 binary format stores only id + float
@@ -186,10 +260,45 @@ module Woods
         populate_vector_metadata(vector_store, metadata_store) if vector_store && metadata_store
 
         Woods::Builder.new(config).build_retriever(
-          vector_store: vector_store, metadata_store: metadata_store
+          vector_store: vector_store, metadata_store: metadata_store,
+          graph_store: graph_store
         )
       end
       private_class_method :build_retriever_from_config
+
+      # Hydrate an in-memory graph store from +dependency_graph.json+ on disk.
+      #
+      # The Indexer doesn't populate the graph store — it accepts the kwarg,
+      # dumps it empty at end of run, and moves on. But +dependency_graph.json+
+      # is already written at extraction time with the full graph. Loading it
+      # here via {DependencyGraph.from_h} turns the retriever's +:hybrid+
+      # strategy from a silent no-op (empty graph → no graph expansion) into
+      # a working graph-expansion source.
+      #
+      # Durable backends other than +:in_memory+ aren't supported here (the
+      # gem only ships +GraphStore::Memory+). Returns nil when the dependency
+      # graph file is absent or unreadable so Builder falls back to a fresh
+      # empty store — the pre-fix behaviour.
+      #
+      # @param config [Woods::Configuration]
+      # @param artifact [Woods::IndexArtifact, nil]
+      # @return [Woods::Storage::GraphStore::Memory, nil]
+      def self.hydrated_graph_store(config, artifact)
+        return nil unless artifact
+        return nil unless config.graph_store == :in_memory
+
+        graph_json = artifact.output_dir.join('dependency_graph.json')
+        return nil unless graph_json.exist?
+
+        require_relative '../dependency_graph'
+        require_relative '../storage/graph_store'
+        graph = Woods::DependencyGraph.from_h(JSON.parse(graph_json.read))
+        Woods::Storage::GraphStore::Memory.new(graph)
+      rescue StandardError => e
+        warn "[woods-mcp] graph hydration failed (#{e.class}: #{e.message}); starting with empty store"
+        nil
+      end
+      private_class_method :hydrated_graph_store
 
       # Back-fill the vector store's per-entry metadata hashes from the
       # metadata store. Only makes sense when both are in-memory — durable

--- a/lib/woods/mcp/bootstrapper.rb
+++ b/lib/woods/mcp/bootstrapper.rb
@@ -168,6 +168,13 @@ module Woods
         metadata_count = refill_in_memory_metadata_store(retriever, config, resolved, artifact)
         graph_count = refill_in_memory_graph_store(retriever, config, artifact)
 
+        # Context-cache entries from the previous embed run no longer agree
+        # with the refreshed stores. Drop them so the next codebase_retrieve
+        # call goes through the full pipeline with the new data. Embedding
+        # caches (query → vector) survive — that mapping is deterministic
+        # for a given provider+model.
+        retriever.invalidate_context_cache! if retriever.respond_to?(:invalidate_context_cache!)
+
         { vectors: vectors_count, metadata: metadata_count, graph: graph_count }
       end
 
@@ -203,16 +210,17 @@ module Woods
 
       # GraphStore::Memory doesn't expose a +clear!+/+bulk_load+ pair today
       # — a fresh run hands it an entirely new DependencyGraph from disk.
-      # Swap the inner graph in place so SearchExecutor / Ranker / MCP tools
-      # keep their references to the same wrapper and see the new graph.
+      # Swap the inner graph via +replace_graph+ so SearchExecutor / Ranker /
+      # MCP tools keep their references to the same wrapper and see the new
+      # graph (no closure references break).
       def self.refill_in_memory_graph_store(retriever, config, artifact)
         gs = retriever.respond_to?(:graph_store) ? retriever.graph_store : nil
-        return 0 unless gs.is_a?(Woods::Storage::GraphStore::Memory)
+        return 0 unless gs.respond_to?(:replace_graph)
 
         fresh = hydrated_graph_store(config, artifact)
-        return 0 unless fresh
+        return 0 if fresh.nil?
 
-        gs.instance_variable_set(:@graph, fresh.instance_variable_get(:@graph))
+        gs.replace_graph(fresh.graph)
         1
       end
       private_class_method :refill_in_memory_graph_store

--- a/lib/woods/mcp/bootstrapper.rb
+++ b/lib/woods/mcp/bootstrapper.rb
@@ -171,9 +171,12 @@ module Woods
         { vectors: vectors_count, metadata: metadata_count, graph: graph_count }
       end
 
+      # Retriever (and CachedRetriever) expose public +vector_store+ /
+      # +metadata_store+ / +graph_store+ readers so this helper never pokes
+      # private state. Durable backends don't implement +clear!+/+bulk_load+
+      # — they return 0 silently because they're already refreshed externally.
       def self.refill_in_memory_vector_store(retriever, config, resolved, artifact)
-        vs = retriever.instance_variable_get(:@vector_store) ||
-             retriever.instance_variable_get(:@executor)&.instance_variable_get(:@vector_store)
+        vs = retriever.respond_to?(:vector_store) ? retriever.vector_store : nil
         return 0 unless vs.respond_to?(:clear!) && vs.respond_to?(:bulk_load)
 
         fresh = hydrated_vector_store(config, resolved, artifact)
@@ -186,7 +189,7 @@ module Woods
       private_class_method :refill_in_memory_vector_store
 
       def self.refill_in_memory_metadata_store(retriever, config, resolved, artifact)
-        ms = retriever.instance_variable_get(:@metadata_store)
+        ms = retriever.respond_to?(:metadata_store) ? retriever.metadata_store : nil
         return 0 unless ms.respond_to?(:clear!) && ms.respond_to?(:bulk_load)
 
         fresh = hydrated_metadata_store(config, resolved, artifact)
@@ -198,9 +201,12 @@ module Woods
       end
       private_class_method :refill_in_memory_metadata_store
 
+      # GraphStore::Memory doesn't expose a +clear!+/+bulk_load+ pair today
+      # — a fresh run hands it an entirely new DependencyGraph from disk.
+      # Swap the inner graph in place so SearchExecutor / Ranker / MCP tools
+      # keep their references to the same wrapper and see the new graph.
       def self.refill_in_memory_graph_store(retriever, config, artifact)
-        executor = retriever.instance_variable_get(:@executor)
-        gs = executor&.instance_variable_get(:@graph_store)
+        gs = retriever.respond_to?(:graph_store) ? retriever.graph_store : nil
         return 0 unless gs.is_a?(Woods::Storage::GraphStore::Memory)
 
         fresh = hydrated_graph_store(config, artifact)

--- a/lib/woods/mcp/provider_probe.rb
+++ b/lib/woods/mcp/provider_probe.rb
@@ -84,9 +84,18 @@ module Woods
 
       # Probe the OpenAI API endpoint.
       #
-      # A 401 Unauthorized response is treated as +ProviderUnreachable+ with
-      # +reason: "unauthorized"+ — the key is invalid and the provider cannot
-      # serve requests.
+      # The probe sends an unauthenticated +GET /v1/models+ so it deliberately
+      # expects a 401 from a healthy OpenAI. Anything that is not a plain 401
+      # or 2xx/3xx means the provider cannot be used from this host:
+      #
+      # - +401 Unauthorized+ → +reason: "unauthorized"+. The expected response
+      #   for an unauthed probe; starts :degraded so the first real query
+      #   carries the API key and surfaces credential errors precisely.
+      # - +403 Forbidden+ → +reason: "forbidden"+. Seen when the edge
+      #   intercepts the request before OpenAI's auth layer (geoblock,
+      #   corporate proxy). Subsequent embed calls will 403 too, so treating
+      #   this as reachable would give operators a false-green status.
+      # - +5xx+ → +reason: "http_500"+.
       #
       # @param provider [Woods::Embedding::Provider::OpenAI]
       # @raise [Woods::MCP::ProviderUnreachable]
@@ -97,22 +106,28 @@ module Woods
                   open_timeout: OPENAI_OPEN_TIMEOUT,
                   read_timeout: OPENAI_READ_TIMEOUT,
                   use_ssl: true) do |response|
-          if response.is_a?(Net::HTTPUnauthorized)
-            raise Woods::MCP::ProviderUnreachable.new(
-              url: base_url,
-              reason: 'unauthorized'
-            )
-          end
+          reason = openai_unreachable_reason(response)
+          next unless reason
 
-          if response.is_a?(Net::HTTPServerError)
-            raise Woods::MCP::ProviderUnreachable.new(
-              url: base_url,
-              reason: 'http_500'
-            )
-          end
+          raise Woods::MCP::ProviderUnreachable.new(url: base_url, reason: reason)
         end
       end
       private_class_method :probe_openai!
+
+      # Map an HTTP response from +GET /v1/models+ to a ProviderUnreachable
+      # reason string, or nil when the response signals a healthy provider.
+      #
+      # Uses +is_a?+ (not +case/when+) so RSpec stubs via
+      # +allow(response).to receive(:is_a?).with(...)+ compose cleanly —
+      # +case/when+ goes through +Module#===+ which some mocks don't round-trip.
+      def self.openai_unreachable_reason(response)
+        return 'unauthorized' if response.is_a?(Net::HTTPUnauthorized)
+        return 'forbidden' if response.is_a?(Net::HTTPForbidden)
+        return 'http_500' if response.is_a?(Net::HTTPServerError)
+
+        nil
+      end
+      private_class_method :openai_unreachable_reason
 
       # Execute +GET path+ against +base_url+ and yield the response to the
       # caller's block for provider-specific checks.

--- a/lib/woods/mcp/server.rb
+++ b/lib/woods/mcp/server.rb
@@ -598,14 +598,15 @@ module Woods
                          'Use `search` for exact name/pattern matching; use this for conceptual questions. ' \
                          'Requires an embedding provider — disabled if OPENAI_API_KEY is unset and Ollama is unreachable. ' \
                          'By default excludes test_mappings (~33% of a typical index) so spec filenames do not ' \
-                         'dominate semantic rank; pass types: ["test_mapping"] to opt back in.',
+                         'dominate semantic rank; pass types: ["test_mapping"] to opt back in. ' \
+                         'Parameter: use `budget` for the token budget (not `limit` — that means result count ' \
+                         'on sibling tools, and mapping it here would silently produce a near-empty response).',
             input_schema: {
               properties: {
                 query: { type: 'string',
                          description: 'Natural language question (e.g. "How does user authentication work?")' },
-                budget: { type: 'integer', description: 'Token budget for context assembly (default: 8000). ' \
-                                                        '`limit` is accepted as an alias for discoverability.' },
-                limit: { type: 'integer', description: 'Alias for `budget`. Either one works.' },
+                budget: { type: 'integer',
+                          description: 'Token budget for context assembly (default: 8000).' },
                 types: {
                   type: 'array', items: { type: 'string' },
                   description: 'Restrict results to these unit types (model, controller, service, job, mailer, ' \
@@ -619,7 +620,26 @@ module Woods
               required: ['query']
             }
           ) do |query:, server_context:, budget: nil, limit: nil, types: nil, exclude_types: nil|
-            budget = coerce_int.call(budget) || coerce_int.call(limit)
+            # `limit` isn't declared in the schema but clients still send it
+            # because sibling tools (search, recent_changes, pagerank) use
+            # `limit` as a result count. Mapping it to `budget` here would
+            # silently produce a near-empty response (limit: 10 → 10-token
+            # budget). Surface a helpful typed error instead.
+            unless limit.nil?
+              next respond_err.call(
+                'codebase_retrieve uses `budget` (token budget, default 8000), not `limit`. ' \
+                '`limit` is the result-count parameter on sibling tools (search, recent_changes, pagerank). ' \
+                "Pass `budget: #{coerce_int.call(limit)}` if you meant a #{coerce_int.call(limit)}-token context, " \
+                'or drop the kwarg entirely for the default 8000.',
+                code: :unsupported_argument,
+                tool: 'codebase_retrieve',
+                argument: 'limit',
+                hint: 'Use `budget:` for tokens. Retrieval does not cap by result count — the token budget ' \
+                      'governs how many ranked units fit in the returned context.'
+              )
+            end
+
+            budget = coerce_int.call(budget)
             types = coerce.call(types)
             exclude_types = coerce.call(exclude_types)
             if retriever
@@ -1304,15 +1324,22 @@ module Woods
         # Resolve the current HEAD SHA for the git repo containing +index_dir+.
         # Returns nil when git is unavailable or +index_dir+ is not in a repo —
         # callers treat nil as "can't compare" rather than "mismatch".
+        #
+        # Uses +capture2e+ so git's "fatal: not a git repository" stderr banner
+        # does not leak through the MCP stdio transport. MCP clients that parse
+        # stderr for protocol framing can't tolerate stray lines.
         def resolve_head_sha(index_dir)
           return nil unless index_dir
 
           dir = index_dir.to_s
           return nil unless File.directory?(dir)
 
-          output, status = Open3.capture2('git', '-C', dir, 'rev-parse', 'HEAD')
+          output, status = Open3.capture2e('git', '-C', dir, 'rev-parse', 'HEAD')
           status.success? ? output.strip : nil
-        rescue StandardError
+        rescue Errno::ENOENT, Errno::EACCES
+          # git not installed or not executable on this host — equivalent to
+          # "can't compare". Any other exception is a genuine bug and should
+          # propagate.
           nil
         end
 

--- a/lib/woods/mcp/server.rb
+++ b/lib/woods/mcp/server.rb
@@ -2,6 +2,7 @@
 
 require 'logger'
 require 'mcp'
+require 'open3'
 require 'time'
 require 'set'
 require_relative '../tasks'
@@ -39,7 +40,7 @@ module Woods
         #   tests or when startup time matters more than first-query latency.
         # @return [MCP::Server] Configured server ready for transport
         def build(index_dir:, retriever: nil, operator: nil, feedback_store: nil, snapshot_store: nil,
-                  bootstrap_state: nil, response_format: nil, warmup: true)
+                  bootstrap_state: nil, response_format: nil, warmup: true, retriever_reloader: nil)
           reader = IndexReader.new(index_dir)
           reader.warmup! if warmup
           config = Woods.configuration
@@ -101,14 +102,20 @@ module Woods
           define_pagerank_tool(server, reader, respond, renderer)
           define_framework_tool(server, reader, respond, renderer)
           define_recent_changes_tool(server, reader, respond, renderer)
-          define_reload_tool(server, reader, respond)
+          define_reload_tool(server, reader, respond, retriever_reloader)
           define_retrieve_tool(server, retriever, respond, respond_err)
           define_trace_flow_tool(server, reader, index_dir, respond, renderer)
-          define_session_trace_tool(server, reader, respond, respond_err)
-          define_operator_tools(server, operator, respond, respond_err, op_missing)
-          define_feedback_tools(server, feedback_store, respond, respond_err, fb_missing)
-          define_snapshot_tools(server, snapshot_store, respond, respond_err, snap_missing)
-          define_notion_sync_tool(server, reader, index_dir, respond, respond_err)
+          # Conditionally register collaborator-dependent tools. Historically
+          # all 15 stubs were registered unconditionally and returned
+          # isError: true when the wiring was missing — that added token
+          # noise to every LLM turn's tool catalog and invited the model to
+          # try tools guaranteed to fail. Only register when the collaborator
+          # is wired, so tools/list reflects what the server can actually do.
+          define_session_trace_tool(server, reader, respond, respond_err) if session_tracer_wired?
+          define_operator_tools(server, operator, respond, respond_err, op_missing) if operator
+          define_feedback_tools(server, feedback_store, respond, respond_err, fb_missing) if feedback_store
+          define_snapshot_tools(server, snapshot_store, respond, respond_err, snap_missing) if snapshot_store
+          define_notion_sync_tool(server, reader, index_dir, respond, respond_err) if notion_wired?
           define_woods_status_tool(server, reader, retriever, index_dir, bootstrap_state, respond)
           register_resource_handler(server, reader)
 
@@ -116,6 +123,28 @@ module Woods
         end
 
         private
+
+        # Session tracer requires a configured session_store on Woods.configuration.
+        # The tool reads the store inside its handler; skipping registration when
+        # the store is absent keeps tools/list honest.
+        def session_tracer_wired?
+          config = Woods.configuration
+          return false unless config
+
+          config.respond_to?(:session_store) && !config.session_store.nil?
+        end
+
+        # Notion export needs both an API token and at least one database ID.
+        # NOTION_API_TOKEN env var overrides the config token (see
+        # docs/NOTION_EXPORT.md).
+        def notion_wired?
+          config = Woods.configuration
+          return false unless config
+
+          token = ENV['NOTION_API_TOKEN'] || (config.respond_to?(:notion_api_token) ? config.notion_api_token : nil)
+          ids = config.respond_to?(:notion_database_ids) ? config.notion_database_ids : nil
+          token && !token.empty? && ids && !ids.empty?
+        end
 
         def text_response(text)
           ::MCP::Tool::Response.new([{ type: 'text', text: text }])
@@ -204,20 +233,34 @@ module Woods
             name: 'lookup',
             description: 'Look up a code unit by its exact identifier. Returns full source code, metadata, ' \
                          'dependencies, and dependents. Use include_source: false to omit source_code. ' \
-                         'Use sections to select specific keys (type, identifier, file_path, namespace are always included).',
+                         'Use sections to select specific keys (type, identifier, file_path, namespace are always included). ' \
+                         '`name` is accepted as an alias for `identifier` for discoverability.',
             input_schema: {
               properties: {
                 identifier: { type: 'string',
                               description: 'Exact unit identifier (e.g. "Post", "PostsController", "Api::V1::HealthController")' },
+                name: { type: 'string', description: 'Alias for `identifier`. Either one works.' },
                 include_source: { type: 'boolean', description: 'Include source_code in response (default: true)' },
                 sections: {
                   type: 'array', items: { type: 'string' },
                   description: 'Select specific keys to return (e.g. ["metadata", "dependencies"]). Always includes type, identifier, file_path, namespace.'
                 }
-              },
-              required: ['identifier']
+              }
+              # NOTE: 'identifier' is not listed as required — `name` is an
+              # accepted alias. The handler validates that one of the two
+              # was provided.
             }
-          ) do |identifier:, server_context:, include_source: nil, sections: nil|
+          ) do |server_context:, identifier: nil, name: nil, include_source: nil, sections: nil|
+            identifier ||= name
+            if identifier.nil? || identifier.empty?
+              next respond_err.call(
+                'lookup requires `identifier` (or its alias `name`).',
+                code: :unsupported_argument,
+                tool: 'lookup',
+                argument: 'identifier',
+                hint: 'Pass identifier: "PostsController" (or name: "PostsController").'
+              )
+            end
             sections = coerce.call(sections)
             unit = reader.find_unit(identifier)
             if unit
@@ -515,45 +558,77 @@ module Woods
           end
         end
 
-        def define_reload_tool(server, reader, respond)
+        def define_reload_tool(server, reader, respond, retriever_reloader)
           server.define_tool(
             name: 'reload',
-            description: 'Reload extraction data from disk. Use after re-running extraction to pick up changes ' \
-                         'without restarting the server.',
+            description: 'Reload extraction data from disk. Use after re-running extraction or woods:embed to pick ' \
+                         'up changes without restarting the server. Refreshes the JSON index (manifest, dependency ' \
+                         'graph, unit cache) AND re-hydrates the retriever\'s in-memory vector/metadata/graph ' \
+                         'stores from the latest dumps. Durable backends (pgvector, Qdrant) are auto-refreshed ' \
+                         'externally — their counts in the response reflect the read-through state.',
             input_schema: { type: 'object', properties: {} }
           ) do |server_context:|
             reader.reload!
             manifest = reader.manifest
-            respond.call(JSON.pretty_generate({
-                                                reloaded: true,
-                                                extracted_at: manifest['extracted_at'],
-                                                total_units: manifest['total_units'],
-                                                counts: manifest['counts']
-                                              }))
+            payload = {
+              reloaded: true,
+              extracted_at: manifest['extracted_at'],
+              total_units: manifest['total_units'],
+              counts: manifest['counts']
+            }
+            if retriever_reloader
+              begin
+                payload[:retriever] = retriever_reloader.call
+              rescue StandardError => e
+                payload[:retriever] = { error: "#{e.class}: #{e.message}" }
+              end
+            end
+            respond.call(JSON.pretty_generate(payload))
           end
         end
 
         def define_retrieve_tool(server, retriever, respond, respond_err)
           coerce_int = method(:coerce_integer)
+          coerce = method(:coerce_array)
           server.define_tool(
             name: 'codebase_retrieve',
             description: 'Semantic search: retrieve relevant code units for a natural-language question. ' \
                          'Example: codebase_retrieve("how does billing work?") returns ranked source context. ' \
                          'Returns a token-budgeted context string ready to paste into a prompt. ' \
                          'Use `search` for exact name/pattern matching; use this for conceptual questions. ' \
-                         'Requires an embedding provider — disabled if OPENAI_API_KEY is unset and Ollama is unreachable.',
+                         'Requires an embedding provider — disabled if OPENAI_API_KEY is unset and Ollama is unreachable. ' \
+                         'By default excludes test_mappings (~33% of a typical index) so spec filenames do not ' \
+                         'dominate semantic rank; pass types: ["test_mapping"] to opt back in.',
             input_schema: {
               properties: {
                 query: { type: 'string',
                          description: 'Natural language question (e.g. "How does user authentication work?")' },
-                budget: { type: 'integer', description: 'Token budget for context assembly (default: 8000)' }
+                budget: { type: 'integer', description: 'Token budget for context assembly (default: 8000). ' \
+                                                        '`limit` is accepted as an alias for discoverability.' },
+                limit: { type: 'integer', description: 'Alias for `budget`. Either one works.' },
+                types: {
+                  type: 'array', items: { type: 'string' },
+                  description: 'Restrict results to these unit types (model, controller, service, job, mailer, ' \
+                               'rails_source, test_mapping, etc.). Overrides the default test_mapping exclusion.'
+                },
+                exclude_types: {
+                  type: 'array', items: { type: 'string' },
+                  description: 'Additional types to exclude on top of the default test_mapping exclusion.'
+                }
               },
               required: ['query']
             }
-          ) do |query:, server_context:, budget: nil|
-            budget = coerce_int.call(budget)
+          ) do |query:, server_context:, budget: nil, limit: nil, types: nil, exclude_types: nil|
+            budget = coerce_int.call(budget) || coerce_int.call(limit)
+            types = coerce.call(types)
+            exclude_types = coerce.call(exclude_types)
             if retriever
-              result = retriever.retrieve(query, budget: budget || 8000)
+              result = retriever.retrieve(
+                query,
+                budget: budget || 8000,
+                types: types,
+                exclude_types: exclude_types
+              )
               respond.call(result.context)
             else
               respond_err.call(
@@ -1149,11 +1224,23 @@ module Woods
         # Build the woods_status payload. Exposed at module level so specs (and future
         # console/unified-server entry points) can assemble the same shape without
         # reaching through the MCP::Server internals.
+        #
+        # +features.embedding_model+ / +features.embedding_provider+ /
+        # +features.vector_store+ prefer the ResolvedConfig captured at embed time
+        # (+bootstrap_state.resolved_config+, which is read back from +woods.json+)
+        # over +Woods.configuration+, whose defaults can contradict the actual
+        # provider in use. Without this, operators debugging "wrong provider" see
+        # status claiming +embedding_model: "text-embedding-3-small"+ next to
+        # +embedding_provider: "ollama"+ and reasonably distrust every field.
         def build_status(reader:, retriever:, index_dir:, bootstrap_state: nil)
           manifest = safe_manifest(reader)
           extracted_at = manifest && manifest['extracted_at']
           staleness = staleness_seconds(extracted_at)
-          config = Woods.configuration
+          # Tolerate a nil Woods.configuration — specs that reset it between
+          # runs can leave a transient nil window, and build_status should
+          # still produce a readable payload during that window.
+          config = Woods.configuration || Woods::Configuration.new
+          resolved = bootstrap_state&.resolved_config
 
           {
             ready: manifest && !manifest['counts'].to_h.empty?,
@@ -1162,36 +1249,117 @@ module Woods
               version: Woods::VERSION,
               index_dir: index_dir.to_s
             },
-            index: {
-              extracted_at: extracted_at,
-              staleness_seconds: staleness,
-              rails_version: manifest && manifest['rails_version'],
-              ruby_version: manifest && manifest['ruby_version'],
-              total_units: manifest && manifest['total_units'],
-              counts: (manifest && manifest['counts']) || {},
-              git_sha: manifest && manifest['git_sha'],
-              git_branch: manifest && manifest['git_branch'],
-              gemfile_lock_sha: manifest && manifest['gemfile_lock_sha'],
-              schema_sha: manifest && manifest['schema_sha']
-            },
+            index: index_section(manifest, extracted_at, staleness, index_dir),
             retriever: {
               configured: !retriever.nil?,
               class: retriever&.class&.name
             },
             bootstrap: bootstrap_state&.to_h,
-            features: {
-              embedding_model: config.respond_to?(:embedding_model) ? config.embedding_model : nil,
-              embedding_provider: config.respond_to?(:embedding_provider) ? presence(config.embedding_provider) : nil,
-              vector_store: config.respond_to?(:vector_store) ? presence(config.vector_store) : nil,
-              session_tracer_enabled: config.respond_to?(:session_tracer_enabled) ? config.session_tracer_enabled : false,
-              snapshots_enabled: config.respond_to?(:enable_snapshots) ? config.enable_snapshots : false,
-              notion_configured: config.respond_to?(:notion_api_token) && !presence(config.notion_api_token).nil?,
-              console_mcp_enabled: config.respond_to?(:console_mcp_enabled) ? config.console_mcp_enabled : false
-            }
+            features: features_from(config, resolved)
           }
         end
 
         private
+
+        # Assemble the +index+ sub-hash of woods_status, including a staleness
+        # gate that compares +manifest.git_sha+ against the current HEAD. The
+        # manifest captures +git_sha+ / +gemfile_lock_sha+ / +schema_sha+ at
+        # extraction time; until this change nothing compared them against the
+        # live working tree, so an agent asking questions after 40 uncommitted
+        # changes and an MCP restart silently got pre-change answers.
+        #
+        # +git_sha_matches_head+ is a tri-state:
+        #   - true      — manifest.git_sha == current HEAD
+        #   - false     — mismatch (stale)
+        #   - nil       — couldn't resolve (not a git repo, git unavailable,
+        #                 or manifest has no git_sha)
+        #
+        # When stale, +head_git_sha+ carries the live HEAD so operators can
+        # diff directly. This is an observability signal, not a hard gate —
+        # hard-refusing responses would be much more disruptive than a loudly-
+        # visible staleness flag that agents can branch on.
+        def index_section(manifest, extracted_at, staleness, index_dir)
+          base = {
+            extracted_at: extracted_at,
+            staleness_seconds: staleness,
+            rails_version: manifest && manifest['rails_version'],
+            ruby_version: manifest && manifest['ruby_version'],
+            total_units: manifest && manifest['total_units'],
+            counts: (manifest && manifest['counts']) || {},
+            git_sha: manifest && manifest['git_sha'],
+            git_branch: manifest && manifest['git_branch'],
+            gemfile_lock_sha: manifest && manifest['gemfile_lock_sha'],
+            schema_sha: manifest && manifest['schema_sha']
+          }
+
+          manifest_sha = manifest && manifest['git_sha']
+          head_sha = manifest_sha ? resolve_head_sha(index_dir) : nil
+          return base unless head_sha
+
+          base[:head_git_sha] = head_sha
+          base[:git_sha_matches_head] = (manifest_sha == head_sha)
+          base
+        end
+
+        # Resolve the current HEAD SHA for the git repo containing +index_dir+.
+        # Returns nil when git is unavailable or +index_dir+ is not in a repo —
+        # callers treat nil as "can't compare" rather than "mismatch".
+        def resolve_head_sha(index_dir)
+          return nil unless index_dir
+
+          dir = index_dir.to_s
+          return nil unless File.directory?(dir)
+
+          output, status = Open3.capture2('git', '-C', dir, 'rev-parse', 'HEAD')
+          status.success? ? output.strip : nil
+        rescue StandardError
+          nil
+        end
+
+        # Assemble the +features+ sub-hash of woods_status, preferring the
+        # ResolvedConfig captured at embed time over live {Woods::Configuration}.
+        #
+        # Fields that read from resolved+config (when present): embedding_model,
+        # embedding_provider, vector_store. Everything else is host-process
+        # state (snapshots_enabled, notion_configured, session_tracer_enabled)
+        # and comes from the running config.
+        #
+        # +console_mcp_enabled+ is intentionally omitted — the index MCP process
+        # has no visibility into the host Rails app's Woods initializer, so
+        # historic status payloads always reported +false+ regardless of the
+        # actual console MCP state. Advertising a misleading field is worse
+        # than not advertising it at all.
+        def features_from(config, resolved)
+          provider_hash = resolved&.embedding_provider || {}
+          resolved_provider = resolved_provider_symbol(provider_hash[:class])
+          resolved_model = provider_hash[:model]
+          resolved_vector = resolved&.stores&.dig(:vector_store)
+
+          {
+            embedding_model: resolved_model || (config.respond_to?(:embedding_model) ? config.embedding_model : nil),
+            embedding_provider: presence(resolved_provider ||
+              (config.respond_to?(:embedding_provider) ? config.embedding_provider : nil)),
+            vector_store: presence(resolved_vector ||
+              (config.respond_to?(:vector_store) ? config.vector_store : nil)),
+            session_tracer_enabled: config.respond_to?(:session_tracer_enabled) ? config.session_tracer_enabled : false,
+            snapshots_enabled: config.respond_to?(:enable_snapshots) ? config.enable_snapshots : false,
+            notion_configured: config.respond_to?(:notion_api_token) && !presence(config.notion_api_token).nil?
+          }
+        end
+
+        # Convert a fully-qualified provider class name (as serialised in
+        # woods.json — e.g. +"Woods::Embedding::Provider::Ollama"+) into the
+        # short symbol form used by +Woods.configuration.embedding_provider+
+        # (+:ollama+, +:openai+). Returns nil when +class_name+ is unknown or
+        # absent so callers fall back to the live config value.
+        def resolved_provider_symbol(class_name)
+          return nil if class_name.nil? || class_name.empty?
+
+          case class_name
+          when /Ollama\z/ then :ollama
+          when /OpenAI\z/ then :openai
+          end
+        end
 
         # Return a Hash of manifest content, or nil if unreadable.
         def safe_manifest(reader)

--- a/lib/woods/retrieval/context_assembler.rb
+++ b/lib/woods/retrieval/context_assembler.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'search_executor'
+
 module Woods
   module Retrieval
     # Transforms ranked search candidates into a token-budgeted context string
@@ -54,6 +56,13 @@ module Woods
         sources = []
         tokens_used = 0
 
+        # Collapse +User#chunk_0+, +User#chunk_1+, … back to their base unit
+        # BEFORE metadata lookup and section assembly. Chunk IDs are an
+        # embedding-side concern — the metadata store is keyed by the base
+        # identifier, and callers don't want the same unit formatted twice
+        # just because multiple chunks matched the query.
+        candidates = collapse_chunk_candidates(candidates)
+
         # Pre-fetch all candidate metadata in one batch query
         @unit_cache = @metadata_store.find_batch(candidates.map(&:identifier))
 
@@ -77,6 +86,46 @@ module Woods
       end
 
       private
+
+      # Suffix the Indexer appends when a single unit is split into multiple
+      # embedding vectors (rails_source and other large units). Separator
+      # is +#+ so it can never collide with a Ruby constant (+::+) or a
+      # method ref (+#instance_method+) in an identifier.
+      CHUNK_SUFFIX_PATTERN = /#chunk_\d+\z/
+      private_constant :CHUNK_SUFFIX_PATTERN
+
+      # Strip the +#chunk_N+ suffix from an identifier, if present.
+      # +User#chunk_3+ → +User+; +User+ stays +User+.
+      def base_identifier(identifier)
+        identifier.sub(CHUNK_SUFFIX_PATTERN, '')
+      end
+
+      # Rewrite every candidate to point at its base identifier and keep only
+      # the highest-scoring candidate per base unit. Preserves original score
+      # ordering on the output so downstream +sort_by(-score)+ gets the same
+      # input it would on an unchunked corpus.
+      def collapse_chunk_candidates(candidates)
+        best = {}
+        candidates.each do |c|
+          base = base_identifier(c.identifier)
+          rewritten = c.identifier == base ? c : rewrite_identifier(c, base)
+          best[base] = rewritten if best[base].nil? || rewritten.score > best[base].score
+        end
+        best.values
+      end
+
+      # Return a clone of +candidate+ with its identifier replaced. Kept as
+      # its own method so the Candidate struct shape is referenced in exactly
+      # one place — if SearchExecutor::Candidate grows fields, this is the
+      # only spot to update.
+      def rewrite_identifier(candidate, new_identifier)
+        SearchExecutor::Candidate.new(
+          identifier: new_identifier,
+          score: candidate.score,
+          source: candidate.source,
+          metadata: candidate.metadata
+        )
+      end
 
       # Add structural context section if provided.
       #

--- a/lib/woods/retriever.rb
+++ b/lib/woods/retriever.rb
@@ -43,13 +43,25 @@ module Woods
     # Unit types queried for the structural context overview.
     STRUCTURAL_TYPES = %w[model controller service job mailer component graphql].freeze
 
+    # Direct handles to the injected stores. The sub-components
+    # ({Retrieval::SearchExecutor}, {Retrieval::Ranker},
+    # {Retrieval::ContextAssembler}) hold their own references too, but those
+    # are implementation details — callers that want to mutate store contents
+    # (e.g. the MCP +reload+ tool) read through these accessors. All three
+    # refer to the same Ruby objects the sub-components were initialised with,
+    # so in-place +#clear!+ + +#bulk_load+ propagates through the entire
+    # pipeline without re-instantiating sub-components.
+    attr_reader :vector_store, :metadata_store, :graph_store
+
     # @param vector_store [Storage::VectorStore::Interface] Vector store adapter
     # @param metadata_store [Storage::MetadataStore::Interface] Metadata store adapter
     # @param graph_store [Storage::GraphStore::Interface] Graph store adapter
     # @param embedding_provider [Embedding::Provider::Interface] Embedding provider
     # @param formatter [#call, nil] Optional callable to post-process the context string
     def initialize(vector_store:, metadata_store:, graph_store:, embedding_provider:, formatter: nil)
+      @vector_store = vector_store
       @metadata_store = metadata_store
+      @graph_store = graph_store
       @formatter = formatter
 
       @classifier = Retrieval::QueryClassifier.new

--- a/lib/woods/retriever.rb
+++ b/lib/woods/retriever.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# Ruby 3.2 autoloads Set, but the gem supports >= 3.0 — make the require
+# explicit so +filter_by_type+ works on the whole supported range.
+require 'set'
+
 require_relative 'retrieval/query_classifier'
 require_relative 'retrieval/search_executor'
 require_relative 'retrieval/ranker'

--- a/lib/woods/retriever.rb
+++ b/lib/woods/retriever.rb
@@ -63,20 +63,32 @@ module Woods
       @assembler = Retrieval::ContextAssembler.new(metadata_store: metadata_store)
     end
 
+    # Unit types excluded from retrieval by default. +test_mapping+ units
+    # make up ~33% of a typical index and lexically dominate semantic rank
+    # for production queries ("stripe webhook" often surfaces
+    # stripe_webhook_spec.rb above the actual controller). Callers can
+    # override by passing +types:+ (include-only) or an explicit +exclude_types:+.
+    DEFAULT_EXCLUDE_TYPES = %w[test_mapping].freeze
+
     # Execute the full retrieval pipeline for a natural language query.
     #
-    # Pipeline: classify -> execute -> rank -> assemble -> format
+    # Pipeline: classify -> execute -> rank -> filter -> assemble -> format
     #
     # @param query [String] Natural language query
     # @param budget [Integer] Token budget for context assembly
+    # @param types [Array<String, Symbol>, nil] If set, restrict results to these
+    #   unit types (overrides DEFAULT_EXCLUDE_TYPES).
+    # @param exclude_types [Array<String, Symbol>, nil] Additional types to
+    #   exclude. Applied on top of DEFAULT_EXCLUDE_TYPES unless +types:+ is set.
     # @return [RetrievalResult] Complete retrieval result
-    def retrieve(query, budget: 8000)
+    def retrieve(query, budget: 8000, types: nil, exclude_types: nil)
       start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
       classification = @classifier.classify(query)
       execution_result = @executor.execute(query: query, classification: classification)
       ranked = @ranker.rank(execution_result.candidates, classification: classification)
-      assembled = assemble_context(ranked, classification, budget)
+      filtered = filter_by_type(ranked, types: types, exclude_types: exclude_types)
+      assembled = assemble_context(filtered, classification, budget)
 
       elapsed_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(1)
 
@@ -84,7 +96,7 @@ module Woods
         classification: classification,
         strategy: execution_result.strategy,
         candidate_count: execution_result.candidates.size,
-        ranked_count: ranked.size,
+        ranked_count: filtered.size,
         tokens_used: assembled.tokens_used,
         elapsed_ms: elapsed_ms
       )
@@ -93,6 +105,53 @@ module Woods
     end
 
     private
+
+    # Filter ranked candidates by type, using an include-list when +types+
+    # is set and an exclude-list otherwise (default: +DEFAULT_EXCLUDE_TYPES+,
+    # extended by any +exclude_types+ the caller adds).
+    #
+    # Candidate type comes from either the metadata store (when populated)
+    # or the candidate's inline +metadata+ hash — both are probed so the
+    # filter still works on graph-expansion candidates that carry no
+    # vector-store metadata.
+    #
+    # @param candidates [Array<Candidate>]
+    # @param types [Array<String, Symbol>, nil]
+    # @param exclude_types [Array<String, Symbol>, nil]
+    # @return [Array<Candidate>]
+    def filter_by_type(candidates, types:, exclude_types:)
+      allowed = normalize_type_list(types)
+      return candidates.select { |c| allowed.include?(candidate_type(c)) } if allowed
+
+      excluded = (normalize_type_list(exclude_types) || Set.new) | DEFAULT_EXCLUDE_TYPES.to_set
+      return candidates if excluded.empty?
+
+      candidates.reject { |c| excluded.include?(candidate_type(c)) }
+    end
+
+    def normalize_type_list(list)
+      return nil if list.nil? || list.empty?
+
+      list.to_set(&:to_s)
+    end
+
+    def candidate_type(candidate)
+      inline = type_from_hash(candidate.metadata)
+      return inline if inline
+
+      # Fall back to the metadata store lookup so graph-expansion candidates
+      # (which come in with metadata: {}) still get type-filtered.
+      type_from_hash(@metadata_store.find(candidate.identifier)) || ''
+    rescue StandardError
+      ''
+    end
+
+    def type_from_hash(hash)
+      return nil unless hash
+
+      value = hash[:type] || hash['type']
+      value&.to_s
+    end
 
     # Assemble token-budgeted context from ranked candidates.
     #

--- a/lib/woods/storage/graph_store.rb
+++ b/lib/woods/storage/graph_store.rb
@@ -78,6 +78,11 @@ module Woods
       class Memory
         include Interface
 
+        # The wrapped graph. Exposed so reload paths can peel the raw
+        # graph out of a freshly-hydrated wrapper and {#replace_graph}
+        # it into the live one.
+        attr_reader :graph
+
         # @param graph [DependencyGraph, nil] Existing graph to wrap, or nil to create a new one
         def initialize(graph = nil)
           @graph = graph || DependencyGraph.new
@@ -88,6 +93,17 @@ module Woods
         # @param unit [ExtractedUnit] The unit to register
         def register(unit)
           @graph.register(unit)
+        end
+
+        # Replace the wrapped graph in place. Used by the MCP +reload+ tool
+        # so tool closures that captured this wrapper see a fresh graph
+        # without needing to re-instantiate the wrapper (and break the
+        # closure references).
+        #
+        # @param graph [DependencyGraph]
+        # @return [void]
+        def replace_graph(graph)
+          @graph = graph
         end
 
         # @see Interface#dependencies_of

--- a/lib/woods/storage/metadata_store.rb
+++ b/lib/woods/storage/metadata_store.rb
@@ -188,6 +188,12 @@ module Woods
           entries.each { |id, meta| @data[id] = meta }
         end
 
+        # Drop every stored entry. Used by the MCP +reload+ tool to pick up a
+        # fresh embed run without restarting the process. Safe on an empty store.
+        def clear!
+          @data = {}
+        end
+
         private
 
         # Match the SQLite adapter's string-key contract regardless of how

--- a/lib/woods/storage/vector_store.rb
+++ b/lib/woods/storage/vector_store.rb
@@ -161,6 +161,20 @@ module Woods
           entries.each { |entry| store(entry[:id], entry[:vector], entry[:metadata] || {}) }
         end
 
+        # Drop every stored entry, restoring the store to its post-+new+ state.
+        #
+        # Used by the MCP +reload+ tool to pick up a fresh embed run without
+        # restarting the process. A subsequent +#bulk_load+ then repopulates
+        # from disk. Safe on an already-empty store.
+        def clear!
+          @dim = nil
+          @ids = []
+          @vectors_flat = []
+          @metadata = []
+          @id_to_index = {}
+          @tombstones = Set.new
+        end
+
         # @see Interface#each_entry
         def each_entry(&block)
           return enum_for(:each_entry) unless block

--- a/spec/cache/cache_store_spec.rb
+++ b/spec/cache/cache_store_spec.rb
@@ -331,7 +331,7 @@ RSpec.describe Woods::Cache::CachedRetriever do
   describe '#retrieve' do
     it 'delegates to the real retriever on cache miss' do
       allow(retriever).to receive(:retrieve)
-        .with('How does User work?', budget: 8000)
+        .with('How does User work?', budget: 8000, types: nil, exclude_types: nil)
         .and_return(retrieval_result)
 
       result = cached_retriever.retrieve('How does User work?')
@@ -342,7 +342,7 @@ RSpec.describe Woods::Cache::CachedRetriever do
 
     it 'returns cached result on cache hit' do
       allow(retriever).to receive(:retrieve)
-        .with('How does User work?', budget: 8000)
+        .with('How does User work?', budget: 8000, types: nil, exclude_types: nil)
         .and_return(retrieval_result)
 
       cached_retriever.retrieve('How does User work?')
@@ -364,8 +364,10 @@ RSpec.describe Woods::Cache::CachedRetriever do
         strategy: :keyword, tokens_used: 20, budget: 8000, trace: nil
       )
 
-      allow(retriever).to receive(:retrieve).with('query A', budget: 8000).and_return(result_a)
-      allow(retriever).to receive(:retrieve).with('query B', budget: 8000).and_return(result_b)
+      allow(retriever).to receive(:retrieve)
+        .with('query A', budget: 8000, types: nil, exclude_types: nil).and_return(result_a)
+      allow(retriever).to receive(:retrieve)
+        .with('query B', budget: 8000, types: nil, exclude_types: nil).and_return(result_b)
 
       cached_retriever.retrieve('query A')
       cached_retriever.retrieve('query B')
@@ -383,14 +385,54 @@ RSpec.describe Woods::Cache::CachedRetriever do
         strategy: :vector, tokens_used: 50, budget: 16_000, trace: nil
       )
 
-      allow(retriever).to receive(:retrieve).with('query', budget: 2000).and_return(result_small)
-      allow(retriever).to receive(:retrieve).with('query', budget: 16_000).and_return(result_large)
+      allow(retriever).to receive(:retrieve)
+        .with('query', budget: 2000, types: nil, exclude_types: nil).and_return(result_small)
+      allow(retriever).to receive(:retrieve)
+        .with('query', budget: 16_000, types: nil, exclude_types: nil).and_return(result_large)
 
       r1 = cached_retriever.retrieve('query', budget: 2000)
       r2 = cached_retriever.retrieve('query', budget: 16_000)
 
       expect(r1.context).to eq('small')
       expect(r2.context).to eq('large')
+    end
+
+    # Regression — the type filter kwargs must participate in the cache key,
+    # otherwise a narrow `types: ["service"]` lookup returns a previously
+    # cached broad result.
+    it 'treats different types: filters as different cache keys' do
+      result_svc = Woods::Retriever::RetrievalResult.new(
+        context: 'svc', sources: [], classification: nil,
+        strategy: :vector, tokens_used: 5, budget: 8000, trace: nil
+      )
+      result_all = Woods::Retriever::RetrievalResult.new(
+        context: 'all', sources: [], classification: nil,
+        strategy: :vector, tokens_used: 50, budget: 8000, trace: nil
+      )
+
+      allow(retriever).to receive(:retrieve)
+        .with('q', budget: 8000, types: %w[service], exclude_types: nil).and_return(result_svc)
+      allow(retriever).to receive(:retrieve)
+        .with('q', budget: 8000, types: nil, exclude_types: nil).and_return(result_all)
+
+      svc = cached_retriever.retrieve('q', types: %w[service])
+      all = cached_retriever.retrieve('q')
+
+      expect(svc.context).to eq('svc')
+      expect(all.context).to eq('all')
+    end
+
+    it 'exposes wrapped stores for MCP reload' do
+      vector_store = double('VectorStore')
+      metadata_store = double('MetadataStore')
+      graph_store = double('GraphStore')
+      allow(retriever).to receive(:vector_store).and_return(vector_store)
+      allow(retriever).to receive(:metadata_store).and_return(metadata_store)
+      allow(retriever).to receive(:graph_store).and_return(graph_store)
+
+      expect(cached_retriever.vector_store).to be(vector_store)
+      expect(cached_retriever.metadata_store).to be(metadata_store)
+      expect(cached_retriever.graph_store).to be(graph_store)
     end
   end
 end

--- a/spec/cache/cache_store_spec.rb
+++ b/spec/cache/cache_store_spec.rb
@@ -435,6 +435,27 @@ RSpec.describe Woods::Cache::CachedRetriever do
       expect(cached_retriever.graph_store).to be(graph_store)
     end
   end
+
+  # Regression — if reload refreshes the retriever's stores but leaves the
+  # context cache alone, codebase_retrieve returns cached results from the
+  # previous embed run until their TTL expires. Drop the :context namespace
+  # entries on reload so the next retrieve goes through the fresh pipeline.
+  describe '#invalidate_context_cache!' do
+    it 'clears only the :context cache namespace' do
+      allow(cache_store).to receive(:clear)
+
+      cached_retriever.invalidate_context_cache!
+
+      expect(cache_store).to have_received(:clear).with(namespace: :context)
+    end
+
+    it 'rescues and warns instead of propagating cache backend errors' do
+      allow(cache_store).to receive(:clear).and_raise(StandardError, 'redis down')
+
+      expect { cached_retriever.invalidate_context_cache! }
+        .to output(/context-cache invalidation failed/).to_stderr
+    end
+  end
 end
 
 # ── RedisCacheStore ────────────────────────────────────────────────────

--- a/spec/embedding/indexer_spec.rb
+++ b/spec/embedding/indexer_spec.rb
@@ -237,7 +237,11 @@ RSpec.describe Woods::Embedding::Indexer do
       expect(record['source_code']).to include('class User')
     end
 
-    it 'keys chunked units by the base identifier (not the #chunk_N id)' do
+    it 'keys chunked units by the base identifier (the ContextAssembler collapses #chunk_N ids)' do
+      # The Indexer stores under the base identifier; the vector store still
+      # stores per-chunk entries (User#chunk_0, User#chunk_1). Retrieval
+      # normalises chunk ids back to the base before metadata lookup — see
+      # Woods::Retrieval::ContextAssembler#collapse_chunk_candidates.
       chunked = unit_data.merge(
         'chunks' => [
           { 'chunk_index' => 0, 'content' => 'chunk one' },

--- a/spec/embedding/indexer_spec.rb
+++ b/spec/embedding/indexer_spec.rb
@@ -197,6 +197,92 @@ RSpec.describe Woods::Embedding::Indexer do
     end
   end
 
+  # Regression — the Indexer accepted a +metadata_store:+ kwarg and persisted
+  # it at end-of-run, but never wrote to it during embedding. The downstream
+  # effect was that every vector-search hit in +codebase_retrieve+ missed on
+  # the empty metadata store and ContextAssembler dropped every candidate to
+  # nil, emitting "" with no error. See commit-message body for full context.
+  describe 'metadata_store population' do
+    let(:metadata_store) { Woods::Storage::MetadataStore::InMemory.new }
+
+    let(:indexer_with_metadata) do
+      described_class.new(
+        provider: provider,
+        text_preparer: text_preparer,
+        vector_store: vector_store,
+        metadata_store: metadata_store,
+        output_dir: output_dir,
+        batch_size: 2
+      )
+    end
+
+    before do
+      File.write(File.join(output_dir, 'user.json'), JSON.generate(unit_data))
+      File.write(File.join(output_dir, 'payment_service.json'), JSON.generate(second_unit_data))
+    end
+
+    it 'stores one metadata record per unit keyed by identifier' do
+      indexer_with_metadata.index_all
+
+      expect(metadata_store.count).to eq(2)
+      expect(metadata_store.find('User')).to include('type' => 'model',
+                                                     'file_path' => 'app/models/user.rb')
+      expect(metadata_store.find('PaymentService')).to include('type' => 'service')
+    end
+
+    it 'preserves source_code so ContextAssembler#format_unit can render content' do
+      indexer_with_metadata.index_all
+
+      record = metadata_store.find('User')
+      expect(record['source_code']).to include('class User')
+    end
+
+    it 'keys chunked units by the base identifier (not the #chunk_N id)' do
+      chunked = unit_data.merge(
+        'chunks' => [
+          { 'chunk_index' => 0, 'content' => 'chunk one' },
+          { 'chunk_index' => 1, 'content' => 'chunk two' }
+        ]
+      )
+      File.write(File.join(output_dir, 'user.json'), JSON.generate(chunked))
+
+      indexer_with_metadata.index_all
+
+      expect(metadata_store.find('User')).not_to be_nil
+      expect(metadata_store.find('User#chunk_0')).to be_nil
+    end
+
+    it 'is a no-op when metadata_store is nil (pre-persistence-arc hosts)' do
+      nil_indexer = described_class.new(
+        provider: provider,
+        text_preparer: text_preparer,
+        vector_store: vector_store,
+        metadata_store: nil,
+        output_dir: output_dir,
+        batch_size: 2
+      )
+
+      expect { nil_indexer.index_all }.not_to raise_error
+    end
+
+    context 'in incremental mode' do
+      before do
+        File.write(File.join(output_dir, 'checkpoint.json'),
+                   JSON.generate('User' => 'abc123', 'PaymentService' => 'stale'))
+      end
+
+      it 'repopulates metadata for units whose embedding is skipped' do
+        # The checkpoint says User is unchanged — embedding skips it — but
+        # the metadata store is a fresh empty in-memory store this run, so
+        # metadata must still be written or retrieval sees a void.
+        indexer_with_metadata.index_incremental
+
+        expect(metadata_store.find('User')).not_to be_nil
+        expect(metadata_store.find('PaymentService')).not_to be_nil
+      end
+    end
+  end
+
   describe '#index_incremental' do
     before do
       File.write(File.join(output_dir, 'user.json'), JSON.generate(unit_data))
@@ -538,6 +624,7 @@ RSpec.describe Woods::Embedding::Indexer do
         store = double('MetadataStore::InMemory')
         allow(store).to receive(:each_entry)
         allow(store).to receive(:bulk_load)
+        allow(store).to receive(:store) # called by persist_unit_metadata
         store
       end
 

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -45,48 +45,46 @@ RSpec.describe 'Install generator initializer template' do
   let(:template_path) do
     File.expand_path('../../lib/generators/woods/templates/woods.rb.tt', __dir__)
   end
+  # The template file has Unicode box-drawing characters in section headers
+  # (── and em-dashes). Force UTF-8 so regex matches don't raise
+  # "invalid byte sequence in US-ASCII" on environments where
+  # Encoding.default_external is US-ASCII.
+  let(:content) { File.read(template_path, encoding: 'UTF-8') }
 
   it 'template file exists' do
     expect(File.exist?(template_path)).to be true
   end
 
   it 'template calls Woods.configure' do
-    content = File.read(template_path)
     expect(content).to include('Woods.configure do |config|')
   end
 
   it 'template sets output_dir relative to Rails.root' do
-    content = File.read(template_path)
     expect(content).to include('Rails.root.join')
     expect(content).to include('tmp/woods')
   end
 
   it 'template mentions configure_with_preset idiom' do
-    content = File.read(template_path)
     expect(content).to include('configure_with_preset')
   end
 
   it 'template covers console_mcp options' do
-    content = File.read(template_path)
     expect(content).to include('console_mcp_enabled')
     expect(content).to include('console_redacted_columns')
   end
 
   it 'template keeps console MCP disabled by default' do
-    content = File.read(template_path)
     # The enable line must be commented out
     expect(content).to match(/^\s*#\s*config\.console_mcp_enabled\s*=\s*false/)
   end
 
   it 'template mentions all three defense layers' do
-    content = File.read(template_path)
     expect(content).to include('Layer 1')
     expect(content).to include('Layer 2')
     expect(content).to include('Layer 3')
   end
 
   it 'has frozen_string_literal comment' do
-    content = File.read(template_path)
     expect(content).to start_with('# frozen_string_literal: true')
   end
 end

--- a/spec/mcp/bootstrapper_spec.rb
+++ b/spec/mcp/bootstrapper_spec.rb
@@ -826,4 +826,86 @@ RSpec.describe Woods::MCP::Bootstrapper do
       end
     end
   end
+
+  # Regression — the Indexer accepted a graph_store kwarg and dumped it
+  # empty at end of run, but never populated it. Retrieval's :hybrid
+  # strategy called @graph_store.dependencies_of on the empty store and
+  # got [] back, silently dropping the graph-expansion step. The fix
+  # hydrates the retriever's graph_store from dependency_graph.json on
+  # disk, which extraction has always written with the real graph.
+  describe 'graph store hydration' do
+    around do |example|
+      original = Woods.configuration
+      Woods.configuration = Woods::Configuration.new
+      example.run
+    ensure
+      Woods.configuration = original
+    end
+
+    it 'returns a populated GraphStore::Memory when dependency_graph.json exists' do
+      require 'woods/index_artifact'
+      require 'woods/storage/graph_store'
+
+      Woods.configuration.graph_store = :in_memory
+
+      Dir.mktmpdir do |dir|
+        artifact = Woods::IndexArtifact.new(dir)
+        graph_data = {
+          'nodes' => {
+            'User' => { 'type' => 'model', 'file_path' => 'app/models/user.rb', 'namespace' => nil },
+            'Organization' => { 'type' => 'model', 'file_path' => 'app/models/organization.rb', 'namespace' => nil }
+          },
+          'edges' => { 'User' => [{ 'target' => 'Organization', 'via' => 'belongs_to' }] },
+          'reverse' => { 'Organization' => ['User'] },
+          'type_index' => { 'model' => %w[User Organization] }
+        }
+        File.write(File.join(dir, 'dependency_graph.json'), JSON.generate(graph_data))
+
+        store = described_class.send(:hydrated_graph_store, Woods.configuration, artifact)
+
+        expect(store).to be_a(Woods::Storage::GraphStore::Memory)
+        expect(store.dependencies_of('User')).to include('Organization')
+        expect(store.dependents_of('Organization')).to include('User')
+      end
+    end
+
+    it 'returns nil when dependency_graph.json is missing' do
+      require 'woods/index_artifact'
+
+      Dir.mktmpdir do |dir|
+        artifact = Woods::IndexArtifact.new(dir)
+        store = described_class.send(:hydrated_graph_store, Woods.configuration, artifact)
+        expect(store).to be_nil
+      end
+    end
+
+    it 'returns nil when graph_store is not :in_memory (durable backends are not hydrated)' do
+      require 'woods/index_artifact'
+
+      Woods.configuration.graph_store = :pgvector
+
+      Dir.mktmpdir do |dir|
+        artifact = Woods::IndexArtifact.new(dir)
+        File.write(File.join(dir, 'dependency_graph.json'), JSON.generate('nodes' => {}, 'edges' => {}))
+        store = described_class.send(:hydrated_graph_store, Woods.configuration, artifact)
+        expect(store).to be_nil
+      end
+    end
+
+    it 'returns nil and warns when dependency_graph.json is malformed' do
+      require 'woods/index_artifact'
+
+      Woods.configuration.graph_store = :in_memory
+
+      Dir.mktmpdir do |dir|
+        artifact = Woods::IndexArtifact.new(dir)
+        File.write(File.join(dir, 'dependency_graph.json'), 'not valid json')
+
+        expect do
+          store = described_class.send(:hydrated_graph_store, Woods.configuration, artifact)
+          expect(store).to be_nil
+        end.to output(/graph hydration failed/).to_stderr
+      end
+    end
+  end
 end

--- a/spec/mcp/error_meta_spec.rb
+++ b/spec/mcp/error_meta_spec.rb
@@ -42,9 +42,13 @@ RSpec.describe 'MCP tool structured errors' do
   end
 
   describe 'pipeline_extract' do
-    it 'returns :not_configured when operator is nil' do
-      response = call_tool(server, 'pipeline_extract')
-      expect_error(response, code: :not_configured, config_key: 'operator')
+    # The tool is not registered when operator is nil — that's the "correct
+    # cliff-avoidance contract". An explicit operator with a missing
+    # component (e.g. no :status_reporter) still registers the tool and
+    # returns :not_configured, which we verify elsewhere.
+    it 'is not registered when operator is nil' do
+      tools = server.instance_variable_get(:@tools)
+      expect(tools.keys).not_to include('pipeline_extract')
     end
   end
 
@@ -59,16 +63,16 @@ RSpec.describe 'MCP tool structured errors' do
   end
 
   describe 'retrieval_rate' do
-    it 'returns :not_configured when feedback_store is nil' do
-      response = call_tool(server, 'retrieval_rate', query: 'q', score: 4)
-      expect_error(response, code: :not_configured, config_key: 'feedback_store')
+    it 'is not registered when feedback_store is nil' do
+      tools = server.instance_variable_get(:@tools)
+      expect(tools.keys).not_to include('retrieval_rate')
     end
   end
 
   describe 'list_snapshots' do
-    it 'returns :not_configured when snapshot_store is nil' do
-      response = call_tool(server, 'list_snapshots')
-      expect_error(response, code: :not_configured, config_key: 'enable_snapshots')
+    it 'is not registered when snapshot_store is nil' do
+      tools = server.instance_variable_get(:@tools)
+      expect(tools.keys).not_to include('list_snapshots')
     end
   end
 
@@ -95,9 +99,10 @@ RSpec.describe 'MCP tool structured errors' do
 
     after { Woods.configuration = nil }
 
-    it 'returns :not_configured with config_key=notion_api_token when token is missing' do
-      response = call_tool(server, 'notion_sync')
-      expect_error(response, code: :not_configured, config_key: 'notion_api_token')
+    it 'is not registered when notion_api_token is missing' do
+      srv = Woods::MCP::Server.build(index_dir: fixture_dir)
+      tools = srv.instance_variable_get(:@tools)
+      expect(tools.keys).not_to include('notion_sync')
     end
   end
 
@@ -113,9 +118,10 @@ RSpec.describe 'MCP tool structured errors' do
 
     after { Woods.configuration = nil }
 
-    it 'returns :not_configured with config_key=session_store when store is missing' do
-      response = call_tool(server, 'session_trace', session_id: 'any')
-      expect_error(response, code: :not_configured, config_key: 'session_store')
+    it 'is not registered when session_store is missing' do
+      srv = Woods::MCP::Server.build(index_dir: fixture_dir)
+      tools = srv.instance_variable_get(:@tools)
+      expect(tools.keys).not_to include('session_trace')
     end
   end
 end

--- a/spec/mcp/provider_probe_spec.rb
+++ b/spec/mcp/provider_probe_spec.rb
@@ -142,6 +142,7 @@ RSpec.describe Woods::MCP::ProviderProbe do
       it 'returns the provider unchanged' do
         response = instance_double(Net::HTTPOK)
         allow(response).to receive(:is_a?).with(Net::HTTPUnauthorized).and_return(false)
+        allow(response).to receive(:is_a?).with(Net::HTTPForbidden).and_return(false)
         allow(response).to receive(:is_a?).with(Net::HTTPServerError).and_return(false)
         stub_net_http('api.openai.com', 443, response)
 
@@ -152,6 +153,7 @@ RSpec.describe Woods::MCP::ProviderProbe do
       it 'probes GET /v1/models over TLS' do
         response = instance_double(Net::HTTPOK)
         allow(response).to receive(:is_a?).with(Net::HTTPUnauthorized).and_return(false)
+        allow(response).to receive(:is_a?).with(Net::HTTPForbidden).and_return(false)
         allow(response).to receive(:is_a?).with(Net::HTTPServerError).and_return(false)
         http_double = stub_net_http('api.openai.com', 443, response)
         allow(http_double).to receive(:use_ssl=).with(true)
@@ -172,6 +174,25 @@ RSpec.describe Woods::MCP::ProviderProbe do
           .to raise_error(Woods::MCP::ProviderUnreachable) do |err|
             expect(err.url).to eq('https://api.openai.com')
             expect(err.reason).to eq('unauthorized')
+          end
+      end
+    end
+
+    context 'when OpenAI returns 403 Forbidden' do
+      # Observed when an edge proxy (corporate firewall, geo-blocked region)
+      # intercepts the probe before it reaches OpenAI's auth layer. Treating
+      # 403 as reachable would give operators a false-green status — the
+      # real embed calls will 403 the same way.
+      it 'raises ProviderUnreachable with reason: "forbidden"' do
+        response = instance_double(Net::HTTPForbidden)
+        allow(response).to receive(:is_a?).with(Net::HTTPUnauthorized).and_return(false)
+        allow(response).to receive(:is_a?).with(Net::HTTPForbidden).and_return(true)
+        stub_net_http('api.openai.com', 443, response)
+
+        expect { described_class.reachable!(openai_provider) }
+          .to raise_error(Woods::MCP::ProviderUnreachable) do |err|
+            expect(err.url).to eq('https://api.openai.com')
+            expect(err.reason).to eq('forbidden')
           end
       end
     end

--- a/spec/mcp/server_spec.rb
+++ b/spec/mcp/server_spec.rb
@@ -14,27 +14,47 @@ RSpec.describe Woods::MCP::Server do
       expect(server).to be_a(MCP::Server)
     end
 
-    it 'registers 29 tools' do
+    it 'registers 14 tools when no optional collaborators are wired' do
+      # Without operator / feedback_store / snapshot_store / session_store /
+      # notion config, the 15 collaborator-dependent tools (5 pipeline_*, 4
+      # retrieval_*, 4 snapshot/history, session_trace, notion_sync) are
+      # intentionally NOT registered — advertising them in tools/list when
+      # they're guaranteed to error just wastes LLM context. Core tools that
+      # only need the on-disk index remain advertised.
       tools = server.instance_variable_get(:@tools)
-      expect(tools.size).to eq(29)
+      expect(tools.size).to eq(14)
     end
 
-    it 'registers expected tool names' do
+    it 'registers the always-on tool names when no optional collaborators are wired' do
       tools = server.instance_variable_get(:@tools)
       expect(tools.keys).to contain_exactly(
         'lookup', 'search', 'dependencies', 'dependents',
         'structure', 'graph_analysis', 'domain_clusters', 'pagerank', 'framework',
         'recent_changes', 'reload', 'codebase_retrieve',
-        'trace_flow', 'session_trace',
-        'pipeline_extract', 'pipeline_embed', 'pipeline_status',
-        'pipeline_diagnose', 'pipeline_repair',
-        'retrieval_rate', 'retrieval_report_gap',
-        'retrieval_explain', 'retrieval_suggest',
-        'list_snapshots', 'snapshot_diff',
-        'unit_history', 'snapshot_detail',
-        'notion_sync',
+        'trace_flow',
         'woods_status'
       )
+    end
+
+    it 'registers pipeline_* tools when operator is wired' do
+      operator = { status_reporter: double('reporter'), pipeline_guard: nil, pipeline_lock: nil, error_escalator: nil }
+      srv = described_class.build(index_dir: fixture_dir, operator: operator)
+      tools = srv.instance_variable_get(:@tools)
+      expect(tools.keys).to include('pipeline_extract', 'pipeline_embed', 'pipeline_status',
+                                    'pipeline_diagnose', 'pipeline_repair')
+    end
+
+    it 'registers retrieval_* tools when feedback_store is wired' do
+      srv = described_class.build(index_dir: fixture_dir, feedback_store: double('fb'))
+      tools = srv.instance_variable_get(:@tools)
+      expect(tools.keys).to include('retrieval_rate', 'retrieval_report_gap',
+                                    'retrieval_explain', 'retrieval_suggest')
+    end
+
+    it 'registers snapshot_* tools when snapshot_store is wired' do
+      srv = described_class.build(index_dir: fixture_dir, snapshot_store: double('snap'))
+      tools = srv.instance_variable_get(:@tools)
+      expect(tools.keys).to include('list_snapshots', 'snapshot_diff', 'unit_history', 'snapshot_detail')
     end
 
     it 'registers 2 resources' do
@@ -123,6 +143,17 @@ RSpec.describe Woods::MCP::Server do
       expect(data).to have_key('source_code')
       expect(data).to have_key('metadata')
       expect(data).to have_key('dependencies')
+    end
+
+    it 'accepts `name` as an alias for `identifier`' do
+      response = call_tool(server, 'lookup', name: 'Post')
+      data = parse_response(response)
+      expect(data['identifier']).to eq('Post')
+    end
+
+    it 'returns a typed error when neither identifier nor name is provided' do
+      response = call_tool(server, 'lookup')
+      expect(response_text(response)).to include('lookup requires')
     end
   end
 
@@ -378,6 +409,38 @@ RSpec.describe Woods::MCP::Server do
         File.write(manifest_path, original_content)
       end
     end
+
+    # Regression — reload used to only refresh reader state. If you ran
+    # `woods:embed` while the MCP server was up, reload picked up the new
+    # manifest.json / dependency_graph.json but the in-memory vectors and
+    # metadata still reflected the previous embed run, which meant
+    # codebase_retrieve returned the old results until an MCP restart.
+    it 'invokes the retriever reloader and surfaces its stats' do
+      reloader = double('reloader', call: { vectors: 100, metadata: 100, graph: 1 })
+      server_with_reloader = described_class.build(
+        index_dir: fixture_dir, response_format: :json, retriever_reloader: reloader
+      )
+
+      response = call_tool(server_with_reloader, 'reload')
+      data = parse_response(response)
+
+      expect(reloader).to have_received(:call)
+      expect(data['retriever']).to include('vectors' => 100, 'metadata' => 100, 'graph' => 1)
+    end
+
+    it 'reports the reloader error instead of raising when re-hydration fails' do
+      reloader = double('reloader')
+      allow(reloader).to receive(:call).and_raise(StandardError, 'dump missing')
+
+      server_with_reloader = described_class.build(
+        index_dir: fixture_dir, response_format: :json, retriever_reloader: reloader
+      )
+
+      response = call_tool(server_with_reloader, 'reload')
+      data = parse_response(response)
+      expect(data['reloaded']).to be true
+      expect(data['retriever']['error']).to include('dump missing')
+    end
   end
 
   describe 'tool: framework' do
@@ -492,12 +555,28 @@ RSpec.describe Woods::MCP::Server do
 
       it 'calls the retriever with the query and default budget' do
         call_tool(server_with_retriever, 'codebase_retrieve', query: 'How does the User model work?')
-        expect(retriever).to have_received(:retrieve).with('How does the User model work?', budget: 8000)
+        expect(retriever).to have_received(:retrieve)
+          .with('How does the User model work?', budget: 8000, types: nil, exclude_types: nil)
       end
 
       it 'passes a custom budget to the retriever' do
         call_tool(server_with_retriever, 'codebase_retrieve', query: 'User model', budget: 4000)
-        expect(retriever).to have_received(:retrieve).with('User model', budget: 4000)
+        expect(retriever).to have_received(:retrieve)
+          .with('User model', budget: 4000, types: nil, exclude_types: nil)
+      end
+
+      it 'accepts `limit` as an alias for `budget`' do
+        call_tool(server_with_retriever, 'codebase_retrieve', query: 'User model', limit: 4000)
+        expect(retriever).to have_received(:retrieve)
+          .with('User model', budget: 4000, types: nil, exclude_types: nil)
+      end
+
+      it 'forwards types: and exclude_types: through to the retriever' do
+        call_tool(server_with_retriever, 'codebase_retrieve',
+                  query: 'billing', types: %w[service], exclude_types: %w[rails_source])
+        expect(retriever).to have_received(:retrieve).with(
+          'billing', budget: 8000, types: %w[service], exclude_types: %w[rails_source]
+        )
       end
 
       it 'returns the context from the retrieval result' do
@@ -513,9 +592,9 @@ RSpec.describe Woods::MCP::Server do
 
   describe 'tool: pipeline_status' do
     context 'without operator configured' do
-      it 'returns not configured message' do
-        response = call_tool(server, 'pipeline_status')
-        expect(response_text(response)).to include('not configured')
+      it 'is not registered in tools/list when operator is missing' do
+        tools = server.instance_variable_get(:@tools)
+        expect(tools.keys).not_to include('pipeline_status')
       end
     end
 
@@ -551,9 +630,9 @@ RSpec.describe Woods::MCP::Server do
 
   describe 'tool: pipeline_extract' do
     context 'without operator configured' do
-      it 'returns not configured message' do
-        response = call_tool(server, 'pipeline_extract')
-        expect(response_text(response)).to include('not configured')
+      it 'is not registered in tools/list when operator is missing' do
+        tools = server.instance_variable_get(:@tools)
+        expect(tools.keys).not_to include('pipeline_extract')
       end
     end
 
@@ -590,9 +669,9 @@ RSpec.describe Woods::MCP::Server do
 
   describe 'tool: pipeline_embed' do
     context 'without operator configured' do
-      it 'returns not configured message' do
-        response = call_tool(server, 'pipeline_embed')
-        expect(response_text(response)).to include('not configured')
+      it 'is not registered in tools/list when operator is missing' do
+        tools = server.instance_variable_get(:@tools)
+        expect(tools.keys).not_to include('pipeline_embed')
       end
     end
 
@@ -783,12 +862,11 @@ RSpec.describe Woods::MCP::Server do
 
       after { Woods.configuration = nil }
 
-      it 'returns a structured error when session tracer is not configured' do
-        response = call_tool(server, 'session_trace', session_id: 'sess1')
-        expect(response_text(response)).to include('not configured')
-        expect(response.error?).to be(true)
-        expect(response.meta[:error_code]).to eq(:not_configured)
-        expect(response.meta[:config_key]).to eq('session_store')
+      it 'is not registered in tools/list when session_store is missing' do
+        # Rebuild server so the session_tracer_wired? check sees the mock config.
+        srv = described_class.build(index_dir: fixture_dir, response_format: :json)
+        tools = srv.instance_variable_get(:@tools)
+        expect(tools.keys).not_to include('session_trace')
       end
     end
 
@@ -855,9 +933,9 @@ RSpec.describe Woods::MCP::Server do
 
   describe 'tool: pipeline_repair' do
     context 'without operator configured' do
-      it 'returns not configured message' do
-        response = call_tool(server, 'pipeline_repair', action: 'clear_locks')
-        expect(response_text(response)).to include('not configured')
+      it 'is not registered in tools/list when operator is missing' do
+        tools = server.instance_variable_get(:@tools)
+        expect(tools.keys).not_to include('pipeline_repair')
       end
     end
   end
@@ -866,9 +944,9 @@ RSpec.describe Woods::MCP::Server do
 
   describe 'tool: retrieval_rate' do
     context 'without feedback store configured' do
-      it 'returns not configured message' do
-        response = call_tool(server, 'retrieval_rate', query: 'test', score: 4)
-        expect(response_text(response)).to include('not configured')
+      it 'is not registered in tools/list when feedback_store is missing' do
+        tools = server.instance_variable_get(:@tools)
+        expect(tools.keys).not_to include('retrieval_rate')
       end
     end
 
@@ -895,19 +973,18 @@ RSpec.describe Woods::MCP::Server do
 
   describe 'tool: retrieval_report_gap' do
     context 'without feedback store configured' do
-      it 'returns not configured message' do
-        response = call_tool(server, 'retrieval_report_gap',
-                             query: 'payments', missing_unit: 'PaymentService', unit_type: 'service')
-        expect(response_text(response)).to include('not configured')
+      it 'is not registered in tools/list when feedback_store is missing' do
+        tools = server.instance_variable_get(:@tools)
+        expect(tools.keys).not_to include('retrieval_report_gap')
       end
     end
   end
 
   describe 'tool: retrieval_explain' do
     context 'without feedback store configured' do
-      it 'returns not configured message' do
-        response = call_tool(server, 'retrieval_explain')
-        expect(response_text(response)).to include('not configured')
+      it 'is not registered in tools/list when feedback_store is missing' do
+        tools = server.instance_variable_get(:@tools)
+        expect(tools.keys).not_to include('retrieval_explain')
       end
     end
 
@@ -939,9 +1016,9 @@ RSpec.describe Woods::MCP::Server do
 
   describe 'tool: retrieval_suggest' do
     context 'without feedback store configured' do
-      it 'returns not configured message' do
-        response = call_tool(server, 'retrieval_suggest')
-        expect(response_text(response)).to include('not configured')
+      it 'is not registered in tools/list when feedback_store is missing' do
+        tools = server.instance_variable_get(:@tools)
+        expect(tools.keys).not_to include('retrieval_suggest')
       end
     end
   end

--- a/spec/mcp/server_spec.rb
+++ b/spec/mcp/server_spec.rb
@@ -565,10 +565,15 @@ RSpec.describe Woods::MCP::Server do
           .with('User model', budget: 4000, types: nil, exclude_types: nil)
       end
 
-      it 'accepts `limit` as an alias for `budget`' do
-        call_tool(server_with_retriever, 'codebase_retrieve', query: 'User model', limit: 4000)
-        expect(retriever).to have_received(:retrieve)
-          .with('User model', budget: 4000, types: nil, exclude_types: nil)
+      it 'rejects `limit` with a helpful typed error (avoids silent near-empty budget)' do
+        response = call_tool(server_with_retriever, 'codebase_retrieve', query: 'User model', limit: 10)
+        expect(response.error?).to be(true)
+        text = response_text(response)
+        expect(text).to include('codebase_retrieve uses `budget`')
+        expect(text).to include('result-count')
+        expect(response.meta[:error_code]).to eq(:unsupported_argument)
+        expect(response.meta[:argument]).to eq('limit')
+        expect(retriever).not_to have_received(:retrieve)
       end
 
       it 'forwards types: and exclude_types: through to the retriever' do

--- a/spec/mcp/snapshot_tools_spec.rb
+++ b/spec/mcp/snapshot_tools_spec.rb
@@ -30,24 +30,24 @@ RSpec.describe 'Snapshot MCP tools' do
   describe 'without snapshot store configured' do
     let(:server) { Woods::MCP::Server.build(index_dir: fixture_dir) }
 
-    it 'list_snapshots returns not configured message' do
-      response = call_tool(server, 'list_snapshots')
-      expect(response_text(response)).to include('not configured')
+    it 'list_snapshots is not registered' do
+      tools = server.instance_variable_get(:@tools)
+      expect(tools.keys).not_to include('list_snapshots')
     end
 
-    it 'snapshot_diff returns not configured message' do
-      response = call_tool(server, 'snapshot_diff', sha_a: 'abc', sha_b: 'def')
-      expect(response_text(response)).to include('not configured')
+    it 'snapshot_diff is not registered' do
+      tools = server.instance_variable_get(:@tools)
+      expect(tools.keys).not_to include('snapshot_diff')
     end
 
-    it 'unit_history returns not configured message' do
-      response = call_tool(server, 'unit_history', identifier: 'User')
-      expect(response_text(response)).to include('not configured')
+    it 'unit_history is not registered' do
+      tools = server.instance_variable_get(:@tools)
+      expect(tools.keys).not_to include('unit_history')
     end
 
-    it 'snapshot_detail returns not configured message' do
-      response = call_tool(server, 'snapshot_detail', git_sha: 'abc')
-      expect(response_text(response)).to include('not configured')
+    it 'snapshot_detail is not registered' do
+      tools = server.instance_variable_get(:@tools)
+      expect(tools.keys).not_to include('snapshot_detail')
     end
   end
 

--- a/spec/mcp/woods_status_spec.rb
+++ b/spec/mcp/woods_status_spec.rb
@@ -47,8 +47,12 @@ RSpec.describe 'woods_status tool' do
     it 'exposes feature flags from Woods.configuration' do
       expect(status[:features]).to include(
         :embedding_model, :session_tracer_enabled, :snapshots_enabled,
-        :notion_configured, :console_mcp_enabled
+        :notion_configured
       )
+    end
+
+    it 'omits console_mcp_enabled (always wrong — index MCP cannot see Rails-side config)' do
+      expect(status[:features]).not_to have_key(:console_mcp_enabled)
     end
 
     it 'reports bootstrap=nil when no BootstrapState is passed (backwards compat)' do
@@ -90,6 +94,138 @@ RSpec.describe 'woods_status tool' do
       expect(s[:bootstrap][:reason]).to include('Woods::MCP::ProviderUnreachable')
       expect(s[:bootstrap][:reason]).to include('connection_refused')
       expect(s[:bootstrap][:degraded_since]).not_to be_nil
+    end
+  end
+
+  describe 'staleness gate (index.git_sha_matches_head)' do
+    # Regression — the manifest captures git_sha / gemfile_lock_sha / schema_sha
+    # at extraction time, but historic build_status never compared them against
+    # the live working tree. A developer who commits 40 changes and restarts the
+    # MCP without re-running woods:embed got pre-change answers silently. The
+    # gate now surfaces git_sha_matches_head + head_git_sha so agents can branch
+    # on staleness even though the server doesn't hard-refuse.
+    let(:manifest_sha) { 'a' * 40 }
+    let(:head_sha) { 'b' * 40 }
+
+    def stub_git_head(head:, status_ok: true)
+      process_status = instance_double(Process::Status, success?: status_ok)
+      allow(Open3).to receive(:capture2).with('git', '-C', anything, 'rev-parse', 'HEAD')
+                                        .and_return(["#{head}\n", process_status])
+    end
+
+    it 'reports git_sha_matches_head=true when manifest.git_sha matches HEAD' do
+      stub_git_head(head: manifest_sha)
+      reader = double('reader', manifest: { 'git_sha' => manifest_sha, 'extracted_at' => nil, 'counts' => {} })
+
+      status = Woods::MCP::Server.build_status(reader: reader, retriever: nil, index_dir: '/tmp')
+
+      expect(status[:index][:git_sha]).to eq(manifest_sha)
+      expect(status[:index][:head_git_sha]).to eq(manifest_sha)
+      expect(status[:index][:git_sha_matches_head]).to be(true)
+    end
+
+    it 'reports git_sha_matches_head=false when HEAD has moved past manifest.git_sha' do
+      stub_git_head(head: head_sha)
+      reader = double('reader', manifest: { 'git_sha' => manifest_sha, 'extracted_at' => nil, 'counts' => {} })
+
+      status = Woods::MCP::Server.build_status(reader: reader, retriever: nil, index_dir: '/tmp')
+
+      expect(status[:index][:git_sha_matches_head]).to be(false)
+      expect(status[:index][:head_git_sha]).to eq(head_sha)
+    end
+
+    it 'omits the comparison keys when index_dir is not a git repo' do
+      stub_git_head(head: '', status_ok: false)
+      reader = double('reader', manifest: { 'git_sha' => manifest_sha, 'extracted_at' => nil, 'counts' => {} })
+
+      status = Woods::MCP::Server.build_status(reader: reader, retriever: nil, index_dir: '/tmp')
+
+      expect(status[:index]).not_to have_key(:git_sha_matches_head)
+      expect(status[:index]).not_to have_key(:head_git_sha)
+    end
+
+    it 'omits the comparison keys when manifest has no git_sha' do
+      reader = double('reader', manifest: { 'extracted_at' => nil, 'counts' => {} })
+
+      status = Woods::MCP::Server.build_status(reader: reader, retriever: nil, index_dir: '/tmp')
+
+      expect(status[:index]).not_to have_key(:git_sha_matches_head)
+    end
+
+    it 'omits the comparison keys when index_dir does not exist (reader survived but dir gone)' do
+      reader = double('reader', manifest: { 'git_sha' => manifest_sha, 'extracted_at' => nil, 'counts' => {} })
+
+      status = Woods::MCP::Server.build_status(reader: reader, retriever: nil, index_dir: '/nonexistent/path/xyz')
+
+      expect(status[:index]).not_to have_key(:git_sha_matches_head)
+    end
+  end
+
+  describe 'features drawn from ResolvedConfig' do
+    # Regression — historic build_status read config.embedding_model (which
+    # defaults to "text-embedding-3-small" in lib/woods.rb) regardless of the
+    # provider actually hydrated from woods.json. Operators saw status claim
+    # `embedding_model: "text-embedding-3-small"` alongside
+    # `embedding_provider: "ollama"` and rightfully distrusted every field.
+    let(:resolved) do
+      require 'woods/resolved_config'
+      Woods::ResolvedConfig.new(
+        schema_version: 1,
+        gem_version: '1.0.0',
+        created_at: Time.now.utc,
+        embedding_provider: {
+          class: 'Woods::Embedding::Provider::Ollama',
+          model: 'nomic-embed-text',
+          dimension: 768,
+          host: 'http://127.0.0.1:11434'
+        },
+        stores: { vector_store: :in_memory, metadata_store: :in_memory, graph_store: :in_memory }
+      )
+    end
+
+    let(:state_with_resolved) do
+      require 'woods/mcp/bootstrap_state'
+      state = Woods::MCP::BootstrapState.new
+      state.resolved_config = resolved
+      state.mark(:hydrated)
+      state
+    end
+
+    it 'reports embedding_model from resolved_config, not Woods.configuration default' do
+      s = Woods::MCP::Server.build_status(
+        reader: reader, retriever: nil, index_dir: fixture_dir,
+        bootstrap_state: state_with_resolved
+      )
+      expect(s[:features][:embedding_model]).to eq('nomic-embed-text')
+    end
+
+    it 'reports embedding_provider as the short symbol form (:ollama, :openai)' do
+      s = Woods::MCP::Server.build_status(
+        reader: reader, retriever: nil, index_dir: fixture_dir,
+        bootstrap_state: state_with_resolved
+      )
+      expect(s[:features][:embedding_provider]).to eq('ollama')
+    end
+
+    it 'reports vector_store from resolved_config.stores' do
+      s = Woods::MCP::Server.build_status(
+        reader: reader, retriever: nil, index_dir: fixture_dir,
+        bootstrap_state: state_with_resolved
+      )
+      expect(s[:features][:vector_store]).to eq('in_memory')
+    end
+
+    it 'falls back to Woods.configuration when resolved_config is absent' do
+      # Other specs in the suite may mutate or nil-out Woods.configuration —
+      # pin a fresh one so the assertion doesn't depend on ordering.
+      original_config = Woods.configuration
+      Woods.configuration = Woods::Configuration.new
+      begin
+        s = Woods::MCP::Server.build_status(reader: reader, retriever: nil, index_dir: fixture_dir)
+        expect(s[:features][:embedding_model]).to eq('text-embedding-3-small')
+      ensure
+        Woods.configuration = original_config
+      end
     end
   end
 

--- a/spec/mcp/woods_status_spec.rb
+++ b/spec/mcp/woods_status_spec.rb
@@ -109,8 +109,8 @@ RSpec.describe 'woods_status tool' do
 
     def stub_git_head(head:, status_ok: true)
       process_status = instance_double(Process::Status, success?: status_ok)
-      allow(Open3).to receive(:capture2).with('git', '-C', anything, 'rev-parse', 'HEAD')
-                                        .and_return(["#{head}\n", process_status])
+      allow(Open3).to receive(:capture2e).with('git', '-C', anything, 'rev-parse', 'HEAD')
+                                         .and_return(["#{head}\n", process_status])
     end
 
     it 'reports git_sha_matches_head=true when manifest.git_sha matches HEAD' do

--- a/spec/retrieval/context_assembler_spec.rb
+++ b/spec/retrieval/context_assembler_spec.rb
@@ -430,4 +430,59 @@ RSpec.describe Woods::Retrieval::ContextAssembler do
       expect(described_class::MIN_USEFUL_TOKENS).to eq(200)
     end
   end
+
+  # ── Chunked-identifier collapsing ─────────────────────────────────
+  describe 'chunked identifier handling' do
+    # Regression — the Indexer stores chunked units under +User#chunk_0+,
+    # +User#chunk_1+, ... in the vector store but under +User+ in the
+    # metadata store. Without normalisation, +find_batch+ misses every
+    # chunked candidate and the context assembler drops them to nil.
+    it 'looks up metadata under the base identifier for #chunk_N candidates' do
+      allow(metadata_store).to receive(:find).with('BigService').and_return(
+        unit_data(identifier: 'BigService', type: :service, file_path: 'app/services/big_service.rb')
+      )
+
+      result = assembler.assemble(
+        candidates: [candidate(identifier: 'BigService#chunk_0', score: 0.9)],
+        classification: classification
+      )
+
+      expect(result.context).to include('BigService')
+      expect(result.sources.first[:identifier]).to eq('BigService')
+    end
+
+    it 'deduplicates multiple chunks of the same unit, keeping the highest score' do
+      allow(metadata_store).to receive(:find).with('BigService').and_return(
+        unit_data(identifier: 'BigService', type: :service, file_path: 'app/services/big_service.rb',
+                  source_code: 'class BigService; end')
+      )
+
+      result = assembler.assemble(
+        candidates: [
+          candidate(identifier: 'BigService#chunk_0', score: 0.7),
+          candidate(identifier: 'BigService#chunk_1', score: 0.9),
+          candidate(identifier: 'BigService#chunk_2', score: 0.6)
+        ],
+        classification: classification
+      )
+
+      # Unit appears exactly once in context
+      expect(result.context.scan('## BigService').size).to eq(1)
+      # Source attribution preserves the highest score
+      expect(result.sources.first[:score]).to eq(0.9)
+    end
+
+    it 'leaves unchunked identifiers unchanged' do
+      allow(metadata_store).to receive(:find).with('User').and_return(
+        unit_data(identifier: 'User', type: :model)
+      )
+
+      result = assembler.assemble(
+        candidates: [candidate(identifier: 'User', score: 0.95)],
+        classification: classification
+      )
+
+      expect(result.sources.first[:identifier]).to eq('User')
+    end
+  end
 end

--- a/spec/retriever_spec.rb
+++ b/spec/retriever_spec.rb
@@ -176,6 +176,83 @@ RSpec.describe Woods::Retriever do
     end
   end
 
+  # ── Type filtering ──────────────────────────────────────────────
+
+  describe 'type filtering' do
+    # Regression — test_mapping units make up ~33% of a typical index and
+    # lexically dominate semantic rank on production queries. The Retriever
+    # now default-excludes them unless the caller explicitly opts back in
+    # via types:. Callers can also add more exclusions via exclude_types:.
+    let(:mixed_candidates) do
+      [
+        Woods::Retrieval::SearchExecutor::Candidate.new(
+          identifier: 'StripeWebhooksController', score: 0.9, source: :vector,
+          metadata: { type: 'controller' }
+        ),
+        Woods::Retrieval::SearchExecutor::Candidate.new(
+          identifier: 'StripeWebhooksControllerSpec', score: 0.85, source: :vector,
+          metadata: { type: 'test_mapping' }
+        ),
+        Woods::Retrieval::SearchExecutor::Candidate.new(
+          identifier: 'Stripe::Webhook', score: 0.8, source: :vector,
+          metadata: { type: 'rails_source' }
+        )
+      ]
+    end
+
+    before do
+      allow(ranker_double).to receive(:rank).and_return(mixed_candidates)
+    end
+
+    it 'excludes test_mapping candidates by default' do
+      expect(assembler_double).to receive(:assemble) do |kwargs|
+        types = kwargs[:candidates].map { |c| c.metadata[:type] }
+        expect(types).not_to include('test_mapping')
+        assembled_context
+      end
+
+      retriever.retrieve('stripe webhook')
+    end
+
+    it 'opts test_mappings back in when types: explicitly includes them' do
+      expect(assembler_double).to receive(:assemble) do |kwargs|
+        types = kwargs[:candidates].map { |c| c.metadata[:type] }
+        expect(types).to include('test_mapping')
+        expect(types).not_to include('controller', 'rails_source')
+        assembled_context
+      end
+
+      retriever.retrieve('stripe webhook', types: %w[test_mapping])
+    end
+
+    it 'accepts exclude_types: for additional exclusions on top of the default' do
+      expect(assembler_double).to receive(:assemble) do |kwargs|
+        types = kwargs[:candidates].map { |c| c.metadata[:type] }
+        expect(types).to eq(%w[controller])
+        assembled_context
+      end
+
+      retriever.retrieve('stripe webhook', exclude_types: %w[rails_source])
+    end
+
+    it 'falls back to metadata_store lookup when candidate metadata has no :type' do
+      # Graph-expansion candidates come in with metadata: {} — the filter
+      # must still resolve their type via the metadata store.
+      bare_candidate = Woods::Retrieval::SearchExecutor::Candidate.new(
+        identifier: 'Orphan', score: 0.5, source: :graph_expansion, metadata: {}
+      )
+      allow(ranker_double).to receive(:rank).and_return([bare_candidate])
+      allow(metadata_store).to receive(:find).with('Orphan').and_return('type' => 'test_mapping')
+
+      expect(assembler_double).to receive(:assemble) do |kwargs|
+        expect(kwargs[:candidates]).to be_empty
+        assembled_context
+      end
+
+      retriever.retrieve('orphan')
+    end
+  end
+
   # ── Pipeline integration ─────────────────────────────────────────
 
   describe 'pipeline flow' do


### PR DESCRIPTION
## Summary

Address the full batch of bugs an agent flagged while exercising Woods against a real host — **plus** a second round of fixes from a hyper-critical self-review of the initial patch, plus two spec-suite failures (one encoding-locale, one probe-behaviour).

## Commits

1. **`fix(embedding): populate metadata_store during embedding`** — the critical `codebase_retrieve` fix. `Indexer#process_batch` writes each unit's data to `@metadata_store` keyed by base identifier.
2. **`fix(exe): suppress json-schema MultiJSON deprecation before require chain`** — MultiJSON banner no longer leaks on MCP stdio.
3. **`fix(mcp): hydrate retriever graph_store from dependency_graph.json at boot`** — `:hybrid` graph expansion works because the retriever's graph store is populated.
4. **`fix(mcp): overhaul woods_status + conditional tool registration + param aliases`** — features read from ResolvedConfig; console_mcp_enabled dropped; git_sha staleness gate; `name` alias on `lookup`; 15 collaborator-dependent tools only register when wired.
5. **`test(mcp): update specs for conditional tool registration + parameter aliases`**.
6. **`feat(retriever): type-filter codebase_retrieve results, default-exclude test_mappings`**.
7. **`fix(mcp): reload tool re-hydrates retriever stores from dumps, not just reader`**.
8. **`fix(mcp): treat 403 Forbidden as ProviderUnreachable for OpenAI probe`** — edge-proxy 403 no longer produces false-green `:hydrated`.
9. **`test(generators): force UTF-8 when reading initializer template`** — test robust across locales (US-ASCII env no longer trips the regex).
10. **`fix(retrieval): collapse #chunk_N candidates to base identifier before metadata lookup`** — **review-surfaced critical bug**: original metadata fix still missed chunked units because vector store returns `User#chunk_0` IDs that don't exist in the metadata store.
11. **`fix(retrieval): expose stores as public accessors + thread type kwargs through cache`** — **review-surfaced**: Retriever stored vector/graph only on `@executor`; CachedRetriever didn't forward `types:`/`exclude_types:` or expose stores for reload.
12. **`fix(mcp): reject `limit` on codebase_retrieve with hint; harden git + http-exe hygiene`** — **review-surfaced**: `limit` aliased to `budget` was a silent footgun (`limit: 10` → 10-token budget); also capture2e for git probe; also MultiJSON suppression for `woods-mcp-http`.

## Bug mapping (feedback → commit)

| Feedback item | Commit |
| --- | --- |
| 🔴 `codebase_retrieve` always returns empty (metadata store never populated) | #1 + #10 |
| 🔴 Parallel "ghost" graph_store (never populated) | #3 |
| 🟡 Status-display drift (`embedding_model` default vs actual provider) | #4 |
| 🟡 `console_mcp_enabled` always wrong in index MCP | #4 (dropped) |
| 🟡 `codebase_retrieve` uses `budget`, docs say `limit` (parameter cliff) | #12 (typed error, not alias) |
| 🟡 `lookup` requires `identifier`, rejects `name` (parameter cliff) | #4 |
| 🟡 15 advertised-but-unavailable tools | #4 + #5 |
| 🟡 Staleness has no gate, only a counter | #4 |
| 🟡 `test_mappings` dominate the index (33%) | #6 |
| 🟡 `reload` tool doesn't re-hydrate retriever | #7 + #11 |
| 🟡 MultiJSON deprecation leaks through stdio | #2 + #12 |

## Review findings (self-audit, commits 10–12)

1. **Chunked-unit retrieval still broken after the initial metadata fix.** The Indexer writes metadata under the base identifier (`User`) but the vector store returns `User#chunk_0` IDs. `ContextAssembler#find_batch` missed every chunked unit — identical silent-empty symptom, just confined to large units (rails_source, multi-chunk services). Fix collapses `#chunk_N` suffixes in the assembler and dedupes.
2. **CachedRetriever broke the new API.** It didn't accept `types:`/`exclude_types:` so cache-enabled callers got `ArgumentError`. It also didn't expose underlying stores so reload was a silent no-op when caching was on.
3. **`limit` alias was a semantic footgun.** On every sibling tool `limit` is a result count; mapping to `budget` would produce a 10-token "context" for `limit: 10`. Switched to a typed error that points to `budget:`.
4. **git probe leaked stderr** through `Open3.capture2` when `index_dir` wasn't a git repo. MCP stdio clients can trip on stray stderr lines. Switched to `capture2e` and narrowed the rescue.
5. **`exe/woods-mcp-http` was missing** the MultiJSON suppression that `woods-mcp` and `woods-console-mcp` had.
6. **Retriever didn't expose its stores as public readers** — reload reached through `instance_variable_get(:@executor)` fragilely.

## New `woods_status` payload shape

```diff
 index:
+  head_git_sha: "abc123..."         # resolved from the current HEAD
+  git_sha_matches_head: false       # tri-state: true / false / nil
 features:
-  embedding_model: "text-embedding-3-small"  # config default (wrong)
+  embedding_model: "nomic-embed-text"        # from ResolvedConfig
-  console_mcp_enabled: false        # always wrong — dropped
```

## New MCP tool surface (no optional collaborators wired)

14 always-on tools: `lookup`, `search`, `dependencies`, `dependents`, `structure`, `graph_analysis`, `domain_clusters`, `pagerank`, `framework`, `recent_changes`, `reload`, `codebase_retrieve`, `trace_flow`, `woods_status`.

15 collaborator-dependent tools light up when their collaborator is passed to `Server.build` (`operator:`, `feedback_store:`, `snapshot_store:`) or Rails-side config is populated (`session_store`, `notion_api_token` + `notion_database_ids`).

## Test plan

- [x] **Full gem suite: 4417 examples, 0 failures, 4 pending.**
- [x] RuboCop clean across 422 files.
- [x] New spec coverage for every change:
  - Indexer metadata/graph population (5 cases inc. incremental mode)
  - `ContextAssembler` chunked-id collapse (3 cases: lookup, dedup, non-chunked passthrough)
  - Bootstrapper graph_store hydration (4 cases)
  - `build_status` resolved_config override (4 cases)
  - `build_status` staleness gate (5 cases)
  - Retriever type filter (4 cases)
  - `codebase_retrieve` `limit` rejected with typed error
  - `codebase_retrieve` `types:`/`exclude_types:` forwarding
  - `lookup` `name` alias + missing-identifier typed error
  - `reload` tool invokes reloader + surfaces stats + error-safe
  - Conditional tool registration (always-on + per-collaborator)
  - CachedRetriever forwards new kwargs, type filter in cache key, exposes stores
  - Provider probe 403 handling
- [ ] Host-app validation in `woods-testbed` `rails-8.0`: run `woods:embed`, boot `woods-mcp`, confirm chunked + unchunked `codebase_retrieve` return populated text, confirm `tools/list` reflects reduced surface, confirm `woods_status` shows correct provider + staleness, confirm `reload` picks up a fresh embed without restart.

https://claude.ai/code/session_01S1WbtdYiZzmZgYw7NZrYW2