### PR TITLE
Fix origin guard security issues: prevent header injection and XSS

### DIFF
--- a/lib/woods/mcp/origin_guard.rb
+++ b/lib/woods/mcp/origin_guard.rb
@@ -50,6 +50,8 @@ module Woods
       end
 
       def origin_allowed?(origin)
+        return false if origin.match?(/[[:cntrl:]]/)
+
         @allowed.include?(normalize(origin)) || @allowed.include?(normalize(origin).sub(/:\d+\z/, ''))
       end
 

--- a/lib/woods/mcp/origin_guard.rb
+++ b/lib/woods/mcp/origin_guard.rb
@@ -12,6 +12,11 @@ module Woods
     # :allowed_origins. Requests without an Origin header (curl, server-to-server,
     # MCP stdio clients) are allowed through — bearer auth still gates them.
     #
+    # Port-matching: an allow-list entry WITHOUT a port (`http://localhost`)
+    # matches that host on any port. An entry WITH a port (`http://localhost:3000`)
+    # requires an exact port match. Specify explicit ports when port isolation
+    # matters.
+    #
     # Also answers CORS preflight (OPTIONS) with the matching allow-list.
     class OriginGuard
       DEFAULT_ALLOWED = %w[

--- a/lib/woods/mcp/origin_guard.rb
+++ b/lib/woods/mcp/origin_guard.rb
@@ -22,6 +22,8 @@ module Woods
       ALLOWED_METHODS = 'GET, POST, DELETE, OPTIONS'
       ALLOWED_HEADERS = 'Authorization, Content-Type, Mcp-Session-Id'
 
+      FORBIDDEN_BODY = { jsonrpc: '2.0', error: { code: -32_002, message: 'Origin not allowed' }, id: nil }.to_json.freeze
+
       def initialize(app, allowed_origins: nil)
         @app = app
         @allowed = Array(allowed_origins).compact.reject { |o| o.to_s.strip.empty? }.map { |o| normalize(o) }
@@ -32,7 +34,7 @@ module Woods
         origin = env['HTTP_ORIGIN']
         method = env['REQUEST_METHOD']
 
-        return forbidden(origin) if origin && !origin_allowed?(origin)
+        return forbidden if origin && !origin_allowed?(origin)
 
         return preflight(origin) if method == 'OPTIONS'
 
@@ -66,9 +68,8 @@ module Woods
         }
       end
 
-      def forbidden(origin)
-        body = { jsonrpc: '2.0', error: { code: -32_002, message: "Origin not allowed: #{origin}" }, id: nil }.to_json
-        [403, { 'content-type' => 'application/json' }, [body]]
+      def forbidden
+        [403, { 'content-type' => 'application/json' }, [FORBIDDEN_BODY]]
       end
     end
   end

--- a/spec/mcp/origin_guard_spec.rb
+++ b/spec/mcp/origin_guard_spec.rb
@@ -46,6 +46,23 @@ RSpec.describe Woods::MCP::OriginGuard do
       expect(body.first).not_to include('<script>')
     end
 
+    it 'returns a spec-compliant JSON-RPC error envelope on rejection' do
+      _status, headers, body = call(middleware, origin: 'http://evil.example.com')
+      expect(headers['content-type']).to eq('application/json')
+      parsed = JSON.parse(body.first)
+      expect(parsed).to include('jsonrpc' => '2.0', 'id' => nil)
+      expect(parsed['error']).to include('code' => -32_002, 'message' => 'Origin not allowed')
+    end
+
+    it 'rejects origins with CRLF / control characters without reflecting them' do
+      malicious = "http://localhost\r\nX-Injected: yes"
+      status, headers, body = call(middleware, origin: malicious)
+      expect(status).to eq(403)
+      expect(headers).not_to have_key('X-Injected')
+      expect(body.first).not_to include("\r\n")
+      expect(body.first).not_to include('X-Injected')
+    end
+
     it 'adds CORS headers to allowed responses' do
       _status, headers, = call(middleware, origin: 'http://localhost')
       expect(headers['access-control-allow-origin']).to eq('http://localhost')

--- a/spec/mcp/origin_guard_spec.rb
+++ b/spec/mcp/origin_guard_spec.rb
@@ -39,6 +39,13 @@ RSpec.describe Woods::MCP::OriginGuard do
       expect(parsed['error']['message']).to match(/Origin not allowed/)
     end
 
+    it 'does not echo the rejected origin value in the response body' do
+      malicious = 'http://evil.example.com/<script>alert(1)</script>'
+      _status, _headers, body = call(middleware, origin: malicious)
+      expect(body.first).not_to include('evil.example.com')
+      expect(body.first).not_to include('<script>')
+    end
+
     it 'adds CORS headers to allowed responses' do
       _status, headers, = call(middleware, origin: 'http://localhost')
       expect(headers['access-control-allow-origin']).to eq('http://localhost')


### PR DESCRIPTION
## Summary

Fix critical security vulnerabilities in the origin guard middleware by preventing header injection attacks via CRLF characters and eliminating XSS risks from echoing rejected origins in response bodies.

## Motivation

The origin guard middleware had two security issues:

1. **Header Injection**: Malicious origins containing CRLF characters (e.g., `http://localhost\r\nX-Injected: yes`) could inject arbitrary HTTP headers into responses.
2. **XSS Risk**: Rejected origins were echoed directly in error messages, allowing attackers to inject malicious scripts into the response body.

These vulnerabilities could be exploited by attackers to manipulate HTTP responses or execute arbitrary JavaScript in clients.

## Changes

- **Reject origins with control characters**: Added validation in `origin_allowed?` to reject any origin containing control characters (including CRLF sequences) using regex matching.
- **Remove origin echo from error response**: Changed `forbidden` method to return a static, pre-computed JSON-RPC error response instead of dynamically including the rejected origin value.
- **Use constant for error body**: Defined `FORBIDDEN_BODY` as a frozen constant to ensure the error response is consistent and immutable.
- **Improve documentation**: Added clarification about port-matching behavior in the class docstring.

## Testing

Added three new test cases covering the security fixes:

1. `does not echo the rejected origin value in the response body` — Verifies XSS prevention by ensuring malicious origin values are not reflected in responses.
2. `returns a spec-compliant JSON-RPC error envelope on rejection` — Confirms the error response follows JSON-RPC 2.0 specification with proper error code (-32_002).
3. `rejects origins with CRLF / control characters without reflecting them` — Validates that CRLF injection attempts are rejected and not reflected in headers or body.

All existing tests continue to pass.

## Checklist

- [x] Tests added/updated
- [x] `bundle exec rake spec` passes
- [ ] `bundle exec rubocop` passes
- [ ] CHANGELOG.md updated (if user-facing change)
- [ ] Documentation updated (if applicable)

https://claude.ai/code/session_012696kZQYvV628E8V9wHqqk