### PR TITLE
Document eval_guard reachability and unsafe-eval opt-in plan

### DIFF
--- a/docs/CONSOLE_MCP_SETUP.md
+++ b/docs/CONSOLE_MCP_SETUP.md
@@ -451,6 +451,8 @@ Two complementary defenses share this flag, both gating credential exfiltration 
 
 - **Parse-time eval guard.** `Woods::Console::EvalGuard` walks the normalized AST of every `console_eval` payload and raises before the bridge ever sees it when the snippet reaches `Rails.application.credentials.*`, `Rails.application.secrets.*`, `ENV` (any form), reflection escapes (`eval`, `instance_eval`, `send`, `const_get`, `binding`, etc.), or credential-file reads (`File.read('config/master.key')`, `File.read('config/credentials.yml.enc')`, etc.). Refusal yields a clean MCP error response (`error: true`) — no transport-level exception, no partial output. Unparseable payloads are also refused, since a snippet that won't parse can't be reasoned about.
 
+  **Reachability note (v0.1).** In the shipped embedded-executor transports (Options A–C) `console_eval` is refused unconditionally at dispatch — see [`console_eval` is permanently disabled in embedded mode](#console_eval-is-permanently-disabled-in-embedded-mode) below — so the EvalGuard code path described here is reached only from the in-development bridge-process mode. The class is retained as the pre-execution gate for bridge mode and for the planned `WOODS_CONSOLE_UNSAFE_EVAL` opt-in (tracked in issue #87 / the `unsafe-eval-opt-in` backlog item). Treat the denylist as authoritative — bridge-mode rollout will adopt it verbatim.
+
 - **Boot-time credential index.** `Woods::Console::CredentialIndex` walks `Rails.application.credentials.config` once at server boot, collects every string leaf with length ≥ 12, and substring-redacts those values from every MCP response. This catches credentials whose *shape* the scanner doesn't recognize but whose *exact contents* Rails already knows — Twilio auth tokens, hand-rolled HMAC seeds, third-party webhook signing keys, custom OAuth client secrets. Hits are marked `[REDACTED:credential]` (distinct from the scanner's `[REDACTED]`) and counted under a `:credential_index` key so audit output shows which layer caught the leak.
 
 **Restart required after credential rotation.** The index is built once at process start and held in memory for the lifetime of the MCP process. When a host app rotates Rails credentials (`rails credentials:edit`), the MCP process keeps the pre-rotation secrets in its Set until the process is restarted — new secrets are not picked up automatically. Only the Layer 2 shape-pattern scanner (Stripe `sk_*`, AWS `AKIA*`, etc.) can catch newly-rotated values before restart.
@@ -740,6 +742,16 @@ The embedded executor (used in Options A–C) implements the 9 Tier 1 tools plus
 
 - For `console_sql` and `console_query`: pass `embedded_read_tools: true` when mounting `Woods::Console::RackMiddleware` (see [Unlocking `console_sql` / `console_query` in embedded mode](#unlocking-console_sql--console_query-in-embedded-mode)).
 - For everything else (`console_diagnose_model`, `console_eval`, domain-aware Tier 2 tools, Tier 3 analytics): switch to the bridge architecture (Option D) — the embedded executor does not implement those tools.
+
+### `console_eval` is permanently disabled in embedded mode
+
+Calling `console_eval` through any embedded-executor transport (Options A–C) returns `error_type: "eval_disabled"` regardless of configuration. The refusal is hard-coded in `EmbeddedExecutor#refusal_for` and fires before dispatch reaches the Tier 4 handler, so `console_credential_defense_enabled` and `WOODS_CONSOLE_UNSAFE_EVAL` have no effect on this path in v0.1.
+
+Implications for operators and contributors:
+
+- **There is no v0.1 opt-in.** The `WOODS_CONSOLE_UNSAFE_EVAL` / `Rails.env.production?` language in the refusal message describes the *future* contract; the opt-in execution wiring is not implemented. Tracked in issue #87 and the `unsafe-eval-opt-in` backlog item.
+- **`Woods::Console::EvalGuard` is scaffold for bridge mode.** The class, its denylist, and its spec are intentionally retained as the pre-execution gate for Option D (bridge process) and for the future opt-in flag. Do not delete it; do not wire it into the embedded path without delivering the full opt-in contract (flag gate + production rejection + confirmation flow).
+- **Run arbitrary Ruby by switching to the bridge architecture** (Option D) once it ships, or by asking the human operator to paste the snippet into a local `rails console` — the error message the agent sees already instructs it to do so.
 
 ### Slow first request on HTTP/Rack middleware
 

--- a/docs/backlog.json
+++ b/docs/backlog.json
@@ -527,5 +527,22 @@
     "description": "Three rake tasks: woods:retrieve[query] (CLI retrieval with HumanAdapter), woods:embed (full embedding pipeline), woods:embed_incremental (content_hash-based).",
     "status": "resolved",
     "depends_on": ["B-038"]
+  },
+  {
+    "id": "B-053",
+    "slug": "unsafe-eval-opt-in",
+    "title": "Wire console_eval behind WOODS_CONSOLE_UNSAFE_EVAL + EvalGuard (v0.2)",
+    "severity": "medium",
+    "category": "implementation",
+    "layer": "console-mcp",
+    "files": [
+      "lib/woods/console/embedded_executor.rb",
+      "lib/woods/console/eval_guard.rb",
+      "lib/woods/console/server.rb",
+      "docs/CONSOLE_MCP_SETUP.md"
+    ],
+    "description": "Embedded-mode console_eval is hard-refused at dispatch (EmbeddedExecutor#refusal_for), so EvalGuard is unreachable on the shipped path. The refusal message already advertises WOODS_CONSOLE_UNSAFE_EVAL + a Rails.env.production? rejection as the opt-in contract, but the execution wiring is not implemented. Deliver the full contract before running any Ruby: (1) gate on both config.console_unsafe_eval_enabled AND ENV['WOODS_CONSOLE_UNSAFE_EVAL']; (2) refuse unconditionally when Rails.env.production?; (3) run EvalGuard.check! before dispatch; (4) require Confirmation approval; (5) record the run in AuditLogger. Partial wiring is worse than the current refusal — ship all five or none. Tracked in issue #87 (option 2 deferral).",
+    "status": "open",
+    "depends_on": []
   }
 ]

--- a/lib/woods/console/embedded_executor.rb
+++ b/lib/woods/console/embedded_executor.rb
@@ -112,6 +112,15 @@ module Woods
       # Return a pre-dispatch refusal hash for tools the executor cannot or
       # will not run, else nil to let dispatch proceed.
       #
+      # `eval` is refused unconditionally here — the branch short-circuits
+      # before reaching the Tier 4 handler, so {Woods::Console::EvalGuard}
+      # is intentionally not consulted on this path. EvalGuard remains the
+      # intended pre-execution gate for bridge mode and for the planned
+      # `WOODS_CONSOLE_UNSAFE_EVAL` opt-in (issue #87 / `unsafe-eval-opt-in`
+      # backlog). Do not call EvalGuard from here without also delivering
+      # the opt-in wiring — a partial wire-up would silently imply eval
+      # is runnable when it still isn't.
+      #
       # @param tool [String] Tool name
       # @return [Hash, nil]
       def refusal_for(tool)

--- a/lib/woods/console/eval_guard.rb
+++ b/lib/woods/console/eval_guard.rb
@@ -12,6 +12,19 @@ module Woods
 
     # Parse-time refusal layer for `console_eval`.
     #
+    # ## Current reachability (v0.1)
+    #
+    # **EvalGuard is not reached on the shipped embedded-executor path.**
+    # `EmbeddedExecutor#refusal_for('eval')` unconditionally returns the
+    # `eval_disabled` error, so dispatch never reaches the Tier 4 handler
+    # where this guard is injected. The class is retained as the defense
+    # layer for the in-development bridge-process mode and for the planned
+    # `WOODS_CONSOLE_UNSAFE_EVAL` opt-in — see issue #87 and the
+    # `unsafe-eval-opt-in` backlog item. Keep the denylist current: when
+    # bridge mode ships, this guard becomes the primary pre-execution gate.
+    #
+    # ## Behaviour
+    #
     # Walks the normalized {Woods::Ast::Parser} tree of the proposed Ruby
     # snippet and refuses any expression that reaches a known credential or
     # reflection escape — so an LLM-generated `Rails.application.credentials


### PR DESCRIPTION
## Summary

This change documents the current reachability limitations of `EvalGuard` in embedded-executor mode and clarifies the planned `WOODS_CONSOLE_UNSAFE_EVAL` opt-in contract. It adds clarifying comments to the code and updates user-facing documentation to prevent misunderstandings about eval availability and security controls.

## Motivation

In v0.1, `console_eval` is unconditionally refused at the `EmbeddedExecutor#refusal_for` dispatch layer, which means `EvalGuard` is never reached on the shipped embedded-executor path (Options A–C). However, the refusal message advertises a future opt-in contract (`WOODS_CONSOLE_UNSAFE_EVAL` + production rejection), which doesn't yet exist. This creates confusion about:

1. Whether eval is actually available via configuration
2. Whether `EvalGuard` is actively protecting eval execution
3. What the actual security contract is in v0.1

This PR clarifies the current state and documents the planned opt-in (tracked in issue #87 and backlog item `unsafe-eval-opt-in`).

## Changes

- **docs/backlog.json**: Added `B-053` (`unsafe-eval-opt-in`) backlog item documenting the full opt-in contract: flag gating, production rejection, `EvalGuard` pre-dispatch check, confirmation flow, and audit logging.

- **lib/woods/console/eval_guard.rb**: Added "Current reachability (v0.1)" section explaining that `EvalGuard` is not reached on the shipped embedded-executor path and is retained as the defense layer for bridge mode and the planned opt-in.

- **lib/woods/console/embedded_executor.rb**: Expanded the `refusal_for` method's docstring to explain why `eval` is refused unconditionally and why `EvalGuard` is intentionally not consulted here.

- **docs/CONSOLE_MCP_SETUP.md**: 
  - Added reachability note to the "Parse-time eval guard" section clarifying that the code path is only reached in bridge mode (v0.1).
  - Added new section "`console_eval` is permanently disabled in embedded mode" explaining the v0.1 limitation, the absence of an opt-in, and implications for operators and contributors.

## Testing

No testing needed. This is a documentation and clarification change with no functional code modifications. Existing tests remain unaffected.

## Checklist

- [x] Documentation updated (CONSOLE_MCP_SETUP.md, backlog.json, code comments)
- [x] No functional code changes (comments and docs only)
- [x] No tests required for documentation clarifications

https://claude.ai/code/session_0154hkz3FdPat23MuUcUWVag