### PR TITLE
Close #87 + #82: surface scaffold status for EvalGuard and StubBridge

### DIFF
--- a/docs/backlog.json
+++ b/docs/backlog.json
@@ -544,5 +544,20 @@
     "description": "Embedded-mode console_eval is hard-refused at dispatch (EmbeddedExecutor#refusal_for), so EvalGuard is unreachable on the shipped path. The refusal message already advertises WOODS_CONSOLE_UNSAFE_EVAL + a Rails.env.production? rejection as the opt-in contract, but the execution wiring is not implemented. Deliver the full contract before running any Ruby: (1) gate on both config.console_unsafe_eval_enabled AND ENV['WOODS_CONSOLE_UNSAFE_EVAL']; (2) refuse unconditionally when Rails.env.production?; (3) run EvalGuard.check! before dispatch; (4) require Confirmation approval; (5) record the run in AuditLogger. Partial wiring is worse than the current refusal — ship all five or none. Tracked in issue #87 (option 2 deferral).",
     "status": "open",
     "depends_on": []
+  },
+  {
+    "id": "B-054",
+    "slug": "extract-bridge-protocol",
+    "title": "Extract BridgeProtocol constants module from StubBridge",
+    "severity": "low",
+    "category": "refactor",
+    "layer": "console-mcp",
+    "files": [
+      "lib/woods/console/bridge.rb",
+      "lib/woods/console/embedded_executor.rb"
+    ],
+    "description": "Issue #82 renamed Woods::Console::Bridge to StubBridge so the scaffold status is obvious. The downstream smell — flagged by both reviewers — is that the canonical protocol contract (SUPPORTED_TOOLS, TIER1_TOOLS, TOOL_HANDLERS) still lives on the stub class. EmbeddedExecutor::TIER1_TOOLS = StubBridge::TIER1_TOOLS reads as 'the real executor borrows constants from the stub', which is backwards. Extract a Woods::Console::BridgeProtocol module owning the three constants; have StubBridge include or reference it; update EmbeddedExecutor to read from BridgeProtocol directly. When the real bridge-process implementation lands it can claim the Bridge class name without the protocol contract migrating with it. Pre-existing doc-rot in docs/design/CONSOLE_SERVER.md (sections 107/118/130 still describe rails runner lib/woods/console/bridge.rb as if it works) is in scope for the same PR.",
+    "status": "open",
+    "depends_on": []
   }
 ]

--- a/lib/woods/console/bridge.rb
+++ b/lib/woods/console/bridge.rb
@@ -6,22 +6,50 @@ require_relative 'safe_context'
 
 module Woods
   module Console
-    # JSON-lines protocol bridge between MCP server and Rails environment.
+    # **PROTOCOL SCAFFOLD — does not execute real queries.** Every handler
+    # below returns static empty data (`{ 'count' => 0 }`, `{ 'records' =>
+    # [] }`, etc.). Real in-process execution lives in
+    # {Woods::Console::EmbeddedExecutor}; the eventual real bridge process
+    # for Option D will replace this scaffold with a class that performs
+    # actual ActiveRecord queries.
+    #
+    # The scaffold pins the JSON-lines wire protocol — request envelope,
+    # response envelope, supported-tools list, error shape — so other
+    # components (EmbeddedExecutor, ConnectionManager, Server) can be
+    # built and tested against a stable contract before the real
+    # bridge-process implementation lands. Treat this class the way you'd
+    # treat a Sinatra fake of a third-party API in tests: it satisfies
+    # the protocol, nothing more.
+    #
+    # ## Why the name carries "Stub"
+    #
+    # Round-1 audit Track H-4 flagged this class as a "critical SafeContext
+    # bypass" because `handle_request` doesn't wrap calls in `SafeContext`.
+    # That finding wasn't exploitable — no live code path executes through
+    # this class in the shipped gem — but the bare name `Bridge` made the
+    # scaffold status invisible to auditors. The `Stub` prefix removes the
+    # ambiguity. When the real bridge-process implementation is delivered,
+    # it should claim the `Bridge` name; this class will either be deleted
+    # (if the protocol is fully owned by the real bridge) or renamed to
+    # `BridgeProtocol` and reduced to a constants module.
+    #
+    # ## Protocol
     #
     # Reads JSON-lines requests from an input IO, validates model/column names,
-    # dispatches to tool handlers, and writes JSON-lines responses to an output IO.
+    # dispatches to (stub) tool handlers, and writes JSON-lines responses to
+    # an output IO.
     #
     # Protocol:
     #   Request:  {"id":"req_1","tool":"count","params":{"model":"Order","scope":{"status":"pending"}}}
     #   Response: {"id":"req_1","ok":true,"result":{"count":1847},"timing_ms":12.3}
     #   Error:    {"id":"req_1","ok":false,"error":"Model not found","error_type":"validation"}
     #
-    # @example
-    #   bridge = Bridge.new(input: $stdin, output: $stdout,
-    #                       model_validator: validator, safe_context: ctx)
+    # @example Wiring against a fake input/output (testing only — handlers return empty data)
+    #   bridge = StubBridge.new(input: $stdin, output: $stdout,
+    #                           model_validator: validator, safe_context: ctx)
     #   bridge.run
     #
-    class Bridge
+    class StubBridge
       SUPPORTED_TOOLS = %w[count sample find pluck aggregate association_count schema recent status].freeze
       # Alias used by EmbeddedExecutor to avoid duplicating the list.
       TIER1_TOOLS = SUPPORTED_TOOLS
@@ -115,10 +143,10 @@ module Woods
         @model_validator.validate_model!(model)
       end
 
-      # Stub handlers below return empty/zero data by design.
-      # This Bridge class is a protocol scaffold — real execution happens
-      # in EmbeddedExecutor (in-process) or a live Rails bridge process.
-      # The stubs satisfy the protocol contract for testing and offline use.
+      # Stub handlers below return empty/zero data by design — see the
+      # class-level docstring. Real in-process execution happens in
+      # EmbeddedExecutor; the eventual Option-D bridge process will replace
+      # this class entirely.
 
       def handle_count(_params)
         { 'count' => 0 }

--- a/lib/woods/console/embedded_executor.rb
+++ b/lib/woods/console/embedded_executor.rb
@@ -9,8 +9,9 @@ require_relative 'table_gate'
 
 module Woods
   module Console
-    # Drop-in replacement for ConnectionManager + Bridge that executes
-    # queries directly via ActiveRecord instead of a separate bridge process.
+    # Drop-in replacement for ConnectionManager + the bridge process that
+    # executes queries directly via ActiveRecord instead of going over the
+    # JSON-lines protocol (see {StubBridge} for the protocol scaffold).
     #
     # Implements the same `send_request(Hash) -> Hash` interface as
     # ConnectionManager, so all existing tool definitions in Server work
@@ -24,7 +25,7 @@ module Woods
     class EmbeddedExecutor # rubocop:disable Metrics/ClassLength
       AGGREGATE_FUNCTIONS = %w[sum average minimum maximum count].freeze
 
-      TIER1_TOOLS = Bridge::TIER1_TOOLS
+      TIER1_TOOLS = StubBridge::TIER1_TOOLS
 
       # Tools gated behind the read_tools_enabled flag.
       # sql/query have existing safety gates (SqlValidator, SafeContext rollback)

--- a/spec/console/bridge_spec.rb
+++ b/spec/console/bridge_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'woods/console/bridge'
 
-RSpec.describe Woods::Console::Bridge do
+RSpec.describe Woods::Console::StubBridge do
   let(:registry) do
     {
       'User' => %w[id email name created_at],


### PR DESCRIPTION
## Summary

Addresses two related audit-noise issues where security-critical-looking scaffold code keeps triggering false-positive audit findings. Both follow the same pattern: the code isn't wrong, but the *presentation* leads auditors to repeatedly re-raise the same concern.

### Closes #87 — EvalGuard unreachable in embedded mode

Delivered option 3 from the ticket (document; option 2 "wire behind `WOODS_CONSOLE_UNSAFE_EVAL`" deferred to v0.2 per the issue's own recommendation).

- `lib/woods/console/eval_guard.rb` — Class-level docstring now leads with the reachability status: `EmbeddedExecutor#refusal_for('eval')` short-circuits before dispatch reaches the Tier 4 handler, so EvalGuard is consulted only on the in-development bridge path. Kept as pre-execution gate for bridge mode + planned opt-in.
- `lib/woods/console/embedded_executor.rb` — Comment above `refusal_for` explains the short-circuit is intentional and warns against partial wire-up (partial wiring would silently imply eval is runnable when it still isn't).
- `docs/CONSOLE_MCP_SETUP.md` — Reachability note on the existing parse-time-eval-guard bullet + new `### console_eval is permanently disabled in embedded mode` troubleshooting section.
- `docs/backlog.json` — `B-053 unsafe-eval-opt-in` added so the 7 in-source references to the backlog item actually resolve. Entry spells out the five-piece v0.2 contract (flag gate + production refusal + EvalGuard.check! + Confirmation + audit logging) that must ship together.

### Closes #82 — Console Bridge scaffold naming

Round-1 audit Track H-4 repeatedly flagged `Bridge` as a "critical SafeContext bypass" because `handle_request` doesn't wrap calls in `SafeContext` — a finding that wasn't exploitable (no live path executes through this class in the shipped gem) but kept resurfacing because the bare name made the scaffold status invisible.

- Rename `Woods::Console::Bridge` → `Woods::Console::StubBridge`. File kept as `bridge.rb` so `ConnectionManager`'s default `rails runner lib/woods/console/bridge.rb` path continues to resolve (a no-op today either way).
- Lead the class docstring with **PROTOCOL SCAFFOLD — does not execute real queries**, explain the stub-handler contract, and document what the real bridge implementation should do to the name when it lands.
- Update the one real callsite (`EmbeddedExecutor::TIER1_TOOLS = StubBridge::TIER1_TOOLS`) and the "drop-in replacement" comment.
- `docs/backlog.json` — `B-054 extract-bridge-protocol` captures the reviewer-surfaced follow-up: the canonical protocol constants (`SUPPORTED_TOOLS`/`TIER1_TOOLS`/`TOOL_HANDLERS`) should move to a dedicated `BridgeProtocol` module rather than being owned by a stub.

## Commits

- `f579c0e` docs(console): mark EvalGuard as bridge-mode scaffold, unreachable in embedded
- `175ffbe` docs(backlog): add B-053 unsafe-eval-opt-in to match in-source references
- `cd841e2` refactor(console): rename Bridge → StubBridge so scaffold status is obvious
- `a7b6ed8` docs(backlog): track BridgeProtocol extraction as B-054

## Test plan

- [x] Full suite: 4570 examples, 0 failures, 4 pending (unrelated tokenizer gem-group specs)
- [x] `bin/rubocop` clean on touched files
- [x] Two independent review agents per commit, all approvals
- [ ] CI green on this PR

## Review notes

Four commits in total; each issue gets a code/docs commit and a follow-up backlog-tracking commit. Diff is narrow — no behavior changes, only class-name rename + docstring/comment/docs additions.

https://claude.ai/code/session_0154hkz3FdPat23MuUcUWVag

---
_Generated by [Claude Code](https://claude.ai/code/session_0154hkz3FdPat23MuUcUWVag)_