### PR TITLE
Strip chunk suffix before metadata store lookups in retrieval

### DIFF
--- a/lib/woods/mcp/bootstrapper.rb
+++ b/lib/woods/mcp/bootstrapper.rb
@@ -337,6 +337,16 @@ module Woods
       end
       private_class_method :hydrated_graph_store
 
+      # Suffix the Indexer appends when a single unit is split into
+      # multiple embedding vectors — see
+      # {Embedding::Indexer#collect_embed_items}. Vector rows are keyed
+      # per-chunk (+Foo#chunk_0+) but metadata is keyed by the base
+      # identifier (+Foo+), so hydration strips the suffix before the
+      # lookup. Mirrors the pattern in {Retriever} and
+      # {Retrieval::ContextAssembler}.
+      CHUNK_SUFFIX_PATTERN = /#chunk_\d+\z/
+      private_constant :CHUNK_SUFFIX_PATTERN
+
       # Back-fill the vector store's per-entry metadata hashes from the
       # metadata store. Only makes sense when both are in-memory — durable
       # backends return nil from the hydration helpers and never reach
@@ -351,7 +361,7 @@ module Woods
         # vector + metadata in place).
         entries = vector_store.each_entry.map { |id, vec, _meta| [id, vec] }
         entries.each do |id, vec|
-          meta = metadata_store.find(id)
+          meta = metadata_store.find(id.to_s.sub(CHUNK_SUFFIX_PATTERN, ''))
           next if meta.nil? || (meta.respond_to?(:empty?) && meta.empty?)
 
           vector_store.store(id, vec, meta)

--- a/lib/woods/retriever.rb
+++ b/lib/woods/retriever.rb
@@ -146,6 +146,16 @@ module Woods
     # override by passing +types:+ (include-only) or an explicit +exclude_types:+.
     DEFAULT_EXCLUDE_TYPES = %w[test_mapping].freeze
 
+    # Suffix the Indexer appends when a single unit is split into multiple
+    # embedding vectors — see {Embedding::Indexer#collect_embed_items}. The
+    # metadata store is keyed by the base identifier only, so the fallback
+    # lookup in +candidate_type+ strips this before probing. Mirrors the
+    # constant in {Retrieval::ContextAssembler}; kept as a local copy so the
+    # two consumers can evolve independently if the chunk format ever
+    # changes on one side of the pipeline.
+    CHUNK_SUFFIX_PATTERN = /#chunk_\d+\z/
+    private_constant :CHUNK_SUFFIX_PATTERN
+
     # Execute the full retrieval pipeline for a natural language query.
     #
     # Pipeline: classify -> execute -> rank -> filter -> assemble -> format
@@ -216,8 +226,13 @@ module Woods
       return inline if inline
 
       # Fall back to the metadata store lookup so graph-expansion candidates
-      # (which come in with metadata: {}) still get type-filtered.
-      type_from_hash(@metadata_store.find(candidate.identifier)) || ''
+      # (which come in with metadata: {}) still get type-filtered. Strip the
+      # chunk suffix first: chunked vector hits arrive with +Foo#chunk_0+
+      # but the store is keyed by the base identifier +Foo+ only, and a
+      # missed lookup would let the candidate past the default-exclude
+      # (type resolves to '', which +excluded+ never contains).
+      lookup_id = candidate.identifier.to_s.sub(CHUNK_SUFFIX_PATTERN, '')
+      type_from_hash(@metadata_store.find(lookup_id)) || ''
     rescue StandardError
       ''
     end

--- a/spec/mcp/bootstrapper_spec.rb
+++ b/spec/mcp/bootstrapper_spec.rb
@@ -643,6 +643,41 @@ RSpec.describe Woods::MCP::Bootstrapper do
       end
     end
 
+    it 'back-fills chunked vector entries from base-identifier metadata' do
+      # The Indexer keys per-chunk vector rows as +Foo#chunk_N+ but stores
+      # unit metadata under the base identifier +Foo+ only. Without
+      # stripping the chunk suffix, the hydration lookup misses and
+      # chunked entries never get their type/file_path/identifier metadata
+      # rebuilt — which then forces the retrieval path into its fallback
+      # and re-introduces the same key-mismatch bug at that layer.
+      Dir.mktmpdir do |dir|
+        write_artifact(
+          dir,
+          vector_entries: [
+            ['User#chunk_0', [1.0, 0.0, 0.0, 0.0], {}],
+            ['User#chunk_1', [0.0, 1.0, 0.0, 0.0], {}],
+            ['Post',         [0.0, 0.0, 1.0, 0.0], {}]
+          ],
+          metadata_entries: [
+            ['User', { 'type' => 'model', 'file_path' => 'app/models/user.rb' }],
+            ['Post', { 'type' => 'model', 'file_path' => 'app/models/post.rb' }]
+          ]
+        )
+
+        retriever, = described_class.build_retriever(index_dir: dir)
+        executor = retriever.instance_variable_get(:@executor)
+        vs = executor.instance_variable_get(:@vector_store)
+
+        metadata_by_id = vs.each_entry.to_h { |id, _, meta| [id, meta] }
+        expect(metadata_by_id['User#chunk_0']).to include('type' => 'model',
+                                                          'file_path' => 'app/models/user.rb')
+        expect(metadata_by_id['User#chunk_1']).to include('type' => 'model',
+                                                          'file_path' => 'app/models/user.rb')
+        expect(metadata_by_id['Post']).to include('type' => 'model',
+                                                  'file_path' => 'app/models/post.rb')
+      end
+    end
+
     it 'ids in vector store but absent from metadata store keep empty metadata hash (no raise)' do
       Dir.mktmpdir do |dir|
         write_artifact(

--- a/spec/retriever_spec.rb
+++ b/spec/retriever_spec.rb
@@ -251,6 +251,29 @@ RSpec.describe Woods::Retriever do
 
       retriever.retrieve('orphan')
     end
+
+    it 'strips #chunk_N suffix before the metadata_store lookup' do
+      # Vector hits for chunked units arrive with identifiers like
+      # +spec/requests/stripe_webhooks_spec.rb#chunk_0+ but the metadata
+      # store keys them under the base identifier only. Without stripping,
+      # the fallback lookup misses, candidate_type falls through to '',
+      # and the default exclude_types filter lets test_mappings through.
+      chunked_candidate = Woods::Retrieval::SearchExecutor::Candidate.new(
+        identifier: 'spec/requests/stripe_webhooks_spec.rb#chunk_0',
+        score: 0.95, source: :vector, metadata: {}
+      )
+      allow(ranker_double).to receive(:rank).and_return([chunked_candidate])
+      allow(metadata_store).to receive(:find)
+        .with('spec/requests/stripe_webhooks_spec.rb')
+        .and_return('type' => 'test_mapping')
+
+      expect(assembler_double).to receive(:assemble) do |kwargs|
+        expect(kwargs[:candidates]).to be_empty
+        assembled_context
+      end
+
+      retriever.retrieve('stripe webhook signature verification')
+    end
   end
 
   # ── Pipeline integration ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fix a key-mismatch bug in the retrieval pipeline where chunked vector entries (keyed as `Foo#chunk_0`, `Foo#chunk_1`, etc.) fail to find their metadata because the metadata store is keyed by the base identifier only (`Foo`). This causes type filtering to fail and allows unwanted candidates through.

## Motivation

The Indexer splits large units into multiple embedding vectors and keys them with a `#chunk_N` suffix, but the metadata store only has entries under the base identifier. When retrieving chunked vectors:

1. In the bootstrapper's hydration phase, chunked vector entries don't get their metadata back-filled, leaving them empty
2. In the retriever's fallback lookup, the chunk suffix prevents finding metadata, causing `candidate_type` to return `''`, which bypasses the default exclude filter

This allows test_mapping candidates and other excluded types to leak through when they shouldn't.

## Changes

- **lib/woods/retriever.rb**: Strip `#chunk_N` suffix before metadata store lookup in `candidate_type` method
- **lib/woods/mcp/bootstrapper.rb**: Strip `#chunk_N` suffix before metadata store lookup in `populate_vector_metadata` method
- Added `CHUNK_SUFFIX_PATTERN` constant to both files (kept as separate copies so consumers can evolve independently)
- **spec/retriever_spec.rb**: Added test verifying chunk suffix is stripped before metadata lookup
- **spec/mcp/bootstrapper_spec.rb**: Added test verifying chunked vector entries get their metadata back-filled from base identifier

## Testing

- Added unit tests in both `retriever_spec.rb` and `bootstrapper_spec.rb` that verify the chunk suffix stripping behavior
- Tests confirm that chunked candidates (`spec/requests/stripe_webhooks_spec.rb#chunk_0`) correctly resolve metadata from the base identifier and are properly filtered
- Tests confirm that vector store hydration back-fills metadata for all chunks from the base identifier entry

## Checklist

- [x] Tests added/updated
- [ ] `bundle exec rake spec` passes (to be verified by CI)
- [ ] `bundle exec rubocop` passes (to be verified by CI)
- [ ] CHANGELOG.md updated (if user-facing change)
- [ ] Documentation updated (if applicable)

https://claude.ai/code/session_016RMwTqA2PzedCPgjaoQLjf