### PR TITLE
Type-aware retrieval, flow precomputation, and search budget fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -154,6 +154,7 @@ Metrics/ParameterLists:
     - 'lib/woods/extracted_unit.rb'
     - 'lib/woods/dependency_graph.rb'
     - 'lib/woods/graph_analyzer.rb'
+    - 'lib/woods/retriever.rb'
     - 'lib/woods/unblocked/**/*'
 
 # MCP descriptions, GraphQL schemas, and regex patterns exceed 120 chars

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -39,6 +39,8 @@ Key enrichments beyond source file content:
 
 **Navigation edges.** View templates scanning for `_path`/`_url` route helper calls produce `link_to` edges pointing to controllers. Controller `redirect_to` calls produce `redirect_to` edges. Form submissions produce `form_action` edges. Filter with the `via` parameter on `dependencies`/`dependents` to isolate UI navigation paths.
 
+**View-template coverage is ERB-only.** HAML, Slim, Stimulus, and Turbo are not extracted. Query the `structure` tool's `template_engines` field if you need to confirm which engines the current index covers — an app written in Slim will appear with zero view units even when views exist. This is a known coverage gap and a `TemplateEngine` interface for pluggable support is tracked as a Turbo prerequisite.
+
 ---
 
 ## MCP Server Setup

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -39,7 +39,7 @@ Key enrichments beyond source file content:
 
 **Navigation edges.** View templates scanning for `_path`/`_url` route helper calls produce `link_to` edges pointing to controllers. Controller `redirect_to` calls produce `redirect_to` edges. Form submissions produce `form_action` edges. Filter with the `via` parameter on `dependencies`/`dependents` to isolate UI navigation paths.
 
-**View-template coverage is ERB-only.** HAML, Slim, Stimulus, and Turbo are not extracted. Query the `structure` tool's `template_engines` field if you need to confirm which engines the current index covers — an app written in Slim will appear with zero view units even when views exist. This is a known coverage gap and a `TemplateEngine` interface for pluggable support is tracked as a Turbo prerequisite.
+**View-template coverage is ERB-only.** HAML, Slim, and Turbo Streams templates are not parsed at all — an app written in Slim will appear with zero view units even when views exist. Stimulus controller *references* are detected inside `PhlexExtractor` and `ViewComponentExtractor` via `data-controller` attribute scanning (dependency edges with `via: :html_attribute`, type `stimulus_controller`), but the Stimulus controller JS files themselves under `app/javascript/controllers/` are not extracted. Query the `structure` tool's `template_engines` field to confirm which engines the current index parses. A `TemplateEngine` interface for pluggable support is tracked as a Turbo prerequisite (issue #110).
 
 ---
 

--- a/docs/EXTRACTOR_REFERENCE.md
+++ b/docs/EXTRACTOR_REFERENCE.md
@@ -280,7 +280,7 @@ Every extractor returns `Array<ExtractedUnit>`. An `ExtractedUnit` is a self-con
 - Navigation edges use `:link_to` and `:form_action` via types in the dependency array
 - Gated by `extract_navigation_edges` config (default: true)
 
-**Template engine coverage.** ERB only. HAML, Slim, Stimulus, and Turbo are *not* extracted. An app using HAML or Slim as its primary view engine gets zero view-layer coverage from this extractor. The MCP `structure` tool surfaces the supported engine list via the `template_engines` field so callers can detect the coverage gap without reading source. When a `TemplateEngine` abstraction lands (tracked as a Turbo prerequisite), this extractor becomes the ERB implementation of that interface and HAML/Slim/Turbo become plug-in additions rather than fork points.
+**Template engine coverage.** ERB only as a parsed template engine — HAML, Slim, and Turbo Streams are not parsed at all; an app using HAML or Slim as its primary view engine gets zero view-layer coverage from this extractor. Stimulus controller *references* are a partial exception: `PhlexExtractor` and `ViewComponentExtractor` scan `data-controller` attributes in their component source and emit `:stimulus_controller` dependency edges — the target Stimulus controller files under `app/javascript/controllers/` are not themselves parsed or extracted. The MCP `structure` tool surfaces the supported engine list via the `template_engines` field. When a `TemplateEngine` abstraction lands (tracked as a Turbo prerequisite, see issue #110), this extractor becomes the ERB implementation of that interface and HAML/Slim/Turbo become plug-in additions rather than fork points.
 
 ---
 

--- a/docs/EXTRACTOR_REFERENCE.md
+++ b/docs/EXTRACTOR_REFERENCE.md
@@ -280,6 +280,8 @@ Every extractor returns `Array<ExtractedUnit>`. An `ExtractedUnit` is a self-con
 - Navigation edges use `:link_to` and `:form_action` via types in the dependency array
 - Gated by `extract_navigation_edges` config (default: true)
 
+**Template engine coverage.** ERB only. HAML, Slim, Stimulus, and Turbo are *not* extracted. An app using HAML or Slim as its primary view engine gets zero view-layer coverage from this extractor. The MCP `structure` tool surfaces the supported engine list via the `template_engines` field so callers can detect the coverage gap without reading source. When a `TemplateEngine` abstraction lands (tracked as a Turbo prerequisite), this extractor becomes the ERB implementation of that interface and HAML/Slim/Turbo become plug-in additions rather than fork points.
+
 ---
 
 ### DecoratorExtractor

--- a/lib/woods/cache/cache_middleware.rb
+++ b/lib/woods/cache/cache_middleware.rb
@@ -430,18 +430,7 @@ module Woods
       def retrieve(query, budget: 8000, types: nil, exclude_types: nil)
         key = context_key(query, budget, types: types, exclude_types: exclude_types)
         cached = @cache_store.read(key)
-
-        if cached
-          return Retriever::RetrievalResult.new(
-            context: cached['context'],
-            sources: cached['sources'],
-            classification: nil,
-            strategy: cached['strategy']&.to_sym,
-            tokens_used: cached['tokens_used'],
-            budget: budget,
-            trace: nil
-          )
-        end
+        return rehydrate_cached(cached, budget) if cached
 
         result = @retriever.retrieve(query, budget: budget, types: types, exclude_types: exclude_types)
 
@@ -484,13 +473,55 @@ module Woods
       #
       # @param result [Retriever::RetrievalResult]
       # @return [Hash]
+      def rehydrate_cached(cached, budget)
+        Retriever::RetrievalResult.new(
+          context: cached['context'],
+          sources: cached['sources'],
+          classification: nil,
+          strategy: cached['strategy']&.to_sym,
+          tokens_used: cached['tokens_used'],
+          budget: budget,
+          trace: nil,
+          type_rank_context: rehydrate_type_rank_context(cached['type_rank_context'])
+        )
+      end
+
       def serialize_result(result)
         {
           'context' => result.context,
           'sources' => result.sources,
           'strategy' => result.strategy&.to_s,
-          'tokens_used' => result.tokens_used
+          'tokens_used' => result.tokens_used,
+          'type_rank_context' => serialize_type_rank_context(result.type_rank_context)
         }
+      end
+
+      # type_rank_context is a Hash<String => Hash<Symbol, ...>> with
+      # :source carrying a Symbol value. JSON-backed caches (Redis,
+      # SolidCache) collapse both to strings on the round-trip, so we
+      # serialize explicitly and re-symbolize both the inner keys and
+      # the :source value on rehydrate. The programmatic contract is
+      # "symbol keys, symbol :source value" regardless of cache hit
+      # vs miss.
+      def serialize_type_rank_context(ctx)
+        return nil if ctx.nil?
+
+        ctx.each_with_object({}) do |(type, info), out|
+          out[type] = info.each_with_object({}) do |(k, v), h|
+            h[k.to_s] = k == :source ? v.to_s : v
+          end
+        end
+      end
+
+      def rehydrate_type_rank_context(raw)
+        return nil if raw.nil?
+
+        raw.each_with_object({}) do |(type, info), out|
+          out[type] = info.each_with_object({}) do |(k, v), h|
+            sym_k = k.to_sym
+            h[sym_k] = sym_k == :source ? v.to_sym : v
+          end
+        end
       end
     end
   end

--- a/lib/woods/extractors/view_template_extractor.rb
+++ b/lib/woods/extractors/view_template_extractor.rb
@@ -24,6 +24,13 @@ module Woods
       include SharedDependencyScanner
       include RouteHelperResolver
 
+      # Template engines this extractor understands. Surfaced through
+      # the MCP `structure` tool so callers can see at a glance what's
+      # covered and what isn't. HAML, Slim, Stimulus, Turbo are
+      # intentionally absent; see docs/EXTRACTOR_REFERENCE.md for the
+      # current coverage boundary.
+      SUPPORTED_TEMPLATE_ENGINES = %i[erb].freeze
+
       # Directories to scan for view templates
       VIEW_DIRECTORIES = %w[
         app/views

--- a/lib/woods/flow_assembler.rb
+++ b/lib/woods/flow_assembler.rb
@@ -253,7 +253,11 @@ module Woods
 
       filenames.each do |filename|
         Dir[File.join(@extracted_dir, '*', filename)].each do |path|
-          return JSON.parse(File.read(path), symbolize_names: true)
+          # Force UTF-8: the extractor writes the routes-comment header in
+          # source_code using Unicode box-drawing characters; reading under
+          # the platform default (US-ASCII on some CIs) raises
+          # InvalidByteSequenceError before JSON parsing.
+          return JSON.parse(File.read(path, encoding: 'UTF-8'), symbolize_names: true)
         rescue JSON::ParserError
           next
         end
@@ -263,28 +267,32 @@ module Woods
     end
 
     # Extract route information from controller metadata.
+    #
+    # Handles two on-disk shapes:
+    # - Hash keyed by action (what ControllerExtractor writes):
+    #     { "create" => [{ verb:, path:, ... }, ...] }
+    # - Array of route hashes (older / test fixture shape):
+    #     [{ action:, verb:, path: }, ...]
     def extract_route(entry_point)
       unit_id, method_name = parse_identifier(entry_point)
       unit_data = load_unit(unit_id)
       return nil unless unit_data
 
       metadata = unit_data[:metadata] || {}
-      routes = metadata[:routes]
-      return nil unless routes.is_a?(Array)
-
-      # Find route matching the method name
-      route = if method_name
-                routes.find { |r| r[:action]&.to_s == method_name }
-              else
-                routes.first
-              end
-
+      route = resolve_route_entry(metadata[:routes], method_name)
       return nil unless route
 
-      {
-        verb: route[:verb],
-        path: route[:path]
-      }
+      { verb: route[:verb], path: route[:path] }
+    end
+
+    def resolve_route_entry(routes, method_name)
+      case routes
+      when Hash
+        action_routes = method_name ? routes[method_name.to_s] || routes[method_name.to_sym] : routes.values.first
+        Array(action_routes).first
+      when Array
+        method_name ? routes.find { |r| r[:action]&.to_s == method_name } : routes.first
+      end
     end
   end
 end

--- a/lib/woods/mcp/index_reader.rb
+++ b/lib/woods/mcp/index_reader.rb
@@ -102,6 +102,17 @@ module Woods
         @manifest ||= parse_json('manifest.json')
       end
 
+      # Template engines the extraction pipeline currently understands.
+      # Read from extractor class constants so the list stays honest as
+      # extractors come and go. Each constant must return an Array of
+      # Symbols. Surfaced by the MCP `structure` tool (#86).
+      #
+      # @return [Array<Symbol>]
+      def template_engines
+        require_relative '../extractors/view_template_extractor'
+        Woods::Extractors::ViewTemplateExtractor::SUPPORTED_TEMPLATE_ENGINES.dup
+      end
+
       # @return [String, nil] SUMMARY.md content, or nil if not present
       def summary
         @summary ||= begin

--- a/lib/woods/mcp/index_reader.rb
+++ b/lib/woods/mcp/index_reader.rb
@@ -319,7 +319,12 @@ module Woods
       # @param limit [Integer] Maximum results to return
       # @return [Array<Hash>] Matching rails_source unit summaries
       def framework_sources(keyword, limit: 20)
-        pattern = Regexp.new(Regexp.escape(keyword), Regexp::IGNORECASE)
+        # Multi-word keywords ("ActiveRecord callbacks") are split on
+        # whitespace and ANDed. Single-word queries behave as before.
+        tokens = keyword.to_s.strip.split(/\s+/)
+        return [] if tokens.empty?
+
+        patterns = tokens.map { |t| Regexp.new(Regexp.escape(t), Regexp::IGNORECASE) }
         results = []
 
         entries = read_index('rails_source')
@@ -330,9 +335,12 @@ module Woods
           unit = find_unit(id)
           next unless unit
 
-          matched = pattern.match?(id) ||
-                    (unit['source_code'] && pattern.match?(unit['source_code'])) ||
-                    (unit['metadata'] && pattern.match?(unit['metadata'].to_json))
+          metadata_json = unit['metadata']&.to_json
+          matched = patterns.all? do |pat|
+            pat.match?(id) ||
+              (unit['source_code'] && pat.match?(unit['source_code'])) ||
+              (metadata_json && pat.match?(metadata_json))
+          end
 
           next unless matched
 

--- a/lib/woods/mcp/index_reader.rb
+++ b/lib/woods/mcp/index_reader.rb
@@ -378,7 +378,8 @@ module Woods
               identifier: id,
               type: DIR_TO_TYPE[dir],
               file_path: unit['file_path'],
-              last_modified: last_modified
+              last_modified: last_modified,
+              author: unit.dig('metadata', 'git', 'last_author')
             }
           end
         end

--- a/lib/woods/mcp/index_reader.rb
+++ b/lib/woods/mcp/index_reader.rb
@@ -207,6 +207,14 @@ module Woods
                  TYPE_DIRS
                end
 
+        # Phase 2 candidates are collected per-dir and then scanned in
+        # round-robin across dirs. Exhausting the per-run scan cap linearly
+        # down TYPE_DIRS order would starve later types (`concerns` at pos
+        # 13, `test_mappings` at pos 31) on any codebase where the earlier
+        # dirs together exceed max_scan entries. Interleaving guarantees
+        # every type contributes to the scanned set.
+        phase2_queues = {}
+
         dirs.each do |dir|
           type_name = DIR_TO_TYPE[dir]
           entries = read_index(dir)
@@ -222,34 +230,54 @@ module Woods
           end
 
           entries.each do |entry|
-            break if results.size >= limit
-
             id = entry['identifier']
             next unless identifier_passes_prefix_suffix?(id, prefix, suffix)
 
-            # Phase 1: identifier matching
+            # Phase 1: identifier matching (still in-order per dir)
             if fields.include?('identifier') && pattern.match?(id)
+              next if results.size >= limit
+
               results << { identifier: id, type: type_name, match_field: 'identifier' }
               next
             end
 
-            # Phase 2: metadata/source_code matching (requires loading full unit)
+            # Phase 2 is only reached when the caller opted into deeper fields.
             next unless fields.include?('metadata') || fields.include?('source_code')
 
-            if phase2_scanned >= max_scan
-              partial = true
-              next
-            end
+            (phase2_queues[dir] ||= []) << [type_name, id]
+          end
+        end
 
-            unit = find_unit(id)
-            next unless unit
+        if results.size < limit && phase2_queues.any?
+          queues = phase2_queues.values.map(&:dup)
+          catch(:phase2_done) do
+            loop do
+              progressed = false
+              queues.each do |queue|
+                next if queue.empty?
 
-            phase2_scanned += 1
+                throw :phase2_done if results.size >= limit
 
-            if fields.include?('source_code') && unit['source_code'] && pattern.match?(unit['source_code'])
-              results << { identifier: id, type: type_name, match_field: 'source_code' }
-            elsif fields.include?('metadata') && unit['metadata'] && pattern.match?(unit['metadata'].to_json)
-              results << { identifier: id, type: type_name, match_field: 'metadata' }
+                if phase2_scanned >= max_scan
+                  partial = true
+                  throw :phase2_done
+                end
+
+                type_name, id = queue.shift
+                progressed = true
+
+                unit = find_unit(id)
+                next unless unit
+
+                phase2_scanned += 1
+
+                if fields.include?('source_code') && unit['source_code'] && pattern.match?(unit['source_code'])
+                  results << { identifier: id, type: type_name, match_field: 'source_code' }
+                elsif fields.include?('metadata') && unit['metadata'] && pattern.match?(unit['metadata'].to_json)
+                  results << { identifier: id, type: type_name, match_field: 'metadata' }
+                end
+              end
+              break unless progressed
             end
           end
         end

--- a/lib/woods/mcp/index_reader.rb
+++ b/lib/woods/mcp/index_reader.rb
@@ -553,14 +553,18 @@ module Woods
                        neighbors
                      end
 
+          # At max depth, record the node with empty deps so the renderer
+          # doesn't emit an extra level of unexpanded neighbors. The parent
+          # node's deps list already shows this node as a child.
+          will_expand = current_depth < depth
           node_meta = nodes_data[current]
           result_nodes[current] = {
             type: node_meta&.dig('type'),
             depth: current_depth,
-            deps: filtered
+            deps: will_expand ? filtered : []
           }
 
-          next if current_depth >= depth
+          next unless will_expand
 
           filtered.each do |neighbor|
             unless visited.include?(neighbor)

--- a/lib/woods/mcp/renderers/claude_renderer.rb
+++ b/lib/woods/mcp/renderers/claude_renderer.rb
@@ -59,6 +59,12 @@ module Woods
           wrap_xml('recent_changes', super)
         end
 
+        def render_trace_flow(data, **)
+          content = super
+          entry_point = data[:entry_point] || data['entry_point']
+          wrap_xml('trace_flow', content, entry_point: entry_point)
+        end
+
         def render_default(data)
           wrap_xml('result', super)
         end

--- a/lib/woods/mcp/renderers/markdown_renderer.rb
+++ b/lib/woods/mcp/renderers/markdown_renderer.rb
@@ -103,6 +103,11 @@ module Woods
             lines << "- **#{key.tr('_', ' ').capitalize}:** #{manifest[key]}" if manifest[key]
           end
           lines << "- **Total units indexed:** #{manifest['total_units']}" if manifest['total_units']
+          template_engines = fetch_key(data, :template_engines)
+          if template_engines.is_a?(Array) && template_engines.any?
+            lines << "- **Supported template engines:** #{template_engines.join(', ')} " \
+                     '(HAML, Slim, Stimulus, Turbo are not extracted)'
+          end
           lines << ''
 
           counts = manifest['counts']

--- a/lib/woods/mcp/renderers/markdown_renderer.rb
+++ b/lib/woods/mcp/renderers/markdown_renderer.rb
@@ -102,7 +102,7 @@ module Woods
           %w[rails_version ruby_version git_branch git_sha extracted_at].each do |key|
             lines << "- **#{key.tr('_', ' ').capitalize}:** #{manifest[key]}" if manifest[key]
           end
-          lines << "- **Total units:** #{manifest['total_units']}" if manifest['total_units']
+          lines << "- **Total units indexed:** #{manifest['total_units']}" if manifest['total_units']
           lines << ''
 
           counts = manifest['counts']
@@ -120,9 +120,30 @@ module Woods
             lines << '### Summary'
             lines << ''
             lines << summary
+            lines << ''
           end
 
+          lines << structure_denominators_glossary
           lines.join("\n").rstrip
+        end
+
+        # Canonical glossary of the three index denominators that differ
+        # across Woods' tools. Surfaced once in the structure tool so
+        # readers don't have to cross-reference other tools' outputs to
+        # understand why the numbers disagree. Resolves #105.
+        def structure_denominators_glossary
+          <<~GLOSSARY
+            ### Denominators
+
+            - **units_indexed** (manifest.json, `structure` tool) — total
+              ExtractedUnits written by the extractor. Canonical count.
+            - **graph_nodes** (`pagerank`, `dependencies`, `dependents`) —
+              units present in the dependency graph. Excludes orphans
+              that have no incoming or outgoing edges.
+            - **searchable_entries** (`codebase_retrieve`) — retriever-store
+              entries, including per-chunk rows for units long enough to
+              be chunked. Always ≥ units_indexed.
+          GLOSSARY
         end
 
         # ── graph_analysis ──────────────────────────────────────────
@@ -236,7 +257,7 @@ module Woods
           lines = []
           lines << '## PageRank Scores'
           lines << ''
-          lines << "#{fetch_key(data, :total_nodes)} nodes in graph."
+          lines << "Ranking #{fetch_key(data, :total_nodes)} nodes in the dependency graph."
           lines << ''
           lines << '| Rank | Identifier | Type | Score |'
           lines << '|------|-----------|------|-------|'

--- a/lib/woods/mcp/renderers/markdown_renderer.rb
+++ b/lib/woods/mcp/renderers/markdown_renderer.rb
@@ -303,6 +303,15 @@ module Woods
           lines.join("\n").rstrip
         end
 
+        # ── trace_flow ──────────────────────────────────────────────
+
+        # @param data [Hash] Serialized FlowDocument
+        # @return [String] Markdown flow document with a step-by-step operations table
+        def render_trace_flow(data, **)
+          require_relative '../../flow_document'
+          Woods::FlowDocument.from_h(data).to_markdown
+        end
+
         # ── Default fallback ────────────────────────────────────────
 
         # @param data [Object] Any data

--- a/lib/woods/mcp/renderers/markdown_renderer.rb
+++ b/lib/woods/mcp/renderers/markdown_renderer.rb
@@ -105,8 +105,7 @@ module Woods
           lines << "- **Total units indexed:** #{manifest['total_units']}" if manifest['total_units']
           template_engines = fetch_key(data, :template_engines)
           if template_engines.is_a?(Array) && template_engines.any?
-            lines << "- **Supported template engines:** #{template_engines.join(', ')} " \
-                     '(HAML, Slim, Stimulus, Turbo are not extracted)'
+            lines << "- **Supported template engines:** #{template_engines.join(', ')}"
           end
           lines << ''
 

--- a/lib/woods/mcp/renderers/plain_renderer.rb
+++ b/lib/woods/mcp/renderers/plain_renderer.rb
@@ -93,6 +93,10 @@ module Woods
             lines << "  #{key}: #{manifest[key]}" if manifest[key]
           end
           lines << "  units_indexed: #{manifest['total_units']}" if manifest['total_units']
+          template_engines = fetch_key(data, :template_engines)
+          if template_engines.is_a?(Array) && template_engines.any?
+            lines << "  template_engines: #{template_engines.join(', ')} (HAML/Slim/Stimulus/Turbo not extracted)"
+          end
 
           counts = manifest['counts']
           if counts.is_a?(Hash) && counts.any?

--- a/lib/woods/mcp/renderers/plain_renderer.rb
+++ b/lib/woods/mcp/renderers/plain_renderer.rb
@@ -89,9 +89,10 @@ module Woods
           lines << 'Codebase Structure'
           lines << DIVIDER
 
-          %w[rails_version ruby_version git_branch git_sha extracted_at total_units].each do |key|
+          %w[rails_version ruby_version git_branch git_sha extracted_at].each do |key|
             lines << "  #{key}: #{manifest[key]}" if manifest[key]
           end
+          lines << "  units_indexed: #{manifest['total_units']}" if manifest['total_units']
 
           counts = manifest['counts']
           if counts.is_a?(Hash) && counts.any?
@@ -106,6 +107,15 @@ module Woods
             lines << DIVIDER
             lines << summary
           end
+
+          lines << ''
+          lines << DIVIDER
+          lines << 'Denominators:'
+          lines << '  units_indexed     (manifest, structure): total ExtractedUnits written.'
+          lines << '  graph_nodes       (pagerank, dependencies, dependents): units in the graph'
+          lines << '                    (excludes orphans with no incoming/outgoing edges).'
+          lines << '  searchable_entries (codebase_retrieve): retriever-store entries including'
+          lines << '                    per-chunk rows. Always >= units_indexed.'
 
           lines.join("\n").rstrip
         end
@@ -144,7 +154,7 @@ module Woods
 
         def render_pagerank(data, **)
           lines = []
-          lines << "PageRank Scores (#{fetch_key(data, :total_nodes)} nodes)"
+          lines << "PageRank Scores (ranking #{fetch_key(data, :total_nodes)} graph nodes)"
           lines << DIVIDER
 
           results = fetch_key(data, :results, [])

--- a/lib/woods/mcp/renderers/plain_renderer.rb
+++ b/lib/woods/mcp/renderers/plain_renderer.rb
@@ -95,7 +95,7 @@ module Woods
           lines << "  units_indexed: #{manifest['total_units']}" if manifest['total_units']
           template_engines = fetch_key(data, :template_engines)
           if template_engines.is_a?(Array) && template_engines.any?
-            lines << "  template_engines: #{template_engines.join(', ')} (HAML/Slim/Stimulus/Turbo not extracted)"
+            lines << "  template_engines: #{template_engines.join(', ')}"
           end
 
           counts = manifest['counts']

--- a/lib/woods/mcp/server.rb
+++ b/lib/woods/mcp/server.rb
@@ -697,11 +697,13 @@ module Woods
                   description: 'Restrict results to these unit types (model, controller, service, job, mailer, ' \
                                'rails_source, test_mapping, etc.). Overrides the default test_mapping exclusion. ' \
                                'When the unfiltered top-K has no candidate of a requested type, the retriever ' \
-                               'falls back to rank-within-type so the response is never empty when the index ' \
-                               'contains units of that type. The response appends a "Type rank context" table ' \
-                               'with per-type: top_of_type_global_rank, global_k, total_of_type. Caller reads ' \
-                               'those integers to tell a strong match (rank close to 1) from a weak one ' \
-                               '(rank > global_k, shown as —).'
+                               'falls back to rank-within-type so the response is populated whenever units of ' \
+                               'the requested type exist in the index. The response appends a "Type rank ' \
+                               'context" table with per-type: source, rank in unfiltered top-K, global_k, ' \
+                               'total_of_type. Read source to tell the cases apart: in_top_k (strong match), ' \
+                               'within_type_fallback (weak match surfaced by the fallback), outside_top_k ' \
+                               '(index has this type but other requested types filled the result), absent ' \
+                               '(zero units of this type in the index).'
                 },
                 exclude_types: {
                   type: 'array', items: { type: 'string' },

--- a/lib/woods/mcp/server.rb
+++ b/lib/woods/mcp/server.rb
@@ -777,9 +777,9 @@ module Woods
             max_depth = coerce_int.call(depth) || 3
 
             # Prefer the precomputed flow JSON written by FlowPrecomputer during
-            # extraction (gated on `config.precompute_flows`). Query-time
-            # reassembly via FlowAssembler has known gaps against real host-app
-            # metadata — see issue #103 for the follow-up.
+            # extraction (gated on `config.precompute_flows`) — it avoids
+            # re-parsing source on every request. Fall back to query-time
+            # reassembly when no precomputed document exists.
             flow_doc = load_precomputed.call(index_dir, entry_point)
             flow_doc ||= begin
               graph = reader.dependency_graph

--- a/lib/woods/mcp/server.rb
+++ b/lib/woods/mcp/server.rb
@@ -695,7 +695,13 @@ module Woods
                 types: {
                   type: 'array', items: { type: 'string' },
                   description: 'Restrict results to these unit types (model, controller, service, job, mailer, ' \
-                               'rails_source, test_mapping, etc.). Overrides the default test_mapping exclusion.'
+                               'rails_source, test_mapping, etc.). Overrides the default test_mapping exclusion. ' \
+                               'When the unfiltered top-K has no candidate of a requested type, the retriever ' \
+                               'falls back to rank-within-type so the response is never empty when the index ' \
+                               'contains units of that type. The response appends a "Type rank context" table ' \
+                               'with per-type: top_of_type_global_rank, global_k, total_of_type. Caller reads ' \
+                               'those integers to tell a strong match (rank close to 1) from a weak one ' \
+                               '(rank > global_k, shown as —).'
                 },
                 exclude_types: {
                   type: 'array', items: { type: 'string' },

--- a/lib/woods/mcp/server.rb
+++ b/lib/woods/mcp/server.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'json'
 require 'logger'
 require 'mcp'
 require 'open3'
@@ -237,6 +238,30 @@ module Woods
           return Integer(value, 10) if value.is_a?(String) && value.match?(INTEGER_STRING)
 
           raise ArgumentError, "expected integer, got #{value.class}: #{value.inspect}"
+        end
+
+        # Load a precomputed flow document written by FlowPrecomputer, when
+        # `config.precompute_flows` was enabled during extraction. Returns nil
+        # when the entry point is missing a method suffix, the JSON file isn't
+        # on disk, or the file can't be parsed — callers fall back to
+        # FlowAssembler.
+        #
+        # @param index_dir [String]
+        # @param entry_point [String] e.g., "PostsController#create"
+        # @return [Woods::FlowDocument, nil]
+        def load_precomputed_flow(index_dir, entry_point)
+          return nil unless entry_point.to_s.include?('#')
+
+          controller, action = entry_point.split('#', 2)
+          return nil if controller.empty? || action.empty?
+
+          filename = "#{controller.gsub('::', '__')}_#{action}.json"
+          path = File.join(index_dir, 'flows', filename)
+          return nil unless File.exist?(path)
+
+          Woods::FlowDocument.from_h(JSON.parse(File.read(path)))
+        rescue JSON::ParserError, Errno::ENOENT
+          nil
         end
 
         # Apply offset+limit pagination to a single section key within a container hash.
@@ -727,8 +752,10 @@ module Woods
 
         def define_trace_flow_tool(server, reader, index_dir, respond, respond_err, renderer)
           require_relative '../flow_assembler'
+          require_relative '../flow_document'
           require_relative '../dependency_graph'
           coerce_int = method(:coerce_integer)
+          load_precomputed = method(:load_precomputed_flow)
 
           server.define_tool(
             name: 'trace_flow',
@@ -748,13 +775,17 @@ module Woods
             }
           ) do |entry_point:, server_context:, depth: nil|
             max_depth = coerce_int.call(depth) || 3
-            graph = reader.dependency_graph
 
-            assembler = Woods::FlowAssembler.new(
-              graph: graph,
-              extracted_dir: index_dir
-            )
-            flow_doc = assembler.assemble(entry_point, max_depth: max_depth)
+            # Prefer the precomputed flow JSON written by FlowPrecomputer during
+            # extraction (gated on `config.precompute_flows`). Query-time
+            # reassembly via FlowAssembler has known gaps against real host-app
+            # metadata — see issue #103 for the follow-up.
+            flow_doc = load_precomputed.call(index_dir, entry_point)
+            flow_doc ||= begin
+              graph = reader.dependency_graph
+              assembler = Woods::FlowAssembler.new(graph: graph, extracted_dir: index_dir)
+              assembler.assemble(entry_point, max_depth: max_depth)
+            end
 
             respond.call(renderer.render(:trace_flow, flow_doc.to_h))
           rescue StandardError => e

--- a/lib/woods/mcp/server.rb
+++ b/lib/woods/mcp/server.rb
@@ -466,7 +466,7 @@ module Woods
               }
             }
           ) do |server_context:, detail: nil|
-            result = { manifest: reader.manifest }
+            result = { manifest: reader.manifest, template_engines: reader.template_engines }
             result[:summary] = reader.summary if (detail || 'summary') == 'full'
             respond.call(renderer.render(:structure, result))
           end

--- a/lib/woods/retrieval/search_executor.rb
+++ b/lib/woods/retrieval/search_executor.rb
@@ -61,9 +61,15 @@ module Woods
       #   filter — used by {Retriever#retrieve} to rank-within-type when
       #   the unfiltered global top-K had no candidate of the requested type.
       #   Overrides the classifier-derived +target_type+ in filter construction.
+      # @param strategy [Symbol, nil] Override the classifier-selected strategy.
+      #   {Retriever#within_type_fallback} passes +:vector+ here because the
+      #   vector path is the only one that honors +type_filter+; if the
+      #   classifier picked +:keyword+ / +:graph+ / +:direct+ the fallback
+      #   would otherwise silently re-run the same strategy, get filtered to
+      #   empty, and violate the "never empty when units exist" contract.
       # @return [ExecutionResult] Candidates with strategy metadata
-      def execute(query:, classification:, limit: 20, type_filter: nil)
-        strategy = select_strategy(classification)
+      def execute(query:, classification:, limit: 20, type_filter: nil, strategy: nil)
+        strategy ||= select_strategy(classification)
         candidates = run_strategy(
           strategy,
           query: query,

--- a/lib/woods/retrieval/search_executor.rb
+++ b/lib/woods/retrieval/search_executor.rb
@@ -56,10 +56,21 @@ module Woods
       # @param query [String] The original query text
       # @param classification [QueryClassifier::Classification] Classified query
       # @param limit [Integer] Maximum candidates to return
+      # @param type_filter [Array<String>, nil] When set, vector and hybrid
+      #   strategies push this down into the vector store's metadata
+      #   filter — used by {Retriever#retrieve} to rank-within-type when
+      #   the unfiltered global top-K had no candidate of the requested type.
+      #   Overrides the classifier-derived +target_type+ in filter construction.
       # @return [ExecutionResult] Candidates with strategy metadata
-      def execute(query:, classification:, limit: 20)
+      def execute(query:, classification:, limit: 20, type_filter: nil)
         strategy = select_strategy(classification)
-        candidates = run_strategy(strategy, query: query, classification: classification, limit: limit)
+        candidates = run_strategy(
+          strategy,
+          query: query,
+          classification: classification,
+          limit: limit,
+          type_filter: type_filter
+        )
 
         ExecutionResult.new(
           candidates: candidates.first(limit),
@@ -104,17 +115,18 @@ module Woods
       # @param query [String] Original query text
       # @param classification [QueryClassifier::Classification]
       # @param limit [Integer] Max results
+      # @param type_filter [Array<String>, nil] Pushed into vector filters
       # @return [Array<Candidate>]
-      def run_strategy(strategy, query:, classification:, limit:)
+      def run_strategy(strategy, query:, classification:, limit:, type_filter: nil)
         case strategy
         when :vector
-          execute_vector(query, classification: classification, limit: limit)
+          execute_vector(query, classification: classification, limit: limit, type_filter: type_filter)
         when :keyword
           execute_keyword(classification: classification, limit: limit)
         when :graph
           execute_graph(classification: classification, limit: limit)
         when :hybrid
-          execute_hybrid(query, classification: classification, limit: limit)
+          execute_hybrid(query, classification: classification, limit: limit, type_filter: type_filter)
         when :direct
           execute_direct(classification: classification, limit: limit)
         end
@@ -123,9 +135,9 @@ module Woods
       # Vector strategy: embed the query and search by similarity.
       #
       # @return [Array<Candidate>]
-      def execute_vector(query, classification:, limit:)
+      def execute_vector(query, classification:, limit:, type_filter: nil)
         query_vector = @embedding_provider.embed(query)
-        filters = build_vector_filters(classification)
+        filters = build_vector_filters(classification, type_filter: type_filter)
 
         results = @vector_store.search(query_vector, limit: limit, filters: filters)
         results.map do |r|
@@ -209,9 +221,10 @@ module Woods
       # Hybrid strategy: combine vector, keyword, and graph expansion.
       #
       # @return [Array<Candidate>]
-      def execute_hybrid(query, classification:, limit:)
+      def execute_hybrid(query, classification:, limit:, type_filter: nil)
         # Gather from all three sources
-        vector_candidates = execute_vector(query, classification: classification, limit: limit)
+        vector_candidates = execute_vector(query, classification: classification, limit: limit,
+                                                  type_filter: type_filter)
         keyword_candidates = execute_keyword(classification: classification, limit: limit)
 
         # Graph expansion on top vector results
@@ -266,13 +279,23 @@ module Woods
         candidates
       end
 
-      # Build metadata filters for vector search based on classification.
+      # Build metadata filters for vector search based on classification
+      # and an optional explicit type filter from the caller.
+      #
+      # The caller's explicit +type_filter+ overrides classifier-derived
+      # +target_type+ when both are present — the caller opted into a
+      # specific set of types and that intent beats a heuristic.
       #
       # @param classification [QueryClassifier::Classification]
+      # @param type_filter [Array<String>, nil]
       # @return [Hash]
-      def build_vector_filters(classification)
+      def build_vector_filters(classification, type_filter: nil)
         filters = {}
-        filters[:type] = classification.target_type.to_s if classification.target_type
+        if type_filter && !type_filter.empty?
+          filters[:type] = type_filter.map(&:to_s)
+        elsif classification.target_type
+          filters[:type] = classification.target_type.to_s
+        end
         filters
       end
 

--- a/lib/woods/retriever.rb
+++ b/lib/woods/retriever.rb
@@ -61,11 +61,25 @@ module Woods
     #
     #   {
     #     "controller" => {
-    #       top_of_type_global_rank: 3,   # 1-based rank in the unfiltered ranked list, or nil
+    #       source: :in_top_k,            # see enum below
+    #       top_of_type_global_rank: 3,   # 1-based rank in unfiltered ranked, or nil
     #       global_k: 20,                 # size of the unfiltered ranked list
-    #       total_of_type: 183            # total units of that type across the whole index
+    #       total_of_type: 183            # total units of that type in the index
     #     }
     #   }
+    #
+    # +:source+ tells the caller which bucket the type landed in without
+    # forcing them to infer it from nil ranks:
+    #   :in_top_k              — type present in the unfiltered ranked list;
+    #                            strong match.
+    #   :within_type_fallback  — type NOT in the unfiltered ranked list, but
+    #                            the fallback vector search returned
+    #                            candidates of this type. Weak match.
+    #   :outside_top_k         — type NOT in the unfiltered ranked list, has
+    #                            units in the index, but the fallback did
+    #                            not run (other requested types filled the
+    #                            result). No results of this type.
+    #   :absent                — type has zero units in the index.
     #
     # Nil for unfiltered queries.
     RetrievalResult = Struct.new(:context, :sources, :classification, :strategy, :tokens_used, :budget, :trace,
@@ -192,10 +206,10 @@ module Woods
       ranked = @ranker.rank(execution_result.candidates, classification: classification)
 
       type_list = normalize_type_list(types)
-      type_rank_context = type_list ? build_type_rank_context(ranked, type_list) : nil
-      filtered = apply_type_filter(
+      filtered, fallback_ran = apply_type_filter(
         ranked, query, classification, types: types, type_list: type_list, exclude_types: exclude_types
       )
+      type_rank_context = type_list ? build_type_rank_context(ranked, type_list, fallback_ran: fallback_ran) : nil
 
       assembled = assemble_context(filtered, classification, budget)
       trace = build_trace(classification, execution_result, filtered, assembled, start_time)
@@ -299,24 +313,40 @@ module Woods
 
     # Post-rank reject, with rank-within-type fallback when the caller
     # passed a type filter and the global top-K had no candidate of the
-    # requested type(s).
+    # requested type(s). Returns +[filtered, fallback_ran]+ — the second
+    # element drives the :source field on type_rank_context.
     def apply_type_filter(ranked, query, classification, types:, type_list:, exclude_types:)
       filtered = filter_by_type(ranked, types: types, exclude_types: exclude_types)
-      return filtered unless type_list && filtered.empty?
+      return [filtered, false] unless type_list && filtered.empty?
 
-      within_type_fallback(query, classification, type_list, exclude_types)
+      [within_type_fallback(query, classification, type_list, exclude_types), true]
     end
 
     # Rank-within-type fallback query. Pushes the explicit type filter
     # into the executor so the vector store only scores candidates of
     # that type. Used when the global top-K had none of the requested
     # types but the index may still contain them.
+    #
+    # Forces +strategy: :vector+. Only the vector path honors
+    # +type_filter+ — on a keyword/graph/direct-classified query the
+    # default strategy would ignore the filter, return the same
+    # candidates, and silently leave +filtered+ empty. Vector search
+    # works for any classification because we always have the raw
+    # query text.
+    #
+    # Short-circuits to an empty Array when every requested type has
+    # zero units in the index — there is nothing for the fallback to
+    # find, so we skip the extra vector search.
     def within_type_fallback(query, classification, type_list, exclude_types)
+      type_array = type_list.to_a
+      return [] if type_array.all? { |t| total_of_type(t).to_i.zero? }
+
       fallback = @executor.execute(
-        query: query, classification: classification, type_filter: type_list.to_a
+        query: query, classification: classification,
+        type_filter: type_array, strategy: :vector
       )
       ranked = @ranker.rank(fallback.candidates, classification: classification)
-      filter_by_type(ranked, types: type_list.to_a, exclude_types: exclude_types)
+      filter_by_type(ranked, types: type_array, exclude_types: exclude_types)
     end
 
     def build_trace(classification, execution_result, filtered, assembled, start_time)
@@ -337,25 +367,40 @@ module Woods
     # candidate of that type in the ranked list, or nil when no candidate
     # of that type survived ranking. +total_of_type+ is the canonical
     # count from the metadata store — answers "does this type exist in the
-    # index at all?" independent of query match.
+    # index at all?" independent of query match. +source+ labels the bucket
+    # the type landed in so the caller doesn't infer it from a nil rank;
+    # see the RetrievalResult docstring for the four-value enum.
     #
     # @param ranked [Array<Candidate>]
     # @param type_list [Set<String>]
+    # @param fallback_ran [Boolean] Whether rank-within-type fallback ran
     # @return [Hash{String => Hash}]
-    def build_type_rank_context(ranked, type_list)
+    def build_type_rank_context(ranked, type_list, fallback_ran:)
       global_k = ranked.size
       type_list.to_h do |type|
         match_index = ranked.index { |c| candidate_type(c) == type }
         top_rank = match_index ? match_index + 1 : nil
+        total = total_of_type(type)
         [
           type,
           {
+            source: type_source(top_rank, total, fallback_ran: fallback_ran),
             top_of_type_global_rank: top_rank,
             global_k: global_k,
-            total_of_type: total_of_type(type)
+            total_of_type: total
           }
         ]
       end
+    end
+
+    # Pick the :source enum value for a single type based on where its
+    # candidate ended up. See RetrievalResult's docstring for the enum.
+    def type_source(top_rank, total, fallback_ran:)
+      return :in_top_k if top_rank
+      return :absent if total.to_i.zero?
+      return :within_type_fallback if fallback_ran
+
+      :outside_top_k
     end
 
     def total_of_type(type)
@@ -366,17 +411,19 @@ module Woods
 
     # Append a compact markdown summary of +type_rank_context+ to the
     # assembled context string. Machine-readable enough for agents to
-    # parse without a structured response channel.
+    # parse without a structured response channel. :source is the first
+    # column so the common "strong match" case (in_top_k) is visible at
+    # a glance without needing to reason about rank vs global_k.
     def append_type_rank_context(context, type_rank_context)
       return context if type_rank_context.empty?
 
       lines = ['', '### Type rank context', '',
-               '| Type | Top-of-type global rank | Global K | Total in index |',
-               '|------|-------------------------|----------|----------------|']
+               '| Type | Source | Rank in unfiltered top-K | Global K | Total in index |',
+               '|------|--------|--------------------------|----------|----------------|']
       type_rank_context.each do |type, info|
         rank = info[:top_of_type_global_rank] || '—'
         total = info[:total_of_type].nil? ? '?' : info[:total_of_type]
-        lines << "| #{type} | #{rank} | #{info[:global_k]} | #{total} |"
+        lines << "| #{type} | #{info[:source]} | #{rank} | #{info[:global_k]} | #{total} |"
       end
       "#{context}\n#{lines.join("\n")}\n"
     end

--- a/lib/woods/retriever.rb
+++ b/lib/woods/retriever.rb
@@ -55,8 +55,21 @@ module Woods
                                 keyword_init: true)
 
     # The result of a retrieval operation.
+    #
+    # When the caller passed +types:+ to +#retrieve+, +type_rank_context+
+    # is a Hash keyed by requested type name with one entry per type:
+    #
+    #   {
+    #     "controller" => {
+    #       top_of_type_global_rank: 3,   # 1-based rank in the unfiltered ranked list, or nil
+    #       global_k: 20,                 # size of the unfiltered ranked list
+    #       total_of_type: 183            # total units of that type across the whole index
+    #     }
+    #   }
+    #
+    # Nil for unfiltered queries.
     RetrievalResult = Struct.new(:context, :sources, :classification, :strategy, :tokens_used, :budget, :trace,
-                                 keyword_init: true)
+                                 :type_rank_context, keyword_init: true)
 
     # Unit types queried for the structural context overview.
     STRUCTURAL_TYPES = %w[model controller service job mailer component graphql].freeze
@@ -158,7 +171,12 @@ module Woods
 
     # Execute the full retrieval pipeline for a natural language query.
     #
-    # Pipeline: classify -> execute -> rank -> filter -> assemble -> format
+    # Pipeline: classify -> execute -> rank -> filter -> (fallback within-type
+    # when filter emptied everything) -> assemble -> format.
+    #
+    # When +types:+ is set, the response carries +type_rank_context+ —
+    # per-type rank metadata the caller uses to tell a strong match from
+    # a weak one without Woods imposing a score threshold.
     #
     # @param query [String] Natural language query
     # @param budget [Integer] Token budget for context assembly
@@ -169,25 +187,23 @@ module Woods
     # @return [RetrievalResult] Complete retrieval result
     def retrieve(query, budget: 8000, types: nil, exclude_types: nil)
       start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-
       classification = @classifier.classify(query)
       execution_result = @executor.execute(query: query, classification: classification)
       ranked = @ranker.rank(execution_result.candidates, classification: classification)
-      filtered = filter_by_type(ranked, types: types, exclude_types: exclude_types)
-      assembled = assemble_context(filtered, classification, budget)
 
-      elapsed_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(1)
-
-      trace = RetrievalTrace.new(
-        classification: classification,
-        strategy: execution_result.strategy,
-        candidate_count: execution_result.candidates.size,
-        ranked_count: filtered.size,
-        tokens_used: assembled.tokens_used,
-        elapsed_ms: elapsed_ms
+      type_list = normalize_type_list(types)
+      type_rank_context = type_list ? build_type_rank_context(ranked, type_list) : nil
+      filtered = apply_type_filter(
+        ranked, query, classification, types: types, type_list: type_list, exclude_types: exclude_types
       )
 
-      build_result(assembled, classification, execution_result.strategy, budget, trace)
+      assembled = assemble_context(filtered, classification, budget)
+      trace = build_trace(classification, execution_result, filtered, assembled, start_time)
+
+      build_result(
+        assembled: assembled, classification: classification, strategy: execution_result.strategy,
+        budget: budget, trace: trace, type_rank_context: type_rank_context
+      )
     end
 
     private
@@ -265,8 +281,9 @@ module Woods
     # @param strategy [Symbol] Search strategy used
     # @param budget [Integer] Token budget
     # @return [RetrievalResult]
-    def build_result(assembled, classification, strategy, budget, trace = nil)
+    def build_result(assembled:, classification:, strategy:, budget:, trace: nil, type_rank_context: nil)
       context = @formatter ? @formatter.call(assembled.context) : assembled.context
+      context = append_type_rank_context(context, type_rank_context) if type_rank_context
 
       RetrievalResult.new(
         context: context,
@@ -275,8 +292,93 @@ module Woods
         strategy: strategy,
         tokens_used: assembled.tokens_used,
         budget: budget,
-        trace: trace
+        trace: trace,
+        type_rank_context: type_rank_context
       )
+    end
+
+    # Post-rank reject, with rank-within-type fallback when the caller
+    # passed a type filter and the global top-K had no candidate of the
+    # requested type(s).
+    def apply_type_filter(ranked, query, classification, types:, type_list:, exclude_types:)
+      filtered = filter_by_type(ranked, types: types, exclude_types: exclude_types)
+      return filtered unless type_list && filtered.empty?
+
+      within_type_fallback(query, classification, type_list, exclude_types)
+    end
+
+    # Rank-within-type fallback query. Pushes the explicit type filter
+    # into the executor so the vector store only scores candidates of
+    # that type. Used when the global top-K had none of the requested
+    # types but the index may still contain them.
+    def within_type_fallback(query, classification, type_list, exclude_types)
+      fallback = @executor.execute(
+        query: query, classification: classification, type_filter: type_list.to_a
+      )
+      ranked = @ranker.rank(fallback.candidates, classification: classification)
+      filter_by_type(ranked, types: type_list.to_a, exclude_types: exclude_types)
+    end
+
+    def build_trace(classification, execution_result, filtered, assembled, start_time)
+      elapsed_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(1)
+      RetrievalTrace.new(
+        classification: classification,
+        strategy: execution_result.strategy,
+        candidate_count: execution_result.candidates.size,
+        ranked_count: filtered.size,
+        tokens_used: assembled.tokens_used,
+        elapsed_ms: elapsed_ms
+      )
+    end
+
+    # Build per-type rank metadata from the unfiltered global ranked list.
+    #
+    # +top_of_type_global_rank+ is the 1-based position of the first
+    # candidate of that type in the ranked list, or nil when no candidate
+    # of that type survived ranking. +total_of_type+ is the canonical
+    # count from the metadata store — answers "does this type exist in the
+    # index at all?" independent of query match.
+    #
+    # @param ranked [Array<Candidate>]
+    # @param type_list [Set<String>]
+    # @return [Hash{String => Hash}]
+    def build_type_rank_context(ranked, type_list)
+      global_k = ranked.size
+      type_list.to_h do |type|
+        match_index = ranked.index { |c| candidate_type(c) == type }
+        top_rank = match_index ? match_index + 1 : nil
+        [
+          type,
+          {
+            top_of_type_global_rank: top_rank,
+            global_k: global_k,
+            total_of_type: total_of_type(type)
+          }
+        ]
+      end
+    end
+
+    def total_of_type(type)
+      @metadata_store.find_by_type(type).size
+    rescue StandardError
+      nil
+    end
+
+    # Append a compact markdown summary of +type_rank_context+ to the
+    # assembled context string. Machine-readable enough for agents to
+    # parse without a structured response channel.
+    def append_type_rank_context(context, type_rank_context)
+      return context if type_rank_context.empty?
+
+      lines = ['', '### Type rank context', '',
+               '| Type | Top-of-type global rank | Global K | Total in index |',
+               '|------|-------------------------|----------|----------------|']
+      type_rank_context.each do |type, info|
+        rank = info[:top_of_type_global_rank] || '—'
+        total = info[:total_of_type].nil? ? '?' : info[:total_of_type]
+        lines << "| #{type} | #{rank} | #{info[:global_k]} | #{total} |"
+      end
+      "#{context}\n#{lines.join("\n")}\n"
     end
 
     # Build a structural context overview from the metadata store.

--- a/lib/woods/retriever.rb
+++ b/lib/woods/retriever.rb
@@ -383,8 +383,10 @@ module Woods
 
     # Build a structural context overview from the metadata store.
     #
-    # Queries the metadata store for total unit count and counts per type,
-    # producing a summary like "Codebase: 42 units (10 models, 5 controllers, ...)".
+    # Reports +searchable_entries+ (the retriever's native denominator:
+    # one row per vector, including per-chunk rows for long units) rather
+    # than +units_indexed+. The two differ because chunking duplicates
+    # units; see the `structure` tool's glossary for the full picture.
     #
     # @return [String, nil] Overview string, or nil if the store is empty or on error
     def build_structural_context
@@ -396,7 +398,7 @@ module Woods
         "#{count} #{type}s" if count.positive?
       end
 
-      "Codebase: #{total} units (#{type_counts.join(', ')})"
+      "Codebase: #{total} searchable entries (#{type_counts.join(', ')})"
     rescue StandardError
       nil
     end

--- a/lib/woods/storage/pgvector.rb
+++ b/lib/woods/storage/pgvector.rb
@@ -205,7 +205,17 @@ module Woods
             # `@connection.quote` so the quoting story is uniform across the
             # key and value positions and a future regex-relaxation does not
             # silently unlock injection.
-            "metadata->>#{@connection.quote(key_s)} = #{@connection.quote(value.to_s)}"
+            if value.is_a?(Array)
+              # Membership filter. An empty Array would produce `IN ()`
+              # which is a syntax error; emit an always-false predicate
+              # so the query still parses and returns no rows.
+              next 'FALSE' if value.empty?
+
+              quoted = value.map { |v| @connection.quote(v.to_s) }.join(', ')
+              "metadata->>#{@connection.quote(key_s)} IN (#{quoted})"
+            else
+              "metadata->>#{@connection.quote(key_s)} = #{@connection.quote(value.to_s)}"
+            end
           end
           "WHERE #{conditions.join(' AND ')}"
         end

--- a/lib/woods/storage/qdrant.rb
+++ b/lib/woods/storage/qdrant.rb
@@ -323,7 +323,11 @@ module Woods
         # @return [Hash] Qdrant-compatible filter with must conditions
         def build_filter(filters)
           conditions = filters.map do |key, value|
-            { key: key.to_s, match: { value: value } }
+            if value.is_a?(Array)
+              { key: key.to_s, match: { any: value } }
+            else
+              { key: key.to_s, match: { value: value } }
+            end
           end
           { must: conditions }
         end

--- a/lib/woods/storage/vector_store.rb
+++ b/lib/woods/storage/vector_store.rb
@@ -62,9 +62,15 @@ module Woods
 
         # Search for similar vectors using cosine similarity.
         #
+        # Filter values may be scalars (exact match) or Arrays (membership
+        # match — "value ∈ array"). Adapters implement the membership
+        # semantics natively: in-memory loops, pgvector IN (...), Qdrant
+        # `match: { any: [...] }`.
+        #
         # @param query_vector [Array<Float>] The query embedding vector
         # @param limit [Integer] Maximum number of results to return
-        # @param filters [Hash] Optional metadata filters to apply
+        # @param filters [Hash] Optional metadata filters — values may be
+        #   scalars or Arrays
         # @return [Array<SearchResult>] Results sorted by descending similarity
         # @raise [NotImplementedError] if not implemented by adapter
         def search(query_vector, limit: 10, filters: {})
@@ -225,6 +231,12 @@ module Woods
 
         private
 
+        # Match a filter value against a metadata value. Arrays are
+        # membership filters ("any of"); scalars are equality.
+        def filter_match?(filter_value, meta_value)
+          filter_value.is_a?(Array) ? filter_value.include?(meta_value) : filter_value == meta_value
+        end
+
         # Append a new entry to the flat buffer.
         def append(id, vector, metadata)
           idx = @ids.size
@@ -260,7 +272,7 @@ module Woods
               next
             end
             meta = @metadata[idx]
-            unless filters.empty? || filters.all? { |k, v| meta[k] == v }
+            unless filters.empty? || filters.all? { |k, v| filter_match?(v, meta[k]) }
               idx += 1
               next
             end

--- a/spec/cache/cache_store_spec.rb
+++ b/spec/cache/cache_store_spec.rb
@@ -726,6 +726,40 @@ RSpec.describe Woods::Cache::CachedRetriever do
       expect(retriever).to have_received(:retrieve).once
     end
 
+    it 'round-trips type_rank_context through the cache with symbol keys preserved (#108)' do
+      typed_result = Woods::Retriever::RetrievalResult.new(
+        context: '## Ctx', sources: [], classification: nil,
+        strategy: :vector, tokens_used: 10, budget: 8000, trace: nil,
+        type_rank_context: {
+          'controller' => {
+            source: :in_top_k,
+            top_of_type_global_rank: 2,
+            global_k: 20,
+            total_of_type: 183
+          },
+          'service' => {
+            source: :within_type_fallback,
+            top_of_type_global_rank: nil,
+            global_k: 20,
+            total_of_type: 17
+          }
+        }
+      )
+      allow(retriever).to receive(:retrieve)
+        .with('typed query', budget: 8000, types: %w[controller service], exclude_types: nil)
+        .and_return(typed_result)
+
+      # Miss → fills cache.
+      fresh = cached_retriever.retrieve('typed query', types: %w[controller service])
+      # Hit → rehydrates from JSON-normalized store.
+      hit = cached_retriever.retrieve('typed query', types: %w[controller service])
+
+      expect(hit.type_rank_context).to eq(fresh.type_rank_context)
+      expect(hit.type_rank_context['controller'][:source]).to eq(:in_top_k)
+      expect(hit.type_rank_context['service'][:source]).to eq(:within_type_fallback)
+      expect(retriever).to have_received(:retrieve).once
+    end
+
     it 'caches different queries independently' do
       result_a = Woods::Retriever::RetrievalResult.new(
         context: 'A', sources: [], classification: nil,

--- a/spec/fixtures/woods/controllers/PostsController_517acb6e.json
+++ b/spec/fixtures/woods/controllers/PostsController_517acb6e.json
@@ -10,7 +10,7 @@
     "parent_class": "ApplicationController",
     "git": {
       "last_modified": "2026-01-12T10:00:00Z",
-      "author": "dev@example.com"
+      "last_author": "dev@example.com"
     }
   },
   "dependencies": [

--- a/spec/fixtures/woods/models/Comment_44f5e3fb.json
+++ b/spec/fixtures/woods/models/Comment_44f5e3fb.json
@@ -18,7 +18,7 @@
     "parent_class": "ApplicationRecord",
     "git": {
       "last_modified": "2026-01-14T16:00:00Z",
-      "author": "dev@example.com"
+      "last_author": "dev@example.com"
     }
   },
   "dependencies": [

--- a/spec/fixtures/woods/models/Post_a5554622.json
+++ b/spec/fixtures/woods/models/Post_a5554622.json
@@ -18,7 +18,7 @@
     "parent_class": "ApplicationRecord",
     "git": {
       "last_modified": "2026-01-10T08:30:00Z",
-      "author": "dev@example.com"
+      "last_author": "dev@example.com"
     }
   },
   "dependencies": [],

--- a/spec/flow_assembler_spec.rb
+++ b/spec/flow_assembler_spec.rb
@@ -277,6 +277,93 @@ RSpec.describe Woods::FlowAssembler do
       expect(flow.route).to eq({ verb: 'POST', path: '/posts' })
     end
 
+    describe 'realistic host-app controller shape (#103 follow-up)' do
+      # ControllerExtractor writes metadata[:routes] as a Hash keyed by
+      # action (one entry per action, values are Array<Hash>), not as
+      # Array<Hash> with an :action key — see extractors/controller_extractor.rb.
+      # The on-disk source_code is also prepended with a routes and
+      # filters comment block. FlowAssembler needs to handle both shapes.
+
+      let(:real_controller_source) do
+        <<~RUBY
+          # ╔═══════════════════════════════════════════════════════════════════════╗
+          # ║ Routes                                                                 ║
+          # ╚═══════════════════════════════════════════════════════════════════════╝
+          #
+          #   POST    /posts                                        → #create
+          #
+          class PostsController < ApplicationController
+            def create
+              Post.create!(post_params)
+              NotifyJob.perform_later(post.id)
+              render status: :created
+            end
+
+            private
+
+            def post_params
+              params.require(:post).permit(:title)
+            end
+          end
+        RUBY
+      end
+
+      it 'extracts routes from the Hash-keyed-by-action shape the real extractor emits' do
+        write_unit(
+          'PostsController',
+          type: 'controller',
+          source_code: real_controller_source,
+          metadata: {
+            'routes' => {
+              'create' => [{ 'verb' => 'POST', 'path' => '/posts', 'name' => 'posts' }]
+            },
+            'actions' => ['create']
+          }
+        )
+        stub_graph_defaults
+
+        flow = described_class.new(graph: graph, extracted_dir: extracted_dir)
+                              .assemble('PostsController#create')
+
+        expect(flow.route).to eq(verb: 'POST', path: '/posts')
+      end
+
+      it 'extracts operations from controller source with prepended route/filter comments' do
+        write_unit(
+          'PostsController',
+          type: 'controller',
+          source_code: real_controller_source,
+          metadata: {
+            'routes' => { 'create' => [{ 'verb' => 'POST', 'path' => '/posts' }] },
+            'actions' => ['create']
+          }
+        )
+        stub_graph_defaults
+
+        flow = described_class.new(graph: graph, extracted_dir: extracted_dir)
+                              .assemble('PostsController#create')
+
+        operations = flow.steps.first[:operations]
+        targets = operations.map { |op| [op[:type], op[:target], op[:method]] }
+        expect(targets).to include([:call, 'Post', 'create!'])
+        expect(targets).to include([:async, 'NotifyJob', 'perform_later'])
+      end
+
+      it 'returns nil route when the Hash has no entry for the method' do
+        write_unit(
+          'PostsController',
+          type: 'controller',
+          source_code: real_controller_source,
+          metadata: { 'routes' => { 'create' => [{ 'verb' => 'POST', 'path' => '/posts' }] } }
+        )
+        stub_graph_defaults
+
+        flow = described_class.new(graph: graph, extracted_dir: extracted_dir)
+                              .assemble('PostsController#destroy')
+        expect(flow.route).to be_nil
+      end
+    end
+
     it 'returns nil route when no route data exists' do
       write_unit('SomeService', type: 'service', source_code: <<~RUBY)
         class SomeService

--- a/spec/integration/mcp_retrieval_spec.rb
+++ b/spec/integration/mcp_retrieval_spec.rb
@@ -127,8 +127,9 @@ RSpec.describe 'MCP Retrieval Tools Integration', :integration do
       response = call_tool(server, 'codebase_retrieve', query: 'How does the User model work?')
       text = response_text(response)
 
-      # Structural context is "Codebase: N units (X models, ...)"
+      # Structural context is "Codebase: N searchable entries (X models, ...)"
       expect(text).to include('Codebase:')
+      expect(text).to include('searchable entries')
     end
 
     it 'respects a custom budget parameter' do

--- a/spec/integration/retrieval_pipeline_spec.rb
+++ b/spec/integration/retrieval_pipeline_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe 'Retrieval Pipeline Integration', :integration do
       result = retriever.retrieve('How does the User model work?')
 
       expect(result.context).to include('Codebase:')
-      expect(result.context).to include('units')
+      expect(result.context).to include('searchable entries')
     end
   end
 

--- a/spec/mcp/index_reader_spec.rb
+++ b/spec/mcp/index_reader_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'digest'
+require 'fileutils'
+require 'tmpdir'
 require 'woods/dependency_graph'
 require 'woods/mcp/index_reader'
 
@@ -610,6 +613,87 @@ RSpec.describe Woods::MCP::IndexReader do
       expect(results).to include(
         a_hash_including(identifier: 'External::Analytics', type: 'lib')
       )
+    end
+  end
+
+  describe 'Phase-2 scan budget distribution across type directories (#104)' do
+    # Phase 2 used to iterate TYPE_DIRS in order and increment a single
+    # global counter, so a codebase with more than max_scan units in the
+    # early dirs (models, controllers) would starve later dirs like
+    # concerns (pos 13) and test_mappings (pos 31). Interleaving ensures
+    # every populated dir gets a share of the scan budget.
+
+    let(:synthetic_dir) { Dir.mktmpdir('woods-search-budget') }
+    let(:synthetic_reader) { described_class.new(synthetic_dir) }
+
+    before do
+      # Satisfy IndexReader's manifest requirement.
+      File.write(
+        File.join(synthetic_dir, 'manifest.json'),
+        JSON.pretty_generate(total_units: 0, counts: {})
+      )
+
+      # 20 models — enough to exhaust any reasonable scan cap on its own.
+      FileUtils.mkdir_p(File.join(synthetic_dir, 'models'))
+      model_entries = 20.times.map do |i|
+        identifier = "Model#{i}"
+        write_unit(synthetic_dir, 'models', identifier, type: 'model', source: 'class body')
+        { 'identifier' => identifier }
+      end
+      File.write(File.join(synthetic_dir, 'models', '_index.json'), JSON.pretty_generate(model_entries))
+
+      # One concern whose source contains the target phrase. Positionally
+      # 13th in TYPE_DIRS — guaranteed to be starved by linear scan when
+      # max_scan is below ~20 models.
+      FileUtils.mkdir_p(File.join(synthetic_dir, 'concerns'))
+      write_unit(
+        synthetic_dir, 'concerns', 'ApiAuthentication',
+        type: 'concern',
+        source: "module ApiAuthentication\n  def requires_authentication\n    true\n  end\nend"
+      )
+      File.write(
+        File.join(synthetic_dir, 'concerns', '_index.json'),
+        JSON.pretty_generate([{ 'identifier' => 'ApiAuthentication' }])
+      )
+    end
+
+    after { FileUtils.remove_entry(synthetic_dir) if File.directory?(synthetic_dir) }
+
+    def write_unit(base, dir, identifier, type:, source:)
+      digest = Digest::SHA256.hexdigest(identifier)[0, 8]
+      filename = "#{identifier.gsub('::', '__').gsub(/[^a-zA-Z0-9_-]/, '_')}_#{digest}.json"
+      File.write(
+        File.join(base, dir, filename),
+        JSON.pretty_generate(
+          type: type, identifier: identifier, source_code: source,
+          metadata: {}, dependencies: [], dependents: []
+        )
+      )
+    end
+
+    it 'reaches the concerns dir even when models dir alone exceeds max_scan' do
+      original = ENV.delete('WOODS_SEARCH_MAX_SCAN')
+      ENV['WOODS_SEARCH_MAX_SCAN'] = '5'
+      begin
+        result = synthetic_reader.search('requires_authentication', fields: %w[source_code])
+        identifiers = result[:results].map { |r| r[:identifier] }
+        expect(identifiers).to include('ApiAuthentication')
+      ensure
+        ENV.delete('WOODS_SEARCH_MAX_SCAN')
+        ENV['WOODS_SEARCH_MAX_SCAN'] = original if original
+      end
+    end
+
+    it 'still sets :partial when the scan cap actually runs out before all candidates load' do
+      original = ENV.delete('WOODS_SEARCH_MAX_SCAN')
+      ENV['WOODS_SEARCH_MAX_SCAN'] = '3'
+      begin
+        result = synthetic_reader.search('class body', fields: %w[source_code])
+        expect(result[:partial]).to be true
+      ensure
+        ENV.delete('WOODS_SEARCH_MAX_SCAN')
+        ENV['WOODS_SEARCH_MAX_SCAN'] = original if original
+      end
     end
   end
 

--- a/spec/mcp/index_reader_spec.rb
+++ b/spec/mcp/index_reader_spec.rb
@@ -458,6 +458,61 @@ RSpec.describe Woods::MCP::IndexReader do
       result = reader.traverse_dependencies('Comment', depth: 1)
       expect(result[:found]).to be true
     end
+
+    describe 'depth bounding (#109)' do
+      # Seed a 3-hop chain Order → Account → Currency → USD so the
+      # off-by-one is observable on real data. The fixture graph is
+      # too shallow to demonstrate the bug.
+      let(:tmp_dir) { Dir.mktmpdir('woods-traverse-depth') }
+      let(:reader) { described_class.new(tmp_dir) }
+
+      before do
+        File.write(File.join(tmp_dir, 'manifest.json'), JSON.pretty_generate(total_units: 0))
+        File.write(
+          File.join(tmp_dir, 'dependency_graph.json'),
+          JSON.pretty_generate(
+            nodes: {
+              'Order' => { 'type' => 'model' },
+              'Account' => { 'type' => 'model' },
+              'Currency' => { 'type' => 'model' },
+              'USD' => { 'type' => 'model' }
+            },
+            edges: {
+              'Order' => [{ 'target' => 'Account', 'via' => 'belongs_to' }],
+              'Account' => [{ 'target' => 'Currency', 'via' => 'belongs_to' }],
+              'Currency' => [{ 'target' => 'USD', 'via' => 'belongs_to' }]
+            },
+            reverse: {
+              'Account' => ['Order'], 'Currency' => ['Account'], 'USD' => ['Currency']
+            }
+          )
+        )
+      end
+
+      after { FileUtils.remove_entry(tmp_dir) if File.directory?(tmp_dir) }
+
+      it 'at depth: 1 exposes only the root and its immediate children' do
+        result = reader.traverse_dependencies('Order', depth: 1)
+        expect(result[:nodes].keys).to contain_exactly('Order', 'Account')
+        # Account is at max depth, so its own entry has empty deps (its
+        # parent's deps list already shows it as a child).
+        expect(result[:nodes]['Account'][:deps]).to eq([])
+        expect(result[:nodes]['Order'][:deps]).to eq(['Account'])
+      end
+
+      it 'at depth: 2 expands one more level' do
+        result = reader.traverse_dependencies('Order', depth: 2)
+        expect(result[:nodes].keys).to contain_exactly('Order', 'Account', 'Currency')
+        expect(result[:nodes]['Currency'][:deps]).to eq([])
+        expect(result[:nodes]['Account'][:deps]).to eq(['Currency'])
+      end
+
+      it 'at depth: 0 returns only the root with empty deps' do
+        result = reader.traverse_dependencies('Order', depth: 0)
+        expect(result[:nodes].keys).to eq(['Order'])
+        expect(result[:nodes]['Order'][:deps]).to eq([])
+      end
+    end
   end
 
   describe '#traverse_dependents' do

--- a/spec/mcp/index_reader_spec.rb
+++ b/spec/mcp/index_reader_spec.rb
@@ -551,6 +551,35 @@ RSpec.describe Woods::MCP::IndexReader do
       result = results.first
       expect(result).to include(:identifier, :type, :file_path, :last_modified)
     end
+
+    it 'populates :author from metadata.git.last_author (#106)' do
+      results = reader.recent_changes(limit: 1)
+      expect(results.first[:author]).to eq('dev@example.com')
+    end
+
+    it 'leaves :author nil when git metadata has no last_author entry' do
+      Dir.mktmpdir('woods-author-nil') do |tmp|
+        File.write(File.join(tmp, 'manifest.json'), JSON.pretty_generate(total_units: 0))
+        FileUtils.mkdir_p(File.join(tmp, 'models'))
+        File.write(
+          File.join(tmp, 'models', '_index.json'),
+          JSON.pretty_generate([{ 'identifier' => 'Anon' }])
+        )
+        digest = Digest::SHA256.hexdigest('Anon')[0, 8]
+        File.write(
+          File.join(tmp, 'models', "Anon_#{digest}.json"),
+          JSON.pretty_generate(
+            type: 'model', identifier: 'Anon',
+            metadata: { git: { last_modified: '2026-04-01T00:00:00Z' } }
+          )
+        )
+
+        reader = described_class.new(tmp)
+        results = reader.recent_changes(limit: 1)
+        expect(results.first[:identifier]).to eq('Anon')
+        expect(results.first[:author]).to be_nil
+      end
+    end
   end
 
   describe 'previously invisible types' do

--- a/spec/mcp/index_reader_spec.rb
+++ b/spec/mcp/index_reader_spec.rb
@@ -583,6 +583,13 @@ RSpec.describe Woods::MCP::IndexReader do
         expect(results).to be_empty
       end
 
+      it 'returns empty when two of three tokens match but the third does not' do
+        # Both "ActiveRecord" and "Persistence" appear in ActiveRecord::Base;
+        # "nonexistent_marker" does not. The AND semantic must reject.
+        results = reader.framework_sources('ActiveRecord Persistence nonexistent_marker')
+        expect(results).to be_empty
+      end
+
       it 'returns empty for a whitespace-only keyword rather than raising' do
         expect(reader.framework_sources('   ')).to eq([])
       end

--- a/spec/mcp/index_reader_spec.rb
+++ b/spec/mcp/index_reader_spec.rb
@@ -513,6 +513,29 @@ RSpec.describe Woods::MCP::IndexReader do
       expect(result[:file_path]).to include('activerecord')
       expect(result[:metadata]).to include('gem_name' => 'activerecord')
     end
+
+    describe 'multi-word keywords (#107)' do
+      it 'ANDs each whitespace-separated token' do
+        results = reader.framework_sources('ActiveRecord Persistence')
+        identifiers = results.map { |r| r[:identifier] }
+        expect(identifiers).to include('ActiveRecord::Base')
+      end
+
+      it 'returns empty when not all tokens match the same unit' do
+        # "Persistence" lives in ActiveRecord::Base source_code; "controller"
+        # only in ActionController::Base metadata — no unit has both.
+        results = reader.framework_sources('Persistence controller')
+        expect(results).to be_empty
+      end
+
+      it 'returns empty for a whitespace-only keyword rather than raising' do
+        expect(reader.framework_sources('   ')).to eq([])
+      end
+
+      it 'returns empty for an empty keyword' do
+        expect(reader.framework_sources('')).to eq([])
+      end
+    end
   end
 
   describe '#recent_changes' do

--- a/spec/mcp/renderers/claude_renderer_spec.rb
+++ b/spec/mcp/renderers/claude_renderer_spec.rb
@@ -69,6 +69,21 @@ RSpec.describe Woods::MCP::Renderers::ClaudeRenderer do
     end
   end
 
+  describe '#render_trace_flow' do
+    it 'wraps the full markdown flow document in <trace_flow entry_point="...">' do
+      flow = {
+        entry_point: 'PostsController#create',
+        steps: [
+          { unit: 'PostsController#create', operations: [{ type: 'call', target: 'Post', method: 'create!', line: 7 }] }
+        ]
+      }
+      out = renderer.render(:trace_flow, flow)
+      expect(out).to start_with('<trace_flow entry_point="PostsController#create">')
+      expect(out).to include('Post.create!')
+      expect(out).to end_with('</trace_flow>')
+    end
+  end
+
   describe 'empty array / nil data edge cases' do
     it 'renders empty dependency trees without crashing' do
       out = renderer.render(:dependencies, { 'root' => 'X', 'nodes' => {} })

--- a/spec/mcp/renderers/markdown_renderer_spec.rb
+++ b/spec/mcp/renderers/markdown_renderer_spec.rb
@@ -49,6 +49,50 @@ RSpec.describe Woods::MCP::Renderers::MarkdownRenderer do
     end
   end
 
+  describe '#render_trace_flow' do
+    it 'renders each step with a full operations table (not the truncated hash fallback)' do
+      flow = {
+        entry_point: 'PostsController#create',
+        route: { verb: 'POST', path: '/posts' },
+        max_depth: 3,
+        steps: [
+          {
+            unit: 'PostsController#create',
+            type: 'controller',
+            file_path: 'app/controllers/posts_controller.rb',
+            operations: [
+              { type: 'call', target: 'Post', method: 'create!', line: 7 },
+              { type: 'async', target: 'NotifyJob', method: 'perform_later', line: 8 },
+              { type: 'response', status_code: 201, render_method: 'render', line: 9 }
+            ]
+          }
+        ]
+      }
+
+      out = renderer.render(:trace_flow, flow)
+
+      expect(out).to include('POST /posts → PostsController#create')
+      expect(out).to include('### 1. PostsController#create')
+      expect(out).to include('app/controllers/posts_controller.rb')
+      expect(out).to include('| # | Operation | Target | Line |')
+      expect(out).to include('Post.create!')
+      expect(out).to include('NotifyJob.perform_later')
+      expect(out).to include('201 (via render)')
+    end
+
+    it 'accepts string-keyed data (JSON round-trip)' do
+      flow = {
+        'entry_point' => 'X#y',
+        'steps' => [
+          { 'unit' => 'X#y', 'operations' => [{ 'type' => 'call', 'target' => 'Y', 'method' => 'z', 'line' => 1 }] }
+        ]
+      }
+      out = renderer.render(:trace_flow, flow)
+      expect(out).to include('X#y')
+      expect(out).to include('Y.z')
+    end
+  end
+
   describe '#render_default' do
     it 'renders a hash as markdown-style bold keys' do
       out = renderer.render(:totally_unknown, { a: 1, b: 2 })

--- a/spec/mcp/renderers/markdown_renderer_spec.rb
+++ b/spec/mcp/renderers/markdown_renderer_spec.rb
@@ -106,6 +106,15 @@ RSpec.describe Woods::MCP::Renderers::MarkdownRenderer do
       expect(out).to include('graph_nodes')
       expect(out).to include('searchable_entries')
     end
+
+    it 'reports supported template engines and names what is out-of-scope (#86)' do
+      out = renderer.render(:structure, {
+                              manifest: { 'total_units' => 10, 'counts' => {} },
+                              template_engines: [:erb]
+                            })
+      expect(out).to include('**Supported template engines:** erb')
+      expect(out).to include('HAML, Slim, Stimulus, Turbo are not extracted')
+    end
   end
 
   describe '#render_pagerank (#105)' do

--- a/spec/mcp/renderers/markdown_renderer_spec.rb
+++ b/spec/mcp/renderers/markdown_renderer_spec.rb
@@ -107,13 +107,12 @@ RSpec.describe Woods::MCP::Renderers::MarkdownRenderer do
       expect(out).to include('searchable_entries')
     end
 
-    it 'reports supported template engines and names what is out-of-scope (#86)' do
+    it 'reports supported template engines (#86)' do
       out = renderer.render(:structure, {
                               manifest: { 'total_units' => 10, 'counts' => {} },
                               template_engines: [:erb]
                             })
       expect(out).to include('**Supported template engines:** erb')
-      expect(out).to include('HAML, Slim, Stimulus, Turbo are not extracted')
     end
   end
 

--- a/spec/mcp/renderers/markdown_renderer_spec.rb
+++ b/spec/mcp/renderers/markdown_renderer_spec.rb
@@ -93,6 +93,28 @@ RSpec.describe Woods::MCP::Renderers::MarkdownRenderer do
     end
   end
 
+  describe '#render_structure (#105)' do
+    it 'labels the total-units line as "Total units indexed" (units_indexed denominator)' do
+      out = renderer.render(:structure, { manifest: { 'total_units' => 6335, 'counts' => {} } })
+      expect(out).to include('**Total units indexed:** 6335')
+    end
+
+    it 'appends the denominators glossary explaining why counts differ across tools' do
+      out = renderer.render(:structure, { manifest: { 'total_units' => 100, 'counts' => { 'model' => 5 } } })
+      expect(out).to include('### Denominators')
+      expect(out).to include('units_indexed')
+      expect(out).to include('graph_nodes')
+      expect(out).to include('searchable_entries')
+    end
+  end
+
+  describe '#render_pagerank (#105)' do
+    it 'labels the graph denominator explicitly' do
+      out = renderer.render(:pagerank, { total_nodes: 6333, results: [] })
+      expect(out).to include('Ranking 6333 nodes in the dependency graph.')
+    end
+  end
+
   describe '#render_default' do
     it 'renders a hash as markdown-style bold keys' do
       out = renderer.render(:totally_unknown, { a: 1, b: 2 })

--- a/spec/mcp/server_spec.rb
+++ b/spec/mcp/server_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'fileutils'
+require 'tmpdir'
 require 'woods'
 require 'woods/dependency_graph'
+require 'woods/flow_document'
 require 'woods/mcp/server'
 
 RSpec.describe Woods::MCP::Server do
@@ -893,6 +896,98 @@ RSpec.describe Woods::MCP::Server do
       expect(response.error?).to be(true)
       expect(response_text(response)).to include('trace_flow failed')
       expect(response_text(response)).to include('unit not found')
+    end
+
+    context 'with a precomputed flow JSON on disk' do
+      let(:tmp_index_dir) { Dir.mktmpdir('woods-flows') }
+      let(:precomputed_server) do
+        described_class.build(index_dir: tmp_index_dir, response_format: :json, warmup: false)
+      end
+      let(:precomputed_payload) do
+        {
+          entry_point: 'PostsController#create',
+          route: { verb: 'POST', path: '/posts' },
+          max_depth: 3,
+          generated_at: '2026-04-24T00:00:00Z',
+          steps: [
+            {
+              unit: 'PostsController#create',
+              type: 'controller',
+              file_path: 'app/controllers/posts_controller.rb',
+              operations: [
+                { type: 'call', target: 'Post', method: 'create!', line: 7 },
+                { type: 'response', status_code: 201, render_method: 'render', line: 9 }
+              ]
+            }
+          ]
+        }
+      end
+
+      before do
+        FileUtils.mkdir_p(File.join(tmp_index_dir, 'flows'))
+        File.write(
+          File.join(tmp_index_dir, 'manifest.json'),
+          JSON.pretty_generate(total_units: 0, counts: {})
+        )
+        File.write(
+          File.join(tmp_index_dir, 'dependency_graph.json'),
+          JSON.pretty_generate(nodes: {}, edges: {}, reverse: {})
+        )
+        File.write(
+          File.join(tmp_index_dir, 'flows', 'PostsController_create.json'),
+          JSON.pretty_generate(precomputed_payload)
+        )
+      end
+
+      after { FileUtils.remove_entry(tmp_index_dir) if File.directory?(tmp_index_dir) }
+
+      it 'serves the precomputed JSON and bypasses FlowAssembler' do
+        expect(Woods::FlowAssembler).not_to receive(:new)
+
+        response = call_tool(precomputed_server, 'trace_flow', entry_point: 'PostsController#create')
+        data = parse_response(response)
+
+        expect(data['entry_point']).to eq('PostsController#create')
+        expect(data['steps']).not_to be_empty
+        expect(data['steps'].first['operations'].size).to eq(2)
+      end
+
+      it 'falls back to FlowAssembler when no precomputed JSON exists for the entry point' do
+        response = call_tool(precomputed_server, 'trace_flow', entry_point: 'PostsController#destroy')
+        expect(mock_assembler).to have_received(:assemble).with('PostsController#destroy', max_depth: 3)
+        expect(parse_response(response)['entry_point']).to eq('PostsController#create')
+      end
+    end
+
+    describe '.load_precomputed_flow' do
+      let(:tmp_dir) { Dir.mktmpdir('woods-flows-helper') }
+
+      after { FileUtils.remove_entry(tmp_dir) if File.directory?(tmp_dir) }
+
+      it 'returns nil when the entry point has no method suffix' do
+        expect(described_class.send(:load_precomputed_flow, tmp_dir, 'PostsController')).to be_nil
+      end
+
+      it 'returns nil when the file is absent' do
+        expect(described_class.send(:load_precomputed_flow, tmp_dir, 'X#y')).to be_nil
+      end
+
+      it 'translates namespaced controllers via :: → __' do
+        FileUtils.mkdir_p(File.join(tmp_dir, 'flows'))
+        File.write(
+          File.join(tmp_dir, 'flows', 'Admin__PostsController_create.json'),
+          JSON.pretty_generate(entry_point: 'Admin::PostsController#create', steps: [])
+        )
+        doc = described_class.send(:load_precomputed_flow, tmp_dir, 'Admin::PostsController#create')
+        expect(doc).to be_a(Woods::FlowDocument)
+        expect(doc.entry_point).to eq('Admin::PostsController#create')
+      end
+
+      it 'returns nil when the JSON file is corrupt' do
+        FileUtils.mkdir_p(File.join(tmp_dir, 'flows'))
+        File.write(File.join(tmp_dir, 'flows', 'X_y.json'), 'not json')
+        expect(described_class.send(:load_precomputed_flow, tmp_dir, 'X#y')).to be_nil
+      end
     end
   end
 

--- a/spec/retrieval/search_executor_spec.rb
+++ b/spec/retrieval/search_executor_spec.rb
@@ -225,6 +225,62 @@ RSpec.describe Woods::Retrieval::SearchExecutor do
         expect(c.metadata[:type] || c.metadata['type']).to eq('model')
       end
     end
+
+    describe 'explicit type_filter: (#108)' do
+      it 'pushes type_filter down into vector store filters' do
+        classification = classifier.classify('how does auth work?')
+        # type_filter restricts vector search to controllers; returns only
+        # UsersController from the four seeded units.
+        result = executor.execute(
+          query: 'how does auth work?',
+          classification: classification,
+          type_filter: ['controller']
+        )
+        types = result.candidates.map { |c| c.metadata[:type] || c.metadata['type'] }
+        expect(types).to all(eq('controller'))
+        expect(result.candidates.map(&:identifier)).to eq(%w[UsersController])
+      end
+
+      it 'accepts multiple types as an Array' do
+        classification = classifier.classify('how does auth work?')
+        result = executor.execute(
+          query: 'how does auth work?',
+          classification: classification,
+          type_filter: %w[service controller]
+        )
+        types = result.candidates.map { |c| c.metadata[:type] || c.metadata['type'] }
+        expect(types).to all(satisfy { |t| %w[service controller].include?(t) })
+        expect(result.candidates.map(&:identifier)).to contain_exactly('UserService', 'UsersController')
+      end
+
+      it 'overrides classifier-derived target_type when both are present' do
+        # "how does User model work" sets classification.target_type = :model,
+        # but an explicit type_filter: [service] must win.
+        classification = classifier.classify('how does the User model work?')
+        expect(classification.target_type).to eq(:model)
+
+        result = executor.execute(
+          query: 'how does the User model work?',
+          classification: classification,
+          type_filter: ['service']
+        )
+        types = result.candidates.map { |c| c.metadata[:type] || c.metadata['type'] }
+        expect(types).to all(eq('service'))
+      end
+
+      it 'ignores an empty type_filter: falls through to classifier-derived filters' do
+        classification = classifier.classify('how does the User model work?')
+        result = executor.execute(
+          query: 'how does the User model work?',
+          classification: classification,
+          type_filter: []
+        )
+        # With type_filter: [], the classifier's target_type :model still
+        # applies — only model-type candidates come through.
+        types = result.candidates.map { |c| c.metadata[:type] || c.metadata['type'] }
+        expect(types).to all(eq('model'))
+      end
+    end
   end
 
   describe 'keyword strategy execution' do

--- a/spec/retriever_spec.rb
+++ b/spec/retriever_spec.rb
@@ -497,7 +497,7 @@ RSpec.describe Woods::Retriever do
 
       result = retriever.send(:build_structural_context)
 
-      expect(result).to include('Codebase: 42 units')
+      expect(result).to include('Codebase: 42 searchable entries')
     end
 
     it 'includes type counts in overview' do

--- a/spec/retriever_spec.rb
+++ b/spec/retriever_spec.rb
@@ -77,6 +77,10 @@ RSpec.describe Woods::Retriever do
 
     # build_structural_context calls metadata_store.count; default to 0 (nil result)
     allow(metadata_store).to receive(:count).and_return(0)
+    # build_type_rank_context calls find_by_type for each requested type.
+    # Empty Array is the right default — tests that care about the total_of_type
+    # value override per-example.
+    allow(metadata_store).to receive(:find_by_type).and_return([])
   end
 
   # ── #retrieve ──────────────────────────────────────────────────────
@@ -273,6 +277,117 @@ RSpec.describe Woods::Retriever do
       end
 
       retriever.retrieve('stripe webhook signature verification')
+    end
+  end
+
+  # ── #108 rank-within-type + type_rank_context ──────────────────
+
+  describe 'types: rank context (#108)' do
+    let(:ranked_candidates) do
+      [
+        Woods::Retrieval::SearchExecutor::Candidate.new(
+          identifier: 'AuthService', score: 0.92, source: :vector,
+          metadata: { type: 'service' }
+        ),
+        Woods::Retrieval::SearchExecutor::Candidate.new(
+          identifier: 'UsersController', score: 0.85, source: :vector,
+          metadata: { type: 'controller' }
+        ),
+        Woods::Retrieval::SearchExecutor::Candidate.new(
+          identifier: 'SessionsController', score: 0.74, source: :vector,
+          metadata: { type: 'controller' }
+        )
+      ]
+    end
+
+    before do
+      allow(ranker_double).to receive(:rank).and_return(ranked_candidates)
+      allow(metadata_store).to receive(:find_by_type).with('controller').and_return(Array.new(42))
+      allow(metadata_store).to receive(:find_by_type).with('service').and_return(Array.new(17))
+      allow(metadata_store).to receive(:find_by_type).with('mailer').and_return(Array.new(3))
+    end
+
+    it 'returns nil type_rank_context when types: is not set' do
+      result = retriever.retrieve('how does auth work?')
+      expect(result.type_rank_context).to be_nil
+    end
+
+    it 'populates top_of_type_global_rank from the unfiltered ranked list' do
+      result = retriever.retrieve('how does auth work?', types: %w[controller])
+      expect(result.type_rank_context['controller']).to eq(
+        top_of_type_global_rank: 2, # UsersController is rank 2
+        global_k: 3,
+        total_of_type: 42
+      )
+    end
+
+    it 'emits per-type entries for multi-type requests' do
+      result = retriever.retrieve('how does auth work?', types: %w[controller service])
+      expect(result.type_rank_context.keys).to contain_exactly('controller', 'service')
+      expect(result.type_rank_context['service'][:top_of_type_global_rank]).to eq(1)
+      expect(result.type_rank_context['controller'][:top_of_type_global_rank]).to eq(2)
+    end
+
+    it 'leaves top_of_type_global_rank nil when the type is absent from the global ranked list' do
+      result = retriever.retrieve('how does auth work?', types: %w[mailer])
+      expect(result.type_rank_context['mailer']).to eq(
+        top_of_type_global_rank: nil,
+        global_k: 3,
+        total_of_type: 3
+      )
+    end
+
+    it 'falls back to rank-within-type when the global top-K has no candidate of the requested type' do
+      # mailer has zero candidates in the global ranked list. The executor
+      # should be called a second time with type_filter so we return a
+      # mailer rather than empty.
+      mailer_candidate = Woods::Retrieval::SearchExecutor::Candidate.new(
+        identifier: 'UserMailer', score: 0.4, source: :vector,
+        metadata: { type: 'mailer' }
+      )
+      fallback_result = instance_double(
+        Woods::Retrieval::SearchExecutor::ExecutionResult,
+        candidates: [mailer_candidate], strategy: :vector, query: 'how does auth work?'
+      )
+      expect(executor_double).to receive(:execute)
+        .with(hash_including(type_filter: %w[mailer]))
+        .and_return(fallback_result)
+      allow(ranker_double).to receive(:rank).and_return(ranked_candidates, [mailer_candidate])
+
+      expect(assembler_double).to receive(:assemble) do |kwargs|
+        expect(kwargs[:candidates].map(&:identifier)).to eq(%w[UserMailer])
+        assembled_context
+      end
+
+      result = retriever.retrieve('how does auth work?', types: %w[mailer])
+      # type_rank_context reports nil top-of-type — this match wasn't in the
+      # original global top-K; fallback surfaced it.
+      expect(result.type_rank_context['mailer'][:top_of_type_global_rank]).to be_nil
+    end
+
+    it 'does not invoke the fallback query when the global top-K already has the type' do
+      expect(executor_double).not_to receive(:execute).with(hash_including(type_filter: anything))
+      retriever.retrieve('how does auth work?', types: %w[controller])
+    end
+
+    it 'appends a type rank context table to the context string when types: is set' do
+      result = retriever.retrieve('how does auth work?', types: %w[controller])
+      expect(result.context).to include('### Type rank context')
+      expect(result.context).to include('| controller | 2 | 3 | 42 |')
+    end
+
+    it 'records total_of_type: 0 when the index has no units of the requested type' do
+      allow(metadata_store).to receive(:find_by_type).with('policy').and_return([])
+      # with zero of that type in the index, fallback runs but returns nothing
+      empty_fallback = instance_double(
+        Woods::Retrieval::SearchExecutor::ExecutionResult,
+        candidates: [], strategy: :vector, query: 'how does auth work?'
+      )
+      allow(executor_double).to receive(:execute).and_return(empty_fallback)
+      allow(ranker_double).to receive(:rank).and_return(ranked_candidates, [])
+
+      result = retriever.retrieve('how does auth work?', types: %w[policy])
+      expect(result.type_rank_context['policy'][:total_of_type]).to eq(0)
     end
   end
 

--- a/spec/retriever_spec.rb
+++ b/spec/retriever_spec.rb
@@ -315,6 +315,7 @@ RSpec.describe Woods::Retriever do
     it 'populates top_of_type_global_rank from the unfiltered ranked list' do
       result = retriever.retrieve('how does auth work?', types: %w[controller])
       expect(result.type_rank_context['controller']).to eq(
+        source: :in_top_k,
         top_of_type_global_rank: 2, # UsersController is rank 2
         global_k: 3,
         total_of_type: 42
@@ -325,14 +326,43 @@ RSpec.describe Woods::Retriever do
       result = retriever.retrieve('how does auth work?', types: %w[controller service])
       expect(result.type_rank_context.keys).to contain_exactly('controller', 'service')
       expect(result.type_rank_context['service'][:top_of_type_global_rank]).to eq(1)
+      expect(result.type_rank_context['service'][:source]).to eq(:in_top_k)
       expect(result.type_rank_context['controller'][:top_of_type_global_rank]).to eq(2)
+      expect(result.type_rank_context['controller'][:source]).to eq(:in_top_k)
     end
 
-    it 'leaves top_of_type_global_rank nil when the type is absent from the global ranked list' do
+    it 'marks :source as :within_type_fallback when the type is missing from top-K but exists in the index' do
+      # mailer isn't in ranked_candidates; fallback runs with mailer
+      # candidate and the per-type :source reflects that path.
+      mailer_candidate = Woods::Retrieval::SearchExecutor::Candidate.new(
+        identifier: 'UserMailer', score: 0.4, source: :vector,
+        metadata: { type: 'mailer' }
+      )
+      fallback_result = instance_double(
+        Woods::Retrieval::SearchExecutor::ExecutionResult,
+        candidates: [mailer_candidate], strategy: :vector, query: 'how does auth work?'
+      )
+      allow(executor_double).to receive(:execute).and_return(fallback_result)
+      allow(ranker_double).to receive(:rank).and_return(ranked_candidates, [mailer_candidate])
+
       result = retriever.retrieve('how does auth work?', types: %w[mailer])
       expect(result.type_rank_context['mailer']).to eq(
+        source: :within_type_fallback,
         top_of_type_global_rank: nil,
         global_k: 3,
+        total_of_type: 3
+      )
+    end
+
+    it 'marks :source as :outside_top_k when the type exists in the index but fallback did not run' do
+      # Multi-type query where one type is in top-K (controller) and
+      # another isn't (mailer). filtered is non-empty from controllers,
+      # so fallback skips. mailer's :source is :outside_top_k.
+      result = retriever.retrieve('how does auth work?', types: %w[controller mailer])
+      expect(result.type_rank_context['controller'][:source]).to eq(:in_top_k)
+      expect(result.type_rank_context['mailer']).to include(
+        source: :outside_top_k,
+        top_of_type_global_rank: nil,
         total_of_type: 3
       )
     end
@@ -373,10 +403,61 @@ RSpec.describe Woods::Retriever do
     it 'appends a type rank context table to the context string when types: is set' do
       result = retriever.retrieve('how does auth work?', types: %w[controller])
       expect(result.context).to include('### Type rank context')
-      expect(result.context).to include('| controller | 2 | 3 | 42 |')
+      expect(result.context).to include('| controller | in_top_k | 2 | 3 | 42 |')
     end
 
-    it 'records total_of_type: 0 when the index has no units of the requested type' do
+    it 'forces strategy: :vector in the fallback so keyword/graph/direct classifications still surface results' do
+      # Simulate a query the classifier sends to :keyword strategy.
+      # Without a strategy override, the fallback would re-run :keyword
+      # (which ignores type_filter) and come back empty. With the
+      # override, :vector runs and returns a mailer.
+      keyword_classification = instance_double(
+        Woods::Retrieval::QueryClassifier::Classification,
+        intent: :locate, scope: :broad, target_type: nil, keywords: %w[mailer]
+      )
+      allow(classifier_double).to receive(:classify).and_return(keyword_classification)
+
+      mailer_candidate = Woods::Retrieval::SearchExecutor::Candidate.new(
+        identifier: 'UserMailer', score: 0.4, source: :vector,
+        metadata: { type: 'mailer' }
+      )
+      global_result = instance_double(
+        Woods::Retrieval::SearchExecutor::ExecutionResult,
+        candidates: [], strategy: :keyword, query: 'find mailer'
+      )
+      vector_fallback = instance_double(
+        Woods::Retrieval::SearchExecutor::ExecutionResult,
+        candidates: [mailer_candidate], strategy: :vector, query: 'find mailer'
+      )
+      allow(executor_double).to receive(:execute) do |**kwargs|
+        kwargs[:strategy] == :vector ? vector_fallback : global_result
+      end
+      allow(ranker_double).to receive(:rank).and_return([], [mailer_candidate])
+
+      retriever.retrieve('find mailer', types: %w[mailer])
+      expect(executor_double).to have_received(:execute).with(
+        hash_including(strategy: :vector, type_filter: %w[mailer])
+      )
+    end
+
+    it 'skips the fallback entirely when every requested type has 0 units in the index' do
+      allow(metadata_store).to receive(:find_by_type).with('nonexistent').and_return([])
+      empty_result = instance_double(
+        Woods::Retrieval::SearchExecutor::ExecutionResult,
+        candidates: [], strategy: :vector, query: 'x'
+      )
+      # Only the initial (non-fallback) execute call should fire — a
+      # second call would mean we wasted a vector search on a type we
+      # already know doesn't exist.
+      expect(executor_double).to receive(:execute).once.and_return(empty_result)
+      allow(ranker_double).to receive(:rank).and_return([])
+
+      result = retriever.retrieve('x', types: %w[nonexistent])
+      expect(result.type_rank_context['nonexistent'][:source]).to eq(:absent)
+      expect(result.type_rank_context['nonexistent'][:total_of_type]).to eq(0)
+    end
+
+    it 'records total_of_type: 0 and :source :absent when the index has no units of the requested type' do
       allow(metadata_store).to receive(:find_by_type).with('policy').and_return([])
       # with zero of that type in the index, fallback runs but returns nothing
       empty_fallback = instance_double(

--- a/spec/storage/pgvector_spec.rb
+++ b/spec/storage/pgvector_spec.rb
@@ -154,6 +154,18 @@ RSpec.describe Woods::Storage::VectorStore::Pgvector do
       expect(connection).to have_received(:execute).with(/metadata->>'type' = 'model'/)
     end
 
+    it 'translates an Array filter value into IN (...) membership (#108)' do
+      store.search([0.1, 0.2, 0.3], filters: { type: %w[model service] })
+
+      expect(connection).to have_received(:execute).with(/metadata->>'type' IN \('model', 'service'\)/)
+    end
+
+    it 'emits an always-false predicate for an empty Array filter' do
+      store.search([0.1, 0.2, 0.3], filters: { type: [] })
+
+      expect(connection).to have_received(:execute).with(/WHERE FALSE/)
+    end
+
     it 'returns empty array when no results' do
       allow(connection).to receive(:execute).and_return([])
 

--- a/spec/storage/qdrant_spec.rb
+++ b/spec/storage/qdrant_spec.rb
@@ -184,6 +184,18 @@ RSpec.describe Woods::Storage::VectorStore::Qdrant do
         expect(body).not_to have_key('filter')
       end
     end
+
+    it 'translates an Array filter value into match.any membership (#108)' do
+      store.search([0.1, 0.2, 0.3], filters: { type: %w[model service] })
+
+      expect(http).to have_received(:request) do |req|
+        body = JSON.parse(req.body)
+        must_conditions = body['filter']['must']
+        expect(must_conditions).to include(
+          { 'key' => 'type', 'match' => { 'any' => %w[model service] } }
+        )
+      end
+    end
   end
 
   describe '#delete' do

--- a/spec/storage/vector_store_spec.rb
+++ b/spec/storage/vector_store_spec.rb
@@ -103,6 +103,16 @@ RSpec.describe Woods::Storage::VectorStore do
         expect(results).to be_empty
       end
 
+      it 'treats Array filter values as membership (#108)' do
+        results = store.search([1.0, 0.0, 0.0], filters: { type: %w[model service] })
+        expect(results.map(&:id)).to contain_exactly('model_user', 'model_order', 'service_auth')
+      end
+
+      it 'an empty Array filter matches nothing' do
+        results = store.search([1.0, 0.0, 0.0], filters: { type: [] })
+        expect(results).to be_empty
+      end
+
       it 'returns empty array for empty store' do
         empty_store = described_class.new
 


### PR DESCRIPTION
## Summary

This PR implements three major features and fixes:

1. **Type-aware retrieval with rank context (#108)**: When callers pass `types:` to `#retrieve`, the response now includes `type_rank_context` — per-type metadata showing whether each type appeared in the global top-K results, fell back to within-type search, or wasn't found. This lets callers distinguish strong matches from weak ones without imposing score thresholds.

2. **Flow document precomputation (#103)**: The MCP server can now load precomputed flow JSON files (written by `FlowPrecomputer` during extraction) instead of assembling them on-demand. Falls back to `FlowAssembler` when precomputed files don't exist.

3. **Search budget distribution fix (#104)**: Phase 2 of the search pipeline now interleaves scanning across type directories instead of exhausting the budget linearly. This ensures later directories (concerns, test_mappings) get a fair share of the scan budget on large codebases.

Additional fixes:
- Depth bounding in `traverse_dependencies` (#109): Correctly limits traversal to the specified depth
- Multi-word keyword search (#107): AND semantics across whitespace-separated tokens in `framework_sources`
- Author metadata population (#106): Reads `metadata.git.last_author` for recent_changes results
- Template engine reporting (#86): Exposes supported template engines via the structure tool
- UTF-8 encoding fix: Handles Unicode box-drawing characters in controller source code

## Motivation

These changes improve the retrieval pipeline's transparency and correctness:
- Type filtering enables smarter ranking and result interpretation in agent workflows
- Flow precomputation reduces latency for frequently-accessed code paths
- Search budget fairness ensures all code types are discoverable, not just early ones
- Depth bounding and keyword AND semantics fix correctness issues in graph traversal and search

## Changes

### Core Retrieval (#108)
- `Retriever#retrieve` now accepts `types:` parameter and returns `type_rank_context` in results
- `SearchExecutor#execute` accepts `type_filter:` and `strategy:` overrides
- `Retriever#apply_type_filter` implements fallback to within-type search when global top-K is empty
- `Retriever#build_type_rank_context` tracks rank metadata per type (`:in_top_k`, `:within_type_fallback`, `:outside_top_k`, `:absent`)
- Vector store adapters (pgvector, Qdrant, in-memory) support Array filter values for membership matching
- Cache middleware serializes/deserializes `type_rank_context` with symbol key preservation

### Flow Precomputation (#103)
- `MCP::Server.load_precomputed_flow` loads JSON from `flows/` directory
- `FlowAssembler` handles both Hash-keyed-by-action and Array route shapes from real extractors
- UTF-8 encoding fix for reading controller source with Unicode characters
- Markdown and Claude renderers support `render_trace_flow` output

### Search Budget (#104)
- `IndexReader#search` Phase 2 now uses round-robin queue interleaving across type directories
- Prevents early directories from starving later ones (concerns, test_mappings)

### Graph Traversal (#109)
- `IndexReader#traverse_dependencies` correctly respects depth parameter
- Added comprehensive test suite with 3-hop chain to verify off-by-one fixes

### Search & Metadata (#106, #107)
- `IndexReader#framework_sources` implements AND semantics for multi-word keywords
- `IndexReader#recent_changes` populates `:author` from `metadata.git.last_author`
- `IndexReader#template_engines` exposes supported template engines

### Rendering (#86, #105)
- Markdown/plain renderers label total units as "Total units indexed" (clarifies denominator)
- Structure tool appends denominators glossary explaining why counts differ across tools
- Reports supported template engines in structure output

## Testing

- Added 60+ new test cases covering type rank context, flow precomputation, search budget interleaving, depth bounding, multi-word keywords, and author metadata

https://claude.ai/code/session_01JH1pLMXu4xymiB719H4d9Z