### PR TITLE
Extract ERB engine logic into ViewEngines::Erb class

### DIFF
--- a/lib/woods/extractors/view_engines/erb.rb
+++ b/lib/woods/extractors/view_engines/erb.rb
@@ -14,13 +14,24 @@ module Woods
       # HAML / Slim / Turbo implementations will land as sibling classes in
       # this namespace (see issue #110 for the non-goals).
       class Erb
-        # File extensions this engine handles. Checked longest-first so
-        # `.html.erb` wins before the bare `.erb` fallback.
+        # File extensions this engine handles.
         EXTENSIONS = %w[.html.erb .erb].freeze
 
         # Symbol surfaced by {ViewTemplateExtractor.supported_template_engines}
         # and the MCP `structure` tool.
         ENGINE_NAME = :erb
+
+        # @return [Symbol] Engine identifier — stable contract for the
+        #   orchestrator so it never reads {ENGINE_NAME} through
+        #   {Class#const_get}-style reach-through.
+        def name
+          ENGINE_NAME
+        end
+
+        # @return [Array<String>] Extensions this engine handles.
+        def extensions
+          EXTENSIONS
+        end
 
         # Common Rails view helper methods to detect in template source.
         COMMON_HELPERS = %w[

--- a/lib/woods/extractors/view_engines/erb.rb
+++ b/lib/woods/extractors/view_engines/erb.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'set'
+
+module Woods
+  module Extractors
+    module ViewEngines
+      # ERB template engine — owns the ERB-specific parsing surface that
+      # {ViewTemplateExtractor} delegates to. Extension list, partial
+      # filename convention, and the three scan operations (partials,
+      # instance variables, helper calls) all live here so the orchestrator
+      # stays engine-agnostic above the seam.
+      #
+      # HAML / Slim / Turbo implementations will land as sibling classes in
+      # this namespace (see issue #110 for the non-goals).
+      class Erb
+        # File extensions this engine handles. Checked longest-first so
+        # `.html.erb` wins before the bare `.erb` fallback.
+        EXTENSIONS = %w[.html.erb .erb].freeze
+
+        # Symbol surfaced by {ViewTemplateExtractor.supported_template_engines}
+        # and the MCP `structure` tool.
+        ENGINE_NAME = :erb
+
+        # Common Rails view helper methods to detect in template source.
+        COMMON_HELPERS = %w[
+          link_to
+          button_to
+          form_for
+          form_with
+          form_tag
+          image_tag
+          stylesheet_link_tag
+          javascript_include_tag
+          content_for
+          yield
+          render
+          redirect_to
+          truncate
+          pluralize
+          number_to_currency
+          number_to_percentage
+          number_with_delimiter
+          time_ago_in_words
+          distance_of_time_in_words
+          simple_format
+          sanitize
+          raw
+          safe_join
+          content_tag
+          tag
+          mail_to
+          url_for
+          asset_path
+          asset_url
+        ].freeze
+
+        # Whether this engine handles the given file path.
+        #
+        # @param file_path [String]
+        # @return [Boolean]
+        def handles?(file_path)
+          EXTENSIONS.any? { |ext| file_path.end_with?(ext) }
+        end
+
+        # Extract partial names from render calls.
+        #
+        # Matches:
+        # - `render partial: 'foo/bar'`
+        # - `render 'foo/bar'`
+        # - `render :foo`
+        #
+        # @param source [String] Template source code
+        # @return [Array<String>] Partial names
+        def scan_partials(source)
+          partials = Set.new
+
+          source.scan(/render\s+partial:\s*['"]([^'"]+)['"]/).each do |match|
+            partials << match[0]
+          end
+
+          source.scan(/render\s+['"]([^'"]+)['"]/).each do |match|
+            partials << match[0]
+          end
+
+          source.scan(/render\s+:(\w+)/).each do |match|
+            partials << match[0]
+          end
+
+          partials.to_a
+        end
+
+        # Extract instance variables used in the template.
+        #
+        # @param source [String] Template source code
+        # @return [Array<String>] Instance variable names, sorted
+        def scan_instance_variables(source)
+          source.scan(/@[a-zA-Z_]\w*/).uniq.sort
+        end
+
+        # Extract common Rails helper calls from the template.
+        #
+        # @param source [String] Template source code
+        # @return [Array<String>] Helper method names, sorted
+        def scan_helpers(source)
+          found = Set.new
+          COMMON_HELPERS.each do |helper|
+            found << helper if source.match?(/\b#{Regexp.escape(helper)}\b/)
+          end
+          found.to_a.sort
+        end
+
+        # Resolve a partial name to its file identifier.
+        #
+        # Given a render call like `render 'comments/comment'`, resolves to
+        # `comments/_comment.html.erb`.
+        #
+        # @param partial_name [String] The partial name from the render call
+        # @param current_identifier [String] The current template's identifier
+        # @return [String] Resolved partial identifier
+        def resolve_partial_identifier(partial_name, current_identifier)
+          if partial_name.include?('/')
+            dir = File.dirname(partial_name)
+            base = File.basename(partial_name)
+            "#{dir}/_#{base}.html.erb"
+          else
+            dir = File.dirname(current_identifier)
+            if dir == '.'
+              "_#{partial_name}.html.erb"
+            else
+              "#{dir}/_#{partial_name}.html.erb"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/woods/extractors/view_template_extractor.rb
+++ b/lib/woods/extractors/view_template_extractor.rb
@@ -41,7 +41,7 @@ module Woods
       #
       # @return [Array<Symbol>]
       def self.supported_template_engines
-        [ViewEngines::Erb::ENGINE_NAME]
+        @supported_template_engines ||= [ViewEngines::Erb.new.name].freeze
       end
 
       def initialize
@@ -56,7 +56,7 @@ module Woods
       # @return [Array<ExtractedUnit>] List of view template units
       def extract_all
         @directories.flat_map do |dir|
-          files = ViewEngines::Erb::EXTENSIONS.flat_map do |ext|
+          files = @engine.extensions.flat_map do |ext|
             Dir[dir.join("**/*#{ext}")]
           end
           files.uniq.filter_map { |file| extract_view_template_file(file) }
@@ -122,7 +122,7 @@ module Woods
       # @return [Hash]
       def build_metadata(source, file_path, partials)
         {
-          template_engine: @engine.class::ENGINE_NAME.to_s,
+          template_engine: @engine.name.to_s,
           is_partial: partial?(file_path),
           partials_rendered: partials,
           instance_variables: @engine.scan_instance_variables(source),

--- a/lib/woods/extractors/view_template_extractor.rb
+++ b/lib/woods/extractors/view_template_extractor.rb
@@ -2,18 +2,22 @@
 
 require_relative 'shared_dependency_scanner'
 require_relative 'route_helper_resolver'
+require_relative 'view_engines/erb'
 
 module Woods
   module Extractors
-    # ViewTemplateExtractor handles ERB view template extraction.
+    # ViewTemplateExtractor orchestrates view-template extraction across
+    # per-engine implementations under {ViewEngines}.
     #
-    # Scans `app/views/` for `.html.erb` and `.erb` files and produces
-    # one ExtractedUnit per template. Extracts render calls (partials),
-    # instance variables, and helper method usage. Links partials via
-    # dependencies and infers the owning controller from directory structure.
+    # Scans the configured view directories, dispatches each file to the
+    # matching engine, and aggregates per-template results into
+    # {ExtractedUnit}s. The orchestrator owns filesystem walking,
+    # identifier construction, controller inference, route-helper edge
+    # resolution, and dependency assembly. Engine-specific concerns
+    # (parsing templates, resolving partial filenames) live on the engine.
     #
-    # This is an ERB-only MVP — HAML, Slim, and layout inheritance
-    # are not yet supported.
+    # ERB is the only shipped engine today. HAML / Slim / Turbo will land
+    # as sibling classes in {Woods::Extractors::ViewEngines} (issue #110).
     #
     # @example
     #   extractor = ViewTemplateExtractor.new
@@ -24,75 +28,48 @@ module Woods
       include SharedDependencyScanner
       include RouteHelperResolver
 
-      # Template engines this extractor understands. Surfaced through
-      # the MCP `structure` tool so callers can see at a glance what's
-      # covered and what isn't. HAML, Slim, Stimulus, Turbo are
-      # intentionally absent; see docs/EXTRACTOR_REFERENCE.md for the
-      # current coverage boundary.
-      SUPPORTED_TEMPLATE_ENGINES = %i[erb].freeze
-
-      # Directories to scan for view templates
+      # Directories to scan for view templates.
       VIEW_DIRECTORIES = %w[
         app/views
       ].freeze
 
-      # Common Rails view helper methods to detect
-      COMMON_HELPERS = %w[
-        link_to
-        button_to
-        form_for
-        form_with
-        form_tag
-        image_tag
-        stylesheet_link_tag
-        javascript_include_tag
-        content_for
-        yield
-        render
-        redirect_to
-        truncate
-        pluralize
-        number_to_currency
-        number_to_percentage
-        number_with_delimiter
-        time_ago_in_words
-        distance_of_time_in_words
-        simple_format
-        sanitize
-        raw
-        safe_join
-        content_tag
-        tag
-        mail_to
-        url_for
-        asset_path
-        asset_url
-      ].freeze
+      # Template engine names the extraction pipeline currently understands.
+      # Surfaced through the MCP `structure` tool so callers can see at a
+      # glance what's covered and what isn't. The list is derived from the
+      # engines this extractor actually instantiates — not a static
+      # constant — so it stays honest as engines are added or removed.
+      #
+      # @return [Array<Symbol>]
+      def self.supported_template_engines
+        [ViewEngines::Erb::ENGINE_NAME]
+      end
 
       def initialize
         @directories = VIEW_DIRECTORIES.map { |d| Rails.root.join(d) }
                                        .select(&:directory?)
+        @engine = ViewEngines::Erb.new
         build_route_helper_map
       end
 
-      # Extract all ERB view templates
+      # Extract all view templates across the supported engines.
       #
       # @return [Array<ExtractedUnit>] List of view template units
       def extract_all
         @directories.flat_map do |dir|
-          erb_files = Dir[dir.join('**/*.html.erb')] + Dir[dir.join('**/*.erb')]
-          erb_files.uniq.filter_map do |file|
-            extract_view_template_file(file)
+          files = ViewEngines::Erb::EXTENSIONS.flat_map do |ext|
+            Dir[dir.join("**/*#{ext}")]
           end
+          files.uniq.filter_map { |file| extract_view_template_file(file) }
         end
       end
 
-      # Extract a single view template file
+      # Extract a single view template file.
       #
-      # @param file_path [String] Path to the ERB template file
-      # @return [ExtractedUnit, nil] The extracted unit or nil if not ERB
+      # @param file_path [String] Path to the template file
+      # @return [ExtractedUnit, nil] The extracted unit or nil if no engine
+      #   handles the file
       def extract_view_template_file(file_path)
-        return nil unless file_path.end_with?('.erb')
+        return nil unless @engine.handles?(file_path)
 
         source = File.read(file_path)
         identifier = build_identifier(file_path)
@@ -106,7 +83,7 @@ module Woods
 
         unit.namespace = namespace
         unit.source_code = source
-        partials = extract_rendered_partials(source)
+        partials = @engine.scan_partials(source)
         unit.metadata = build_metadata(source, file_path, partials)
         unit.dependencies = build_dependencies(source, file_path, identifier, partials)
 
@@ -145,11 +122,11 @@ module Woods
       # @return [Hash]
       def build_metadata(source, file_path, partials)
         {
-          template_engine: 'erb',
+          template_engine: @engine.class::ENGINE_NAME.to_s,
           is_partial: partial?(file_path),
           partials_rendered: partials,
-          instance_variables: extract_instance_variables(source),
-          helpers_called: extract_helpers(source),
+          instance_variables: @engine.scan_instance_variables(source),
+          helpers_called: @engine.scan_helpers(source),
           loc: source.lines.count { |l| l.strip.length.positive? }
         }
       end
@@ -162,56 +139,6 @@ module Woods
         File.basename(file_path).start_with?('_')
       end
 
-      # Extract partial names from render calls.
-      #
-      # Matches:
-      # - render partial: 'foo/bar'
-      # - render 'foo/bar'
-      # - render :foo
-      #
-      # @param source [String] Template source code
-      # @return [Array<String>] Partial names
-      def extract_rendered_partials(source)
-        partials = Set.new
-
-        # render partial: 'path/to/partial'
-        source.scan(/render\s+partial:\s*['"]([^'"]+)['"]/).each do |match|
-          partials << match[0]
-        end
-
-        # render 'path/to/partial' (string without keyword)
-        source.scan(/render\s+['"]([^'"]+)['"]/).each do |match|
-          partials << match[0]
-        end
-
-        # render :symbol
-        source.scan(/render\s+:(\w+)/).each do |match|
-          partials << match[0]
-        end
-
-        partials.to_a
-      end
-
-      # Extract instance variables used in the template.
-      #
-      # @param source [String] Template source code
-      # @return [Array<String>] Instance variable names
-      def extract_instance_variables(source)
-        source.scan(/@[a-zA-Z_]\w*/).uniq.sort
-      end
-
-      # Extract common Rails helper calls from the template.
-      #
-      # @param source [String] Template source code
-      # @return [Array<String>] Helper method names
-      def extract_helpers(source)
-        found = Set.new
-        COMMON_HELPERS.each do |helper|
-          found << helper if source.match?(/\b#{Regexp.escape(helper)}\b/)
-        end
-        found.to_a.sort
-      end
-
       # Build dependencies for the template.
       #
       # @param source [String] Template source code
@@ -222,46 +149,18 @@ module Woods
       def build_dependencies(source, file_path, identifier, partials)
         deps = []
 
-        # Rendered partials
         partials.each do |partial_name|
-          partial_identifier = resolve_partial_identifier(partial_name, identifier)
+          partial_identifier = @engine.resolve_partial_identifier(partial_name, identifier)
           deps << { type: :view_template, target: partial_identifier, via: :render }
         end
 
-        # Inferred controller
         controller = infer_controller(file_path)
         deps << { type: :controller, target: controller, via: :view_render } if controller
 
-        # Navigation edges (link_to, button_to via _path/_url helpers)
         deps.concat(scan_navigation_dependencies(source, via_type: :link_to))
-
-        # Form destinations (form_with/form_for submitting to a route)
         deps.concat(scan_form_dependencies(source))
 
         deps.uniq { |d| [d[:type], d[:target], d[:via]] }
-      end
-
-      # Resolve a partial name to its file identifier.
-      #
-      # Given a render call like `render 'comments/comment'`, resolves to
-      # `comments/_comment.html.erb`.
-      #
-      # @param partial_name [String] The partial name from the render call
-      # @param current_identifier [String] The current template's identifier
-      # @return [String] Resolved partial identifier
-      def resolve_partial_identifier(partial_name, current_identifier)
-        if partial_name.include?('/')
-          dir = File.dirname(partial_name)
-          base = File.basename(partial_name)
-          "#{dir}/_#{base}.html.erb"
-        else
-          dir = File.dirname(current_identifier)
-          if dir == '.'
-            "_#{partial_name}.html.erb"
-          else
-            "#{dir}/_#{partial_name}.html.erb"
-          end
-        end
       end
 
       # Infer the controller class from the template's directory path.
@@ -271,8 +170,6 @@ module Woods
       def infer_controller(file_path)
         namespace = extract_view_namespace(file_path)
         return nil unless namespace
-
-        # Skip layout-only directories
         return nil if namespace == 'layouts'
 
         parts = namespace.split('/')

--- a/lib/woods/mcp/index_reader.rb
+++ b/lib/woods/mcp/index_reader.rb
@@ -103,14 +103,14 @@ module Woods
       end
 
       # Template engines the extraction pipeline currently understands.
-      # Read from extractor class constants so the list stays honest as
-      # extractors come and go. Each constant must return an Array of
-      # Symbols. Surfaced by the MCP `structure` tool (#86).
+      # Delegates to {ViewTemplateExtractor.supported_template_engines} so
+      # the list stays honest as engines are added or removed. Surfaced by
+      # the MCP `structure` tool (#86).
       #
       # @return [Array<Symbol>]
       def template_engines
         require_relative '../extractors/view_template_extractor'
-        Woods::Extractors::ViewTemplateExtractor::SUPPORTED_TEMPLATE_ENGINES.dup
+        Woods::Extractors::ViewTemplateExtractor.supported_template_engines.dup
       end
 
       # @return [String, nil] SUMMARY.md content, or nil if not present

--- a/spec/extractors/view_engines/erb_spec.rb
+++ b/spec/extractors/view_engines/erb_spec.rb
@@ -6,19 +6,15 @@ require 'woods/extractors/view_engines/erb'
 RSpec.describe Woods::Extractors::ViewEngines::Erb do
   subject(:engine) { described_class.new }
 
-  describe '::EXTENSIONS' do
-    it 'lists both .html.erb and .erb' do
-      expect(described_class::EXTENSIONS).to eq(%w[.html.erb .erb])
-    end
-
-    it 'orders longer suffix first so dispatch can match greedily' do
-      expect(described_class::EXTENSIONS.first).to eq('.html.erb')
+  describe '#extensions' do
+    it 'returns both .html.erb and .erb' do
+      expect(engine.extensions).to contain_exactly('.html.erb', '.erb')
     end
   end
 
-  describe '::ENGINE_NAME' do
+  describe '#name' do
     it 'is :erb' do
-      expect(described_class::ENGINE_NAME).to eq(:erb)
+      expect(engine.name).to eq(:erb)
     end
   end
 
@@ -71,6 +67,10 @@ RSpec.describe Woods::Extractors::ViewEngines::Erb do
     it 'returns an empty array for source with no render calls' do
       expect(engine.scan_partials('<h1>No renders</h1>')).to eq([])
     end
+
+    it 'returns an empty array for empty source' do
+      expect(engine.scan_partials('')).to eq([])
+    end
   end
 
   describe '#scan_instance_variables' do
@@ -86,6 +86,10 @@ RSpec.describe Woods::Extractors::ViewEngines::Erb do
 
     it 'returns an empty array when no ivars are present' do
       expect(engine.scan_instance_variables('<h1>static</h1>')).to eq([])
+    end
+
+    it 'returns an empty array for empty source' do
+      expect(engine.scan_instance_variables('')).to eq([])
     end
   end
 
@@ -105,10 +109,13 @@ RSpec.describe Woods::Extractors::ViewEngines::Erb do
       expect(engine.scan_helpers(source)).not_to include('link_to')
     end
 
-    it 'returns results sorted' do
+    it 'returns results sorted alphabetically' do
       source = '<%= link_to %> <%= image_tag %> <%= button_to %>'
-      result = engine.scan_helpers(source)
-      expect(result).to eq(result.sort)
+      expect(engine.scan_helpers(source)).to eq(%w[button_to image_tag link_to])
+    end
+
+    it 'returns an empty array for empty source' do
+      expect(engine.scan_helpers('')).to eq([])
     end
   end
 

--- a/spec/extractors/view_engines/erb_spec.rb
+++ b/spec/extractors/view_engines/erb_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'woods/extractors/view_engines/erb'
+
+RSpec.describe Woods::Extractors::ViewEngines::Erb do
+  subject(:engine) { described_class.new }
+
+  describe '::EXTENSIONS' do
+    it 'lists both .html.erb and .erb' do
+      expect(described_class::EXTENSIONS).to eq(%w[.html.erb .erb])
+    end
+
+    it 'orders longer suffix first so dispatch can match greedily' do
+      expect(described_class::EXTENSIONS.first).to eq('.html.erb')
+    end
+  end
+
+  describe '::ENGINE_NAME' do
+    it 'is :erb' do
+      expect(described_class::ENGINE_NAME).to eq(:erb)
+    end
+  end
+
+  describe '#handles?' do
+    it 'matches .html.erb' do
+      expect(engine.handles?('app/views/users/index.html.erb')).to be true
+    end
+
+    it 'matches bare .erb' do
+      expect(engine.handles?('app/views/mailers/welcome.erb')).to be true
+    end
+
+    it 'rejects .haml' do
+      expect(engine.handles?('app/views/users/show.html.haml')).to be false
+    end
+
+    it 'rejects .slim' do
+      expect(engine.handles?('app/views/users/show.html.slim')).to be false
+    end
+  end
+
+  describe '#scan_partials' do
+    it 'extracts render partial: "path" form' do
+      source = "<%= render partial: 'comments/comment' %>"
+      expect(engine.scan_partials(source)).to eq(['comments/comment'])
+    end
+
+    it 'extracts bare render "path" form' do
+      source = "<%= render 'shared/sidebar' %>"
+      expect(engine.scan_partials(source)).to eq(['shared/sidebar'])
+    end
+
+    it 'extracts render :symbol form' do
+      source = '<%= render :header %>'
+      expect(engine.scan_partials(source)).to eq(['header'])
+    end
+
+    it 'handles all three forms in the same template without duplicates' do
+      source = <<~ERB
+        <%= render partial: 'comments/comment' %>
+        <%= render 'shared/sidebar' %>
+        <%= render :header %>
+        <%= render 'shared/sidebar' %>
+      ERB
+      expect(engine.scan_partials(source)).to contain_exactly(
+        'comments/comment', 'shared/sidebar', 'header'
+      )
+    end
+
+    it 'returns an empty array for source with no render calls' do
+      expect(engine.scan_partials('<h1>No renders</h1>')).to eq([])
+    end
+  end
+
+  describe '#scan_instance_variables' do
+    it 'extracts @ivars in sorted order' do
+      source = '<p><%= @user.name %> <%= @articles.count %> <%= @user.email %></p>'
+      expect(engine.scan_instance_variables(source)).to eq(%w[@articles @user])
+    end
+
+    it 'deduplicates repeated ivars' do
+      source = '<%= @a %> <%= @a %>'
+      expect(engine.scan_instance_variables(source)).to eq(['@a'])
+    end
+
+    it 'returns an empty array when no ivars are present' do
+      expect(engine.scan_instance_variables('<h1>static</h1>')).to eq([])
+    end
+  end
+
+  describe '#scan_helpers' do
+    it 'detects common Rails helpers' do
+      source = <<~ERB
+        <%= link_to 'X', path %>
+        <%= image_tag photo %>
+        <%= number_to_currency price %>
+      ERB
+      expect(engine.scan_helpers(source)).to include('link_to', 'image_tag', 'number_to_currency')
+    end
+
+    it 'uses word boundaries to avoid false positives inside other identifiers' do
+      # `my_link_to_thing` contains "link_to" but shouldn't match as a helper
+      source = '<%= my_link_to_thing %>'
+      expect(engine.scan_helpers(source)).not_to include('link_to')
+    end
+
+    it 'returns results sorted' do
+      source = '<%= link_to %> <%= image_tag %> <%= button_to %>'
+      result = engine.scan_helpers(source)
+      expect(result).to eq(result.sort)
+    end
+  end
+
+  describe '#resolve_partial_identifier' do
+    it 'resolves namespaced partial paths to their file identifier' do
+      result = engine.resolve_partial_identifier('comments/comment', 'posts/show.html.erb')
+      expect(result).to eq('comments/_comment.html.erb')
+    end
+
+    it 'resolves bare partial names relative to the current template directory' do
+      result = engine.resolve_partial_identifier('comment', 'posts/show.html.erb')
+      expect(result).to eq('posts/_comment.html.erb')
+    end
+
+    it 'handles bare partials in the root view directory' do
+      result = engine.resolve_partial_identifier('sidebar', 'index.html.erb')
+      expect(result).to eq('_sidebar.html.erb')
+    end
+  end
+end

--- a/spec/extractors/view_template_extractor_spec.rb
+++ b/spec/extractors/view_template_extractor_spec.rb
@@ -11,6 +11,12 @@ require 'woods/extractors/view_template_extractor'
 RSpec.describe Woods::Extractors::ViewTemplateExtractor do
   include_context 'extractor setup'
 
+  describe '.supported_template_engines' do
+    it 'returns the engine names currently wired into the orchestrator' do
+      expect(described_class.supported_template_engines).to eq([:erb])
+    end
+  end
+
   describe '#extract_all' do
     context 'when app/views/ does not exist' do
       it 'returns an empty array' do


### PR DESCRIPTION
## Summary

Refactor `ViewTemplateExtractor` to delegate ERB-specific parsing logic to a new `ViewEngines::Erb` engine class. This establishes the architectural seam needed to support additional template engines (HAML, Slim, Turbo) as sibling implementations in the `ViewEngines` namespace.

## Motivation

The current `ViewTemplateExtractor` mixes orchestration concerns (filesystem walking, identifier construction, controller inference) with ERB-specific parsing (partial extraction, instance variable scanning, helper detection). This makes it difficult to add new template engines without duplicating orchestration logic.

By extracting ERB logic into a dedicated engine class, we:
- Create a clear interface for new engines to implement
- Keep the orchestrator engine-agnostic
- Enable future engines (HAML, Slim, Turbo) to land as sibling classes without modifying the extractor
- Improve testability of engine-specific behavior

Addresses issue #110 (template engine extensibility).

## Changes

- **New file: `lib/woods/extractors/view_engines/erb.rb`**
  - `Erb` class owns all ERB-specific parsing: `scan_partials`, `scan_instance_variables`, `scan_helpers`, `resolve_partial_identifier`
  - Defines `EXTENSIONS` (`.html.erb`, `.erb`), `ENGINE_NAME` (`:erb`), and `COMMON_HELPERS` constant
  - Implements `handles?(file_path)` to support engine dispatch

- **Modified: `lib/woods/extractors/view_template_extractor.rb`**
  - Removed `SUPPORTED_TEMPLATE_ENGINES` constant; replaced with `supported_template_engines` class method that delegates to wired engines
  - Removed ERB-specific methods: `extract_rendered_partials`, `extract_instance_variables`, `extract_helpers`, `resolve_partial_identifier`
  - Instantiate `@engine = ViewEngines::Erb.new` in `initialize`
  - Updated `extract_all` to use `@engine.handles?` and `ViewEngines::Erb::EXTENSIONS` for file discovery
  - Delegate parsing to engine: `@engine.scan_partials`, `@engine.scan_instance_variables`, `@engine.scan_helpers`, `@engine.resolve_partial_identifier`
  - Updated docstring to reflect orchestrator role and future engine extensibility

- **Modified: `lib/woods/mcp/index_reader.rb`**
  - Updated `template_engines` method to call `ViewTemplateExtractor.supported_template_engines` instead of reading a static constant

- **New file: `spec/extractors/view_engines/erb_spec.rb`**
  - Comprehensive unit tests for `Erb` engine: `handles?`, `scan_partials`, `scan_instance_variables`, `scan_helpers`, `resolve_partial_identifier`

- **Modified: `spec/extractors/view_template_extractor_spec.rb`**
  - Added test for `supported_template_engines` class method

## Testing

- Added 131 lines of unit tests covering the new `Erb` engine class (file extension matching, partial extraction, instance variable scanning, helper detection, partial identifier resolution)
- Existing `ViewTemplateExtractor` tests continue to pass with the refactored implementation
- New test verifies `supported_template_engines` returns `[:erb]`

## Checklist

- [x] Tests added/updated
- [x] `bundle exec rake spec` passes
- [x] `bundle exec rubocop` passes
- [ ] CHANGELOG.md updated (not a user-facing change)
- [x] Documentation updated (docstrings clarify orchestrator vs. engine responsibilities)

https://claude.ai/code/session_01MShn8Awbb2ZYbbnCAnpX7u