### PR TITLE
Document MySQL vector pairing (#83 docs subset) + fix #21 tag comment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,6 @@ jobs:
       - name: Push to RubyGems
         run: gem push woods-*.gem
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           generate_release_notes: true

--- a/docs/BACKEND_MATRIX.md
+++ b/docs/BACKEND_MATRIX.md
@@ -33,6 +33,17 @@ The shape determines the capability matrix:
 
 ## Vector Stores
 
+### Database compatibility
+
+The vector store you can use depends on the primary database your Rails app uses. MySQL stacks **must** pair with an external vector backend; PostgreSQL stacks have the option of running pgvector inside the same database.
+
+| Primary database | Supported vector stores | Required? |
+|---|---|---|
+| **MySQL / Percona / MariaDB / Aurora MySQL** | `:qdrant`, `:pinecone` (external), `:sqlite` (local dev only) | Yes — MySQL has no native vector extension |
+| **PostgreSQL / Aurora PostgreSQL** | `:pgvector` (in-database), `:qdrant`, `:pinecone`, `:sqlite` (local dev only) | No — `:pgvector` runs inside the same database |
+
+**Why MySQL needs an external backend.** MySQL ships no equivalent of the `pgvector` extension. Approximate-nearest-neighbour search over arbitrary float vectors is not part of the InnoDB / MyISAM storage engines and cannot be added via plugin. Woods does not emulate vector search in MySQL — the gem only ships adapters that delegate to a real vector engine. The recommended pairing is `:mysql` (metadata + graph) + `:qdrant` (vectors); the [MySQL section below](#mysql) covers this stack end to end.
+
 ### pgvector (PostgreSQL Extension)
 
 **What it is:** PostgreSQL extension that adds vector similarity search directly to Postgres.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -276,6 +276,44 @@ console_sample(model: "Order", scope: { created_at: { gte: "2025-01-01" } })
 
 ## Embedding Problems
 
+### Configuring vector search on MySQL
+
+**Symptom:** You're on MySQL (or Percona / MariaDB / Aurora MySQL) and `config.vector_store = :pgvector` fails at boot, or you can't find a `:mysql` vector adapter in `lib/woods/storage/`.
+
+**Cause:** MySQL has no native vector-search extension equivalent to `pgvector`. Woods does not emulate vector search in MySQL — every vector adapter the gem ships delegates to a real vector engine. The metadata + graph layer happily lives in MySQL (`config.metadata_store = :mysql`, recursive CTEs on 8.0+), but vectors have to go somewhere else.
+
+**Fix:** Pair MySQL with one of the supported external vector backends. Qdrant is the recommended default for self-hosted / Docker stacks:
+
+```ruby
+# config/initializers/woods.rb — MySQL host with Qdrant for vectors
+Woods.configure do |config|
+  config.metadata_store = :mysql
+  config.metadata_store_connection = ENV.fetch("DATABASE_URL")
+
+  config.vector_store = :qdrant
+  config.vector_store_url = ENV.fetch("QDRANT_URL", "http://localhost:6333")
+end
+```
+
+The Postgres equivalent (in-database vectors) is shown for contrast:
+
+```ruby
+# PostgreSQL host with pgvector for vectors
+Woods.configure do |config|
+  config.metadata_store = :postgresql
+  config.metadata_store_connection = ENV.fetch("DATABASE_URL")
+
+  config.vector_store = :pgvector
+  config.vector_store_connection = ENV.fetch("DATABASE_URL")
+end
+```
+
+For local development against a MySQL app, `config.vector_store = :sqlite` (or `:in_memory` with the `:shared_filesystem` preset) is a reasonable stand-in — it keeps the dev environment dependency-free at the cost of not exercising the production vector engine. Production MySQL stacks should run Qdrant (or Pinecone for managed environments).
+
+See [`docs/BACKEND_MATRIX.md`](BACKEND_MATRIX.md#database-compatibility) for the full matrix and the [MySQL section](BACKEND_MATRIX.md#mysql) for graph-traversal details (recursive CTEs on 8.0+).
+
+---
+
 ### "Dimension mismatch" error when querying embeddings
 
 **Symptom:** `codebase_retrieve` raises an error about vector dimensions not matching.


### PR DESCRIPTION
## Summary

- **#83 docs subset**: Surface the "MySQL must pair with Qdrant/Pinecone/FAISS for vectors" constraint where readers will actually hit it — a new "Database compatibility" table at the top of `BACKEND_MATRIX.md` Vector Stores, plus a "Configuring vector search on MySQL" entry in `TROUBLESHOOTING.md` (MySQL+Qdrant config first, Postgres+pgvector second per `.claude/rules/docs.md`).
- **#21 follow-up**: dependabot bumped the `softprops/action-gh-release` SHA to v3.0.0 but didn't refresh the trailing `# v2` tag comment. One-line fix.

#83 stays open to track the remaining (non-docs) suggested scope: `:mysql_qdrant` preset and integration spec.

## Test plan

- [ ] Confirm CI is green
- [ ] Skim rendered `docs/BACKEND_MATRIX.md` — new "Database compatibility" subsection sits between the `## Vector Stores` heading and `### pgvector`
- [ ] Skim rendered `docs/TROUBLESHOOTING.md` — new entry appears under "Embedding Problems" before "Dimension mismatch"