### PR TITLE
chore(release): prepare v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-06-10
+
 ### Added — Incremental Unblocked sync (PR #128)
 
 - **`woods:unblocked_sync` is now incremental.** A new `Woods::Unblocked::SyncManifest`

--- a/lib/woods/version.rb
+++ b/lib/woods/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Woods
-  VERSION = '1.3.0'
+  VERSION = '1.4.0'
 end


### PR DESCRIPTION
Stamps `Woods::VERSION = '1.4.0'` and dates the CHANGELOG entry for the incremental Unblocked sync (#128).

Merging this, then tagging `v1.4.0`, triggers the release workflow (RubyGems publish + GitHub release).