### PR TITLE
fix(unblocked): disambiguate URIs when multiple units share one file (#130)

### DIFF
--- a/.claude/skills/unblocked-sync/SKILL.md
+++ b/.claude/skills/unblocked-sync/SKILL.md
@@ -70,6 +70,8 @@ agent-facing operational map.
 |---------|--------------|
 | Everything re-pushes every run | Manifest not persisted between CI runs (cache restore missing), OR a `DocumentBuilder` change altered all bodies, OR nondeterministic body output (unsorted collection — check any new `build_*` method) |
 | `0 synced, N skipped`, but docs stale in Unblocked | Hash matched stale manifest from another checkout — delete the manifest to force reconcile |
+| A few units re-push every warm run; manifest entry count < synced | Multiple units share one `file_path` (nested/namespaced classes, several classes per `.rb`). `build_uri_index` disambiguates them (`?unit=` suffix on all but the lexically-first identifier) — if it regresses, those units collide on one URI again |
+| A unit's document is missing from the collection (only one of N co-located classes present) | Same file-sharing collision overwriting on a shared URI — `build_uri_index` is the fix |
 | `WARNING: refusing to delete X of Y documents` | Partial index — sync against full extraction output. Or an *intentional* large removal (type dropped from FULL_SYNC_TYPES, `unblocked_repo_url` change, big deletion): re-run once with `UNBLOCKED_FORCE_PURGE=1` |
 | `daily budget exhausted` | >1000 calls today. Cold start needs ~1005 for ~1000 docs; converges next run. Raise `UNBLOCKED_DAILY_BUDGET` only if the plan allows |
 | Bare `400 Bad Request` on create_collection | Missing `iconUrl` (live-API quirk) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Unblocked sync: multiple units sharing one file no longer collide on a single
+  URI** (#130). A document's URI derives from `file_path`, so a file defining
+  several extracted units (nested/namespaced classes, STI subclasses, multiple
+  classes in one `.rb`) mapped every unit to the same URI — the remote document
+  was overwritten per unit (only the last survived) and, under the content-hash
+  manifest, those units re-pushed on every run. The exporter now detects files
+  shared by more than one synced unit and disambiguates: the lexically-first
+  identifier keeps the bare blob URL, siblings get a `?unit=<identifier>` suffix.
+  Solo files (the overwhelming majority) are untouched. Sibling of the
+  no-`file_path` guard shipped in 1.4.0.
+
 ## [1.4.0] - 2026-06-10
 
 ### Added — Incremental Unblocked sync (PR #128)

--- a/lib/woods/unblocked/exporter.rb
+++ b/lib/woods/unblocked/exporter.rb
@@ -2,6 +2,7 @@
 
 require 'set'
 require 'digest'
+require 'uri'
 require 'woods'
 require_relative 'client'
 require_relative 'rate_limiter'
@@ -83,6 +84,9 @@ module Woods
         # sync_type_partial methods work standalone (track_uri needs them).
         @current_uris = Set.new
         @budget_exhausted = false
+        # base URI => identifier that keeps the bare URI (only populated for
+        # URIs shared by >1 unit). Rebuilt per sync_all run.
+        @uri_primary = {}
       end
 
       # Sync all configured unit types to the Unblocked collection.
@@ -91,6 +95,7 @@ module Woods
       def sync_all
         @current_uris = Set.new
         @budget_exhausted = false
+        build_uri_index
         reconcile_from_remote if @manifest.empty?
 
         synced = 0
@@ -232,6 +237,11 @@ module Woods
         # ping-pong the manifest hash forever. Skip them.
         return :skipped unless unit_data['file_path']
 
+        # When several units share one file they share one base URI; only one
+        # keeps it, the rest get a `?unit=` suffix so each is a distinct remote
+        # document (and a distinct manifest key).
+        uri = effective_uri(unit_data)
+
         doc = @builder.build(unit_data)
         # An empty body means the credential scrub failed closed (the builders
         # always emit at least a header). Upserting it would overwrite a good
@@ -241,16 +251,16 @@ module Woods
         end
 
         hash = fingerprint(doc)
-        return :skipped if !@force_full && @manifest.unchanged?(doc[:uri], hash)
+        return :skipped if !@force_full && @manifest.unchanged?(uri, hash)
 
         response = @client.put_document(
           collection_id: @collection_id,
           title: doc[:title],
           body: doc[:body],
-          uri: doc[:uri]
+          uri: uri
         )
-        document_id = (response['id'] if response.is_a?(Hash)) || @manifest.document_id_for(doc[:uri])
-        @manifest.record(uri: doc[:uri], hash: hash, document_id: document_id)
+        document_id = (response['id'] if response.is_a?(Hash)) || @manifest.document_id_for(uri)
+        @manifest.record(uri: uri, hash: hash, document_id: document_id)
         :synced
       end
 
@@ -360,7 +370,47 @@ module Woods
         # stale repo-root document from before this guard should purge.
         return unless unit_data['file_path']
 
-        @current_uris << @builder.uri_for(unit_data)
+        # Must match the URI push_document actually uses, or a colliding unit's
+        # disambiguated document would look stale and be purged.
+        @current_uris << effective_uri(unit_data)
+      end
+
+      # The URI a unit's document is stored under. Normally the file's blob URL;
+      # when several units share that file, all but the lexically-first
+      # identifier get a `?unit=` suffix so each keeps a distinct document
+      # rather than overwriting the others (see #build_uri_index).
+      def effective_uri(unit_data)
+        base = @builder.uri_for(unit_data)
+        primary = @uri_primary[base]
+        return base if primary.nil? || primary == unit_data['identifier']
+
+        "#{base}?unit=#{URI.encode_www_form_component(unit_data['identifier'])}"
+      end
+
+      # One cheap pass over the type indexes (entries already carry file_path,
+      # and read_index is cached) to find files that define more than one synced
+      # unit. For each such base URI, the lexically-smallest identifier — the
+      # outer/top-level class — keeps the bare URI; siblings are suffixed. Solo
+      # files (the overwhelming majority) are absent from the map and unchanged,
+      # so this introduces no churn for them.
+      def build_uri_index
+        groups = Hash.new { |h, k| h[k] = [] }
+        synced_types.each do |type|
+          @reader.list_units(type: type).each do |entry|
+            next unless entry['file_path']
+
+            groups[@builder.uri_for(entry)] << entry['identifier']
+          end
+        end
+
+        @uri_primary = groups.each_with_object({}) do |(uri, identifiers), primary|
+          unique = identifiers.uniq
+          primary[uri] = unique.min if unique.size > 1
+        end
+      end
+
+      def synced_types
+        FULL_SYNC_TYPES + PARTIAL_SYNC_TYPES.map(&:first)
       end
 
       def fingerprint(doc)

--- a/spec/unblocked/exporter_spec.rb
+++ b/spec/unblocked/exporter_spec.rb
@@ -574,6 +574,80 @@ RSpec.describe Woods::Unblocked::Exporter do
       end
     end
 
+    context 'when multiple units share one file_path (URI collision)' do
+      # Two model units defined in one file — e.g. an outer class and a nested
+      # one. Both resolve to the same blob URI; without disambiguation they
+      # overwrite each other remotely (only the last survives) and ping-pong
+      # the manifest hash every run.
+      let(:shared_path) { 'app/models/order.rb' }
+      let(:base_uri) { uri_for(shared_path) }
+
+      def stub_colliding_pair # rubocop:disable Metrics/AbcSize
+        entries = [
+          { 'identifier' => 'Order', 'type' => 'model', 'file_path' => shared_path },
+          { 'identifier' => 'Order::Line', 'type' => 'model', 'file_path' => shared_path }
+        ]
+        allow(reader).to receive(:list_units).and_return([])
+        allow(reader).to receive(:list_units).with(type: 'model').and_return(entries)
+        allow(reader).to receive(:find_unit).with('Order').and_return(
+          { 'type' => 'model', 'identifier' => 'Order', 'file_path' => shared_path, 'metadata' => {} }
+        )
+        allow(reader).to receive(:find_unit).with('Order::Line').and_return(
+          { 'type' => 'model', 'identifier' => 'Order::Line', 'file_path' => shared_path, 'metadata' => {} }
+        )
+      end
+
+      it 'pushes each unit under a distinct URI (lexically-first identifier keeps the bare path)' do
+        stub_colliding_pair
+        uris = []
+        allow(client).to receive(:put_document) { |args|
+          uris << args[:uri]
+          { 'id' => 'd' }
+        }
+
+        stats = exporter.sync_all
+
+        expect(stats[:synced]).to eq(2)
+        expect(uris).to contain_exactly(
+          base_uri,
+          "#{base_uri}?unit=Order%3A%3ALine"
+        )
+      end
+
+      it 'skips both on a warm second run instead of re-pushing forever' do
+        stub_colliding_pair
+        exporter.sync_all # cold: 2 pushes
+
+        warm = described_class.new(
+          index_dir: @index_dir, config: stub_config, client: client,
+          reader: reader, output: StringIO.new
+        )
+        stats = warm.sync_all
+
+        expect(stats[:synced]).to eq(0)
+        expect(stats[:skipped]).to be >= 2
+        expect(client).to have_received(:put_document).twice # still only the cold run's 2
+      end
+
+      it 'leaves a solo unit on the bare URI (no needless suffix churn)' do
+        allow(reader).to receive(:list_units).and_return([])
+        allow(reader).to receive(:list_units).with(type: 'model')
+                                             .and_return([{ 'identifier' => 'Solo', 'type' => 'model',
+                                                            'file_path' => 'app/models/solo.rb' }])
+        allow(reader).to receive(:find_unit).with('Solo').and_return(
+          { 'type' => 'model', 'identifier' => 'Solo', 'file_path' => 'app/models/solo.rb', 'metadata' => {} }
+        )
+        pushed = nil
+        allow(client).to receive(:put_document) { |args|
+          pushed = args[:uri]
+          { 'id' => 'd' }
+        }
+
+        exporter.sync_all
+        expect(pushed).to eq(uri_for('app/models/solo.rb'))
+      end
+    end
+
     context 'when the credential scrub fails closed (empty body)' do
       let(:manifest) { manifest_double }
 


### PR DESCRIPTION
Fixes #130.

## Problem

A document's URI is derived solely from `file_path` (`DocumentBuilder#uri_for`). A file that defines **multiple extracted units** — nested/namespaced classes, STI subclasses, or several classes in one `.rb` — maps every unit to the **same** blob URI. Since documents upsert by URI:

1. **Data loss:** the shared URI is PUT once per colliding unit, so only the last-built unit's profile survives remotely — the others are invisible to the review agent.
2. **Manifest thrash:** under the content-hash manifest, each colliding unit writes a different hash to the same key → never matches → those units re-push on every warm run (manifest entry count trails synced count by the collision count).

This is the sibling of the no-`file_path` guard from 1.4.0 — same root cause (URI keyed on file), the non-nil-shared-path case.

## Fix

A cheap pre-pass (`build_uri_index`) over the type indexes — entries already carry `file_path` and `read_index` is cached, so no extra unit loads — finds base URIs shared by >1 synced unit. For each, the **lexically-first identifier** (the outer/top-level class) keeps the bare blob URL; siblings get a `?unit=<identifier>` suffix:

- distinct remote document + distinct manifest key per unit (fixes overwrite **and** thrash)
- the suffixed URL still resolves to the correct file on GitHub
- **solo files — the overwhelming majority — are absent from the map and keep their exact current URI**, so there's no re-sync churn for them

Disambiguation lives in the Exporter (it has the full unit set); `DocumentBuilder#uri_for` stays a pure per-unit function.

### Why not the other options
- **`#L<line>` anchors** would be nicer citations, but extractors discard the source line (`file, _line = source_location`) — persisting it is an extraction-layer change for a sync-layer bug. `identifier` is already in the index, so the suffix is fully contained to `lib/woods/unblocked/`.
- **Merging co-located units into one file-doc** sacrifices the per-unit granularity (blast radius, associations, entry points) that makes these docs useful for review.

## Tests
- each colliding unit pushed under a distinct URI (primary keeps the bare path)
- warm second run skips both instead of re-pushing forever
- solo unit left on the bare URI (no needless suffix)

Full suite green (4971 examples); rubocop clean.