### PR TITLE
chore(release): prepare v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-06-10
+
 ### Fixed
 
 - **Unblocked sync: multiple units sharing one file no longer collide on a single

--- a/lib/woods/version.rb
+++ b/lib/woods/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Woods
-  VERSION = '1.4.0'
+  VERSION = '1.4.1'
 end


### PR DESCRIPTION
Stamps `Woods::VERSION = '1.4.1'` and dates the CHANGELOG entry for the URI-collision fix (#131, fixes #130).

Merging this, then tagging `v1.4.1`, triggers the release workflow (RubyGems publish + GitHub release).