### PR TITLE
chore(release): prepare v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-06-23
+
 ### Added
 
 - **Rails 6.0 support: the `railties` floor is lowered from `>= 6.1` to `>= 6.0`**

--- a/lib/woods/version.rb
+++ b/lib/woods/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Woods
-  VERSION = '1.4.1'
+  VERSION = '1.5.0'
 end


### PR DESCRIPTION
Prepares the **v1.5.0** release. This PR is the version bump only — it touches just `lib/woods/version.rb` (`1.4.1` → `1.5.0`) and dates the `[1.5.0]` CHANGELOG section. All the feature/dependency work it documents is already on `main`.

### What's in v1.5.0
Compiled from the `v1.4.1..main` diff:

- **Rails 6.0 support** — `railties` floor lowered `>= 6.1` → `>= 6.0` (#135). The two 6.1-only calls touched (`connection_db_config`, `has_many_inversing`) are `respond_to?`-guarded with a regression spec.
- **CI Rails-version matrix + booted-app extraction test** (#136) — `Appraisals` + `gemfiles/rails_*.gemfile` across Rails 6.0/6.1/7.0/7.1/7.2/8.0, a Ruby 4.0 lane, and a real in-process end-to-end extraction gating the introspection path the stubbed unit suite can't.
- **Index Server pattern-only boot by default** (#138) — `woods-mcp` no longer raises `MissingArtifact` when no embedding index is present; always-on tools serve with zero config and `codebase_retrieve` activates once a provider is set. `WOODS_REQUIRE_INDEX=1` restores fail-closed; `WOODS_ALLOW_AUTODETECT` kept as a no-op.
- **Worktree-aware git provenance** (#137) — new `Woods::GitProvenance` fixes stale `git_branch`/`git_sha` in `manifest.json` inside linked worktrees, emitting `"unknown"` rather than a baked-in env fallback when a `.git` is present but unresolvable.

Plus CI/dependency maintenance also landed since 1.4.1: `actions/checkout` v4 → v7 (#126), `ruby/setup-ruby` → 1.314.0 (#134), `rubygems/configure-rubygems-credentials` → 2.1.0 (#133).

### Releasing
This PR does **not** publish anything. After merge:

1. Push tag **`v1.5.0`** on `main`.
2. `release.yml` builds the gem and publishes via trusted publishing (now on `configure-rubygems-credentials` 2.1.0 / Node 24), then cuts the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBfDCj1HmesF3Ry9nSEmNC)_