### PR TITLE
Audit: extraction/graph/flow bugs, security hardening, retrieval correctness, DRY, and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hardcoded MySQL literal-stripping, so on PostgreSQL (`standard_conforming_strings`)
   the MySQL `\'` rule could over-strip and swallow a real `FROM <blocked>`
   clause. It now strips under both dialects and unions the identifiers.
-- **`EvalGuard` rejects `%x` shell literals with any delimiter.** It keyed off a
-  hand-picked delimiter set, so `%x/…/`, `%x~…~` slipped through to
-  `instance_eval`.
-- **`PipelineLock` no longer allows two processes to hold the lock.** A TOCTOU
-  race in stale-lock takeover and an ownership-unchecked release are fixed:
-  takeover is an atomic rename, and release verifies an ownership token before
-  deleting.
+- **TableGate no longer misses a table hidden behind a comment marker inside a
+  string literal.** `SqlNoiseStripper` stripped comments *before* literals, so
+  `SELECT '-- ' FROM blocked` had its real `FROM blocked` swallowed as a line
+  comment and slipped past the gate. Comment- and literal-stripping now run in a
+  single combined left-to-right pass (`SqlNoiseStripper.strip_noise`) — a
+  comment marker inside a literal, and a quote inside a comment, are each
+  protected by whichever opens first. `SqlValidator` and the scope-template
+  guard route through the same pass.
+- **`EvalGuard` rejects `%x` shell literals with any delimiter — including
+  whitespace.** The delimiter check excluded `\s`, but a newline is a valid `%x`
+  delimiter (`%x\ncmd\n` compiles and executes), so it slipped through to
+  `instance_eval`. The check now matches any non-word delimiter (`[^\w]`).
+- **`PipelineLock` no longer allows two processes to hold the lock.** Both the
+  stale-lock takeover and the release path had TOCTOU windows: a process that
+  passed the staleness check could rename away — or a plain read-then-unlink
+  release could delete — a competitor's *fresh* lock, so both would "hold" it.
+  Takeover now re-verifies the retired file is still stale (restoring it and
+  backing off if a competitor already took over), and release renames the file
+  aside and re-checks its ownership token before deleting.
 
 ### Fixed
 
@@ -42,9 +54,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returns string keys — so all four scored every unit at their neutral fallback
   in production. The ranker now reads both key forms.
 - **The embedding cache is now scoped to the provider model.** The cache key was
-  `SHA256(text)` with no model or dimensions, so a persistent shared backend
-  served the previous model's vector after a model switch. `model_name` and
-  `dimensions` are now part of the key.
+  `SHA256(text)` with no model, so a persistent shared backend served the
+  previous model's vector after a model switch. `model_name` is now part of the
+  key — a plain attribute rather than `dimensions`, whose Ollama implementation
+  is a live `embed('test')` probe (keying on it made every cache lookup, hits
+  included, depend on the provider being reachable, and defeated the cache while
+  the backend was down).
 - **`callback_count` reports real counts.** It called the nonexistent
   `CallbackChain#size`, which raised and left the count silently at 0 for every
   model; switched to `#count`.
@@ -57,13 +72,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on re-registration, inflating incremental blast radius.
 - **Precomputed request flows are no longer empty/stale.** `FlowPrecomputer` ran
   before unit JSON was written to disk; it now runs after `write_results`.
+- **`trace_flow` resolves precomputed flows again.** The reader allow-listed the
+  entry point but the writer left the action name raw, so a flow for an action
+  outside `[A-Za-z0-9_-]` was written under one filename and looked up under
+  another (silently falling back to live assembly). Both sides now derive the
+  filename from the shared `FilenameUtils.flow_filename`.
+- **Flow annotation no longer resurrects deleted units.** On a full extraction
+  with `precompute_flows`, refreshing a type's `_index.json` rebuilt it from a
+  disk glob of the never-wiped output dir, re-adding unit files for classes
+  deleted from the app since the last run. The index is now rebuilt from the
+  in-memory `@results` (the incremental path, which only holds changed units,
+  still rebuilds from disk).
 - **`FlowAssembler` no longer reports DAG diamonds as cycles**, and
   `IndexArtifact#promote` no longer accepts sibling directories that merely
   share a name prefix with `dumps/`.
 - **`implicit_belongs_to` metadata is accurate.** It was flagged on every
   ActiveRecord presence validator; it now keys on `belongs_to` reflections.
 - **Dependency scanning ignores commented references consistently** across all
-  three passes (a commented `Library::Book` still produced a ghost edge).
+  three passes (a commented `Library::Book` still produced a ghost edge), while
+  keeping references that follow a `#` *inside a string literal* (`link_to "Tag
+  #ruby", Article.recent`). Comment-stripping is string-literal-aware — a plain
+  `#…` regex ate the rest of such lines and dropped the real edge.
 - **`pipeline_extract(incremental: true)` requires `changed_files`** instead of
   silently re-extracting nothing while reporting success.
 - **`pipeline_diagnose` classifies by the supplied error class** (it built a bare
@@ -71,7 +100,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `:unknown`).
 - **`notion_sync` honors the `NOTION_API_TOKEN` env var**, matching the gate that
   registers the tool (ENV-only hosts previously saw the tool but every call
-  failed).
+  failed). A *blank* env var (docker-compose `${NOTION_API_TOKEN}` interpolation
+  of an unset host variable) is now treated as absent rather than masking a
+  configured token or passing through as a blank bearer. All four resolution
+  sites (exporter, `notion_wired?` gate, tool handler, rake task) share
+  `Woods.resolve_notion_token`.
 - **Embedded documents include the `dependencies:` line again** — the indexer
   leaves dependency hashes string-keyed and the text preparer only read symbol
   keys.
@@ -82,7 +115,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recovering service), and a slow probe's success could wipe failures recorded
   by an overlapping probe. Concurrent probes are now rejected with
   `CircuitOpenError`, and an optional `success_threshold` requires N consecutive
-  successful probes to close (default 1).
+  successful probes to close (default 1). Recovery accounting is also keyed to
+  the per-call probe flag, not the shared state: a stale call admitted while the
+  circuit was *closed* that completes after the transition to `half_open` no
+  longer counts as the probe (it could otherwise close the circuit — or clear a
+  concurrent probe's slot — while the service was still down).
 - **`Retry-After` honors the HTTP-date form.** The Notion and Unblocked clients
   parsed the header with `.to_f`, turning an HTTP-date into `0.0` and retrying
   immediately against a throttling server. A shared `Woods::RetryAfter` helper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keys.
 - The MCP CLI integration spec no longer fails under a POSIX/C locale (UTF-8
   subprocess output is normalized before regex matching).
+- **`CircuitBreaker` admits only a single probe in `half_open`.** It let every
+  concurrent call through while half-open (a thundering herd against a
+  recovering service), and a slow probe's success could wipe failures recorded
+  by an overlapping probe. Concurrent probes are now rejected with
+  `CircuitOpenError`, and an optional `success_threshold` requires N consecutive
+  successful probes to close (default 1).
+- **`Retry-After` honors the HTTP-date form.** The Notion and Unblocked clients
+  parsed the header with `.to_f`, turning an HTTP-date into `0.0` and retrying
+  immediately against a throttling server. A shared `Woods::RetryAfter` helper
+  now handles both the delta-seconds and HTTP-date forms.
+- **The MCP pipeline lock is no longer racy under the HTTP transport.** The
+  `@pipeline_mutex ||= Mutex.new` lazy init let two concurrent handlers create
+  separate mutexes and run two pipelines of the same kind; the mutex is now
+  eagerly initialized.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,89 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Console `sample`/`recent` tools now validate `columns` against the model's
+  real columns.** They passed the raw array to ActiveRecord's `.select`, which
+  treats string args as SQL fragments — a crafted column could smuggle a
+  subquery into the SELECT list, bypassing TableGate and column redaction
+  (`pluck` already validated; `sample`/`recent` didn't).
+- **`trace_flow` sanitizes the entry point before building the flow file path.**
+  Only `::`→`__` was applied, so `/` and `..` in a client-supplied entry point
+  could traverse outside the `flows/` directory (a file-read oracle over the
+  HTTP transport). Both path segments now go through the `FilenameUtils`
+  allow-list.
+- **TableGate's SQL table detector no longer misses tables on PostgreSQL.** It
+  hardcoded MySQL literal-stripping, so on PostgreSQL (`standard_conforming_strings`)
+  the MySQL `\'` rule could over-strip and swallow a real `FROM <blocked>`
+  clause. It now strips under both dialects and unions the identifiers.
+- **`EvalGuard` rejects `%x` shell literals with any delimiter.** It keyed off a
+  hand-picked delimiter set, so `%x/…/`, `%x~…~` slipped through to
+  `instance_eval`.
+- **`PipelineLock` no longer allows two processes to hold the lock.** A TOCTOU
+  race in stale-lock takeover and an ownership-unchecked release are fixed:
+  takeover is an atomic rename, and release verifies an ownership token before
+  deleting.
+
+### Fixed
+
+- **Incremental extraction no longer corrupts the index.** `rake woods:incremental`
+  overwrote `manifest.json` with zero counts, captured an empty temporal snapshot
+  (making the diff report every unit as deleted), wrote absolute file paths into
+  the index, and re-indexed affected units with a null `estimated_tokens`.
+- **Retrieval ranking signals work on real backends again.** Recency, importance,
+  type-match, and diversity read metadata with symbol keys, but every store
+  returns string keys — so all four scored every unit at their neutral fallback
+  in production. The ranker now reads both key forms.
+- **The embedding cache is now scoped to the provider model.** The cache key was
+  `SHA256(text)` with no model or dimensions, so a persistent shared backend
+  served the previous model's vector after a model switch. `model_name` and
+  `dimensions` are now part of the key.
+- **`callback_count` reports real counts.** It called the nonexistent
+  `CallbackChain#size`, which raised and left the count silently at 0 for every
+  model; switched to `#count`.
+- **`ResolvedConfig` is now deeply immutable.** Nested strings in
+  `embedding_provider`/`stores` stayed mutable, so the frozen snapshot could be
+  corrupted in place.
+- **Model dependency edges are correct for nested and re-registered units.** The
+  `ModelNameCache` alternation matched a prefixed parent (`Library::Book` for
+  `Library::Book::Chapter`); `DependencyGraph#register` left stale reverse edges
+  on re-registration, inflating incremental blast radius.
+- **Precomputed request flows are no longer empty/stale.** `FlowPrecomputer` ran
+  before unit JSON was written to disk; it now runs after `write_results`.
+- **`FlowAssembler` no longer reports DAG diamonds as cycles**, and
+  `IndexArtifact#promote` no longer accepts sibling directories that merely
+  share a name prefix with `dumps/`.
+- **`implicit_belongs_to` metadata is accurate.** It was flagged on every
+  ActiveRecord presence validator; it now keys on `belongs_to` reflections.
+- **Dependency scanning ignores commented references consistently** across all
+  three passes (a commented `Library::Book` still produced a ghost edge).
+- **`pipeline_extract(incremental: true)` requires `changed_files`** instead of
+  silently re-extracting nothing while reporting success.
+- **`pipeline_diagnose` classifies by the supplied error class** (it built a bare
+  `StandardError`, so every `Timeout`/`Net::`/`Errno` error came back
+  `:unknown`).
+- **`notion_sync` honors the `NOTION_API_TOKEN` env var**, matching the gate that
+  registers the tool (ENV-only hosts previously saw the tool but every call
+  failed).
+- **Embedded documents include the `dependencies:` line again** — the indexer
+  leaves dependency hashes string-keyed and the text preparer only read symbol
+  keys.
+- The MCP CLI integration spec no longer fails under a POSIX/C locale (UTF-8
+  subprocess output is normalized before regex matching).
+
+### Changed
+
+- Directory globbing and dependency deduplication across the extractor fleet are
+  centralized in `SharedUtilityMethods#find_files_in_directories` and
+  `SharedDependencyScanner#consolidate_dependencies` (behavior-preserving).
+
+### Documentation
+
+- Added an in-container Index Server section to `DOCKER_SETUP.md` (#139),
+  corrected stale tool counts, corrected backend config examples that referenced
+  nonexistent adapters (#83), and listed the previously-undocumented rake tasks.
+
 ## [1.5.0] - 2026-06-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,9 +19,18 @@ bundle exec rake woods:extract_framework # Rails/gem sources
 bundle exec rake woods:validate          # Index integrity check
 bundle exec rake woods:stats             # Show extraction stats
 bundle exec rake woods:clean             # Remove index output
+bundle exec rake woods:embed             # Embed all extracted units
+bundle exec rake woods:embed_incremental # Embed changed units only
+bundle exec rake "woods:retrieve[query]" # Ad-hoc retrieval against the index
+bundle exec rake "woods:flow[entry]"     # Execution flow document for an entry point
+bundle exec rake woods:console           # Embedded Console MCP server (stdio)
 bundle exec rake woods:notion_sync       # Sync models/columns to Notion
+bundle exec rake woods:unblocked_sync    # Sync to an Unblocked collection
 bundle exec rake woods:obsidian          # Export to an Obsidian vault (alias: woods:vault)
-# Woods-themed aliases: woods:scan (extract), woods:look (stats), woods:vet (validate)
+bundle exec rake woods:generate_token    # Random bearer token for woods-mcp-http
+# Woods-themed aliases: woods:scan (extract), woods:tend (incremental), woods:look (stats),
+# woods:vet (validate), woods:clear (clean), woods:nest (embed), woods:hone (embed_incremental),
+# woods:send (notion_sync), woods:relay (unblocked_sync)
 ```
 
 > **Docker:** Extraction runs inside the container (`docker compose exec app bundle exec rake ...`). The Index Server runs on the host reading volume-mounted output. See `docs/DOCKER_SETUP.md` for the full Docker guide.

--- a/docs/BACKEND_MATRIX.md
+++ b/docs/BACKEND_MATRIX.md
@@ -39,10 +39,10 @@ The vector store you can use depends on the primary database your Rails app uses
 
 | Primary database | Supported vector stores | Required? |
 |---|---|---|
-| **MySQL / Percona / MariaDB / Aurora MySQL** | `:qdrant`, `:pinecone` (external), `:sqlite` (local dev only) | Yes — MySQL has no native vector extension |
-| **PostgreSQL / Aurora PostgreSQL** | `:pgvector` (in-database), `:qdrant`, `:pinecone`, `:sqlite` (local dev only) | No — `:pgvector` runs inside the same database |
+| **MySQL / Percona / MariaDB / Aurora MySQL** | `:qdrant` (external); `:in_memory` (local dev only); `:pinecone` planned | Yes — MySQL has no native vector extension |
+| **PostgreSQL / Aurora PostgreSQL** | `:pgvector` (in-database), `:qdrant`; `:in_memory` (local dev only); `:pinecone` planned | No — `:pgvector` runs inside the same database |
 
-**Why MySQL needs an external backend.** MySQL ships no equivalent of the `pgvector` extension. Approximate-nearest-neighbour search over arbitrary float vectors is not part of the InnoDB / MyISAM storage engines and cannot be added via plugin. Woods does not emulate vector search in MySQL — the gem only ships adapters that delegate to a real vector engine. The recommended pairing is `:mysql` (metadata + graph) + `:qdrant` (vectors); the [MySQL section below](#mysql) covers this stack end to end.
+**Why MySQL needs an external backend.** MySQL ships no equivalent of the `pgvector` extension. Approximate-nearest-neighbour search over arbitrary float vectors is not part of the InnoDB / MyISAM storage engines and cannot be added via plugin. Woods does not emulate vector search in MySQL — the gem only ships adapters that delegate to a real vector engine. The recommended pairing today is `:qdrant` for vectors with Woods' own `:sqlite` metadata store (Woods never stores metadata in your application database; a native `:mysql` metadata adapter is a documented design target — see the [Metadata Stores status note](#metadata-stores)). The [MySQL section below](#mysql) covers the design-target stack end to end.
 
 ### pgvector (PostgreSQL Extension)
 
@@ -173,7 +173,7 @@ volumes:
 > **Status: planned, not yet implemented.** There is no `lib/woods/storage/pinecone.rb`
 > adapter in the shipped gem. The section below documents the design target.
 > Track progress in #83 or open a new issue if you need this sooner. Current
-> shipped vector stores: `:pgvector`, `:qdrant`, `:sqlite` (in-memory).
+> shipped vector stores: `:pgvector`, `:qdrant`, `:in_memory`.
 
 **What it is:** Fully managed cloud vector database.
 
@@ -542,8 +542,8 @@ config.metadata_store_connection = ENV["DATABASE_URL"]
 # Or use the application's existing ActiveRecord connection:
 config.metadata_store_connection = :active_record
 
-# Vector store must be separate
-config.vector_store = :qdrant  # or :pinecone, :sqlite_faiss
+# Vector store must be separate (shipped today: :qdrant; :pinecone is planned)
+config.vector_store = :qdrant
 ```
 
 **Performance notes:**

--- a/docs/DOCKER_SETUP.md
+++ b/docs/DOCKER_SETUP.md
@@ -9,7 +9,7 @@ Woods has a split architecture: extraction requires a booted Rails environment (
 ```
 HOST                                    CONTAINER
 ─────────────────────────────           ──────────────────────
-Index Server (27 tools)                 Rails App
+Index Server (29 tools)                 Rails App
   reads JSON from disk                    bundle exec rake woods:extract
   no Rails needed                           writes to tmp/woods/
         ▲                                         │
@@ -141,7 +141,40 @@ woods-mcp-start ./tmp/woods
 
 The `woods-mcp-start` wrapper validates the index directory, checks for `manifest.json`, ensures dependencies are installed, and restarts on failure. Use it instead of `woods-mcp` directly.
 
-> **Common mistake:** Using the container path (`/app/tmp/woods`) in `.mcp.json`. The Index Server runs on the host — it needs the host-side path to the volume-mounted output.
+> **Common mistake:** Using the container path (`/app/tmp/woods`) in `.mcp.json`. The host-side Index Server needs the host-side path to the volume-mounted output. (The in-container variant below is the opposite — it takes the container path.)
+
+### In-container Index Server (tmpfs / non-host-visible indexes)
+
+The host-side setup above assumes the extraction output is readable from the host. That breaks when `/app/tmp` is mounted as **tmpfs** for speed, or when the index directory lives in a **named Docker volume** — in both cases the index is not host-visible, so the host cannot run `woods-mcp-start ./tmp/woods`.
+
+The alternative is to run the Index Server **inside the container** via `docker exec`, pointing at the **container path**:
+
+```json
+{
+  "mcpServers": {
+    "woods": {
+      "command": "docker",
+      "args": ["exec", "-i", "my_app_web_1", "bundle", "exec", "woods-mcp", "/app/tmp/woods"]
+    }
+  }
+}
+```
+
+(With Compose, `"args": ["compose", "exec", "-i", "app", "bundle", "exec", "woods-mcp", "/app/tmp/woods"]` works the same way. The `-i` flag is required, exactly as for the embedded Console Server.)
+
+This form is also **cwd-independent** — there is no relative launcher path to resolve, which matters when the same server entry is referenced from multiple project roots or git worktrees.
+
+Two gotchas:
+
+1. **tmpfs wipes the index on container restart.** If `/app/tmp` is tmpfs, re-run `rake woods:extract` after each restart, or persist the index by mounting a named volume at the index path (e.g. `- woods-data:/app/tmp/woods`) or writing the index outside the tmpfs mount.
+2. **Container path, not host path.** This is the mirror image of the host-side "common mistake" above: the in-container server needs `/app/tmp/woods` (the container path), while the host-side server needs the host path. Pick the path that matches where the server process actually runs.
+
+| | Host-side (`woods-mcp-start`) | In-container (`docker exec`) |
+|---|---|---|
+| **Index location** | Host-visible volume mount | Anywhere in the container (tmpfs, named volume) |
+| **Path in `.mcp.json`** | Host path (`./tmp/woods`) | Container path (`/app/tmp/woods`) |
+| **Survives container restart** | Yes (on host disk) | Only with a named volume |
+| **Needs Ruby on host** | Yes | No |
 
 ## Console Server Setup
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Woods is a Ruby gem that extracts structured data from Rails applications for AI
 
 ## Current State
 
-All major layers are implemented: 34 extractors (including state machines, events, decorators, database views, caching patterns, factories, test mappings, and more), retrieval pipeline (query classification, hybrid search, RRF ranking), storage backends (pgvector, Qdrant, SQLite), embedding providers (OpenAI, Ollama), two MCP servers (27-tool index server + 31-tool console server), AST analysis, flow extraction, temporal snapshots, Notion export, and evaluation harness. Behavioral depth enrichment adds callback side-effect analysis, resolved Rails config introspection (`BehavioralProfile`), and optional pre-computed request flow maps (`FlowPrecomputer`).
+All major layers are implemented: 34 extractors (including state machines, events, decorators, database views, caching patterns, factories, test mappings, and more), retrieval pipeline (query classification, hybrid search, RRF ranking), storage backends (pgvector, Qdrant, SQLite), embedding providers (OpenAI, Ollama), two MCP servers (29-tool index server + 31-tool console server), AST analysis, flow extraction, temporal snapshots, Notion + Obsidian export, and evaluation harness. Behavioral depth enrichment adds callback side-effect analysis, resolved Rails config introspection (`BehavioralProfile`), and optional pre-computed request flow maps (`FlowPrecomputer`).
 
 What's next: see [COVERAGE_GAP_ANALYSIS.md](COVERAGE_GAP_ANALYSIS.md) for remaining coverage work (HAML/Slim expansion, configuration semantic parsing, Stimulus/Hotwire).
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -307,35 +307,37 @@ console_sample(model: "Order", scope: { created_at: { gte: "2025-01-01" } })
 
 **Symptom:** You're on MySQL (or Percona / MariaDB / Aurora MySQL) and `config.vector_store = :pgvector` fails at boot, or you can't find a `:mysql` vector adapter in `lib/woods/storage/`.
 
-**Cause:** MySQL has no native vector-search extension equivalent to `pgvector`. Woods does not emulate vector search in MySQL — every vector adapter the gem ships delegates to a real vector engine. The metadata + graph layer happily lives in MySQL (`config.metadata_store = :mysql`, recursive CTEs on 8.0+), but vectors have to go somewhere else.
+**Cause:** MySQL has no native vector-search extension equivalent to `pgvector`. Woods does not emulate vector search in MySQL — every vector adapter the gem ships delegates to a real vector engine. Note that being on MySQL only constrains the *vector* choice: Woods keeps its own metadata in SQLite or memory (`metadata_store: :sqlite | :in_memory`), never in your application database, so there is no MySQL metadata adapter to configure. (Native `:mysql` / `:postgresql` metadata adapters are future work — `BACKEND_MATRIX.md` documents the shape they would take.)
 
-**Fix:** Pair MySQL with one of the supported external vector backends. Qdrant is the recommended default for self-hosted / Docker stacks:
+**Fix:** Pair the host app with one of the supported external vector backends. Qdrant is the recommended default for self-hosted / Docker stacks:
 
 ```ruby
-# config/initializers/woods.rb — MySQL host with Qdrant for vectors
+# config/initializers/woods.rb — MySQL host app: vectors go to Qdrant
 Woods.configure do |config|
-  config.metadata_store = :mysql
-  config.metadata_store_connection = ENV.fetch("DATABASE_URL")
-
+  config.metadata_store = :sqlite   # Woods-internal metadata, not your app DB
   config.vector_store = :qdrant
-  config.vector_store_url = ENV.fetch("QDRANT_URL", "http://localhost:6333")
+  config.vector_store_options = {
+    url: ENV.fetch("QDRANT_URL", "http://localhost:6333"),
+    collection: "woods_units"
+  }
 end
 ```
 
-The Postgres equivalent (in-database vectors) is shown for contrast:
+The Postgres equivalent (in-database vectors via pgvector) is shown for contrast:
 
 ```ruby
-# PostgreSQL host with pgvector for vectors
+# PostgreSQL host: vectors can live in the same database via pgvector
 Woods.configure do |config|
-  config.metadata_store = :postgresql
-  config.metadata_store_connection = ENV.fetch("DATABASE_URL")
-
+  config.metadata_store = :sqlite
   config.vector_store = :pgvector
-  config.vector_store_connection = ENV.fetch("DATABASE_URL")
+  config.vector_store_options = {
+    connection: your_pg_connection,   # a PG::Connection to a pgvector-enabled DB
+    dimensions: 1536
+  }
 end
 ```
 
-For local development against a MySQL app, `config.vector_store = :sqlite` (or `:in_memory` with the `:shared_filesystem` preset) is a reasonable stand-in — it keeps the dev environment dependency-free at the cost of not exercising the production vector engine. Production MySQL stacks should run Qdrant (or Pinecone for managed environments).
+For local development against a MySQL app, the `:local` preset (`Woods.configure_with_preset(:local)` — in-memory vectors, SQLite metadata, Ollama embeddings) is a reasonable stand-in — it keeps the dev environment dependency-free at the cost of not exercising the production vector engine. Production MySQL stacks should run Qdrant; the `:production` preset (`vector_store: :qdrant`) is the matching starting point.
 
 See [`docs/BACKEND_MATRIX.md`](BACKEND_MATRIX.md#database-compatibility) for the full matrix and the [MySQL section](BACKEND_MATRIX.md#mysql) for graph-traversal details (recursive CTEs on 8.0+).
 

--- a/docs/backlog.json
+++ b/docs/backlog.json
@@ -657,8 +657,8 @@
     "category": "code-bug",
     "layer": "mcp",
     "files": ["lib/woods/mcp/server.rb", "lib/woods/notion/client.rb", "lib/woods/unblocked/client.rb", "lib/woods/resilience/circuit_breaker.rb", "lib/woods/mcp/bootstrapper.rb"],
-    "description": "HTTP transport concurrent-handler unsynchronized IndexReader cache + lazy pipeline mutex init; Notion/Unblocked POST retry on read-timeout duplicates; Retry-After to_f zeros HTTP-date form; CircuitBreaker half-open unlimited probes + reset on overlap; bootstrapper/reload string-keyed vector metadata vs symbol-keyed search filters. Tracked in GH #150.",
-    "status": "ready",
+    "description": "HTTP transport concurrent-handler unsynchronized IndexReader cache + lazy pipeline mutex init; Notion/Unblocked POST retry on read-timeout duplicates; Retry-After to_f zeros HTTP-date form; CircuitBreaker half-open unlimited probes + reset on overlap; bootstrapper/reload string-keyed vector metadata vs symbol-keyed search filters. Tracked in GH #150. PARTIAL (PR #151): FIXED the pipeline-lock mutex race (eager init), Retry-After (shared Woods::RetryAfter helper, both clients), and CircuitBreaker (single half-open probe + success_threshold). REMAINING: IndexReader cache guard, POST-retry idempotency, bootstrap/reload key-form normalization.",
+    "status": "in-progress",
     "depends_on": []
   }
 ]

--- a/docs/backlog.json
+++ b/docs/backlog.json
@@ -612,5 +612,53 @@
     "description": "Woods::Obsidian::NoteBuilder (B-056) and Woods::Unblocked::DocumentBuilder independently walk unit metadata (associations-by-type, blast-radius buckets, entry points, side effects, schema highlights, deps/dependents-by-type). That selection/shaping logic is format-agnostic; only the final string assembly (plain-text + GitHub URIs vs wikilinks + frontmatter) diverges. Extract a Woods::Export::UnitFacts that turns a unit_data hash into a structured intermediate, and make both builders thin formatters over it, so a unit-type metadata change is fixed in one place. PREREQUISITE: Unblocked detects changes by hashing the rendered body (Exporter#fingerprint = SHA256(title + body)), and its specs guard determinism/structure but NOT byte-exact output, so a refactor could pass CI green yet force a one-time mass re-push. Before touching DocumentBuilder, add golden-output regression specs that pin its exact body bytes per unit type. Until this lands, B-056 mitigates drift with a shared metadata-shape fixture asserted by both spec suites. Tracked in #144. RESOLVED: added lib/woods/export/unit_facts.rb (associations_by_type, schema_highlights, blast_radius) + specs; added spec/unblocked/document_builder_golden_spec.rb pinning DocumentBuilder body bytes per unit type against spec/fixtures/unblocked/golden_units.rb + golden/*.md; migrated DocumentBuilder model_associations + model_schema_highlights onto UnitFacts with the golden suite confirming byte-identical output (no Unblocked re-push); migrated NoteBuilder associations onto UnitFacts and added a shared Schema section; GoldenUnits is now asserted by both the Unblocked golden suite and the Obsidian NoteBuilder suite as the shared metadata-shape fixture.",
     "status": "resolved",
     "depends_on": ["B-056"]
+  },
+  {
+    "id": "B-058",
+    "slug": "qdrant-point-id-uuid-mapping",
+    "title": "Qdrant adapter sends Woods identifiers as point IDs \u2014 every upsert 400s",
+    "severity": "high",
+    "category": "code-bug",
+    "layer": "storage",
+    "files": ["lib/woods/storage/qdrant.rb", "lib/woods/embedding/indexer.rb"],
+    "description": "Qdrant only accepts uint/UUID point IDs but the adapter passes Woods identifiers (\"User\", \"User#chunk_0\") straight through, so every upsert 400s and the Qdrant path is non-functional. Fix: UUIDv5 point id + identifier in payload + reverse-map in search/delete. Needs live-Qdrant validation. Tracked in GH #147.",
+    "status": "ready",
+    "depends_on": []
+  },
+  {
+    "id": "B-059",
+    "slug": "incremental-embed-inmemory-data-loss",
+    "title": "Incremental embed against in-memory vector store discards vectors but advances checkpoint",
+    "severity": "high",
+    "category": "code-bug",
+    "layer": "embedding",
+    "files": ["lib/woods/embedding/indexer.rb"],
+    "description": "index_incremental never persist_snapshots and process_units always advances checkpoint.json, so on :local/:shared_filesystem presets changed units embed into a throwaway store, nothing is written to dumps/, and the checkpoint skips them next run \u2014 unrecoverable without full re-embed. Fix: hydrate+persist in incremental mode, or do not advance checkpoint when unpersisted. Tracked in GH #148.",
+    "status": "ready",
+    "depends_on": []
+  },
+  {
+    "id": "B-060",
+    "slug": "notion-column-name-collision",
+    "title": "Notion Columns sync collapses same-named columns across models",
+    "severity": "high",
+    "category": "code-bug",
+    "layer": "export",
+    "files": ["lib/woods/notion/exporter.rb", "lib/woods/notion/mappers/column_mapper.rb"],
+    "description": "Column pages are upserted by bare column name and found by title equality across the whole DB, so shared columns (id/created_at/updated_at) overwrite each other across models \u2014 the Columns DB collapses to one page per distinct name. Fix: qualify title (users.id) or filter lookup by Table relation. Tracked in GH #149.",
+    "status": "ready",
+    "depends_on": []
+  },
+  {
+    "id": "B-061",
+    "slug": "audit-medium-followups",
+    "title": "Audit follow-ups: medium-severity correctness/robustness findings",
+    "severity": "medium",
+    "category": "code-bug",
+    "layer": "mcp",
+    "files": ["lib/woods/mcp/server.rb", "lib/woods/notion/client.rb", "lib/woods/unblocked/client.rb", "lib/woods/resilience/circuit_breaker.rb", "lib/woods/mcp/bootstrapper.rb"],
+    "description": "HTTP transport concurrent-handler unsynchronized IndexReader cache + lazy pipeline mutex init; Notion/Unblocked POST retry on read-timeout duplicates; Retry-After to_f zeros HTTP-date form; CircuitBreaker half-open unlimited probes + reset on overlap; bootstrapper/reload string-keyed vector metadata vs symbol-keyed search filters. Tracked in GH #150.",
+    "status": "ready",
+    "depends_on": []
   }
 ]

--- a/lib/tasks/woods.rake
+++ b/lib/tasks/woods.rake
@@ -534,8 +534,10 @@ namespace :woods do
     require 'woods/notion/exporter'
 
     config = Woods.configuration
-    # Env var takes precedence over configured value
-    config.notion_api_token = ENV.fetch('NOTION_API_TOKEN', nil) || config.notion_api_token
+    # A non-blank env var takes precedence over the configured value; a blank
+    # NOTION_API_TOKEN is treated as absent. Shared resolution keeps the rake
+    # task, the exporter, and the MCP tool consistent.
+    config.notion_api_token = Woods.resolve_notion_token(config)
 
     unless config.notion_api_token
       puts 'ERROR: Notion API token not configured.'

--- a/lib/woods.rb
+++ b/lib/woods.rb
@@ -319,6 +319,30 @@ module Woods
       end
     end
 
+    # Resolve the effective Notion API token.
+    #
+    # A non-blank +NOTION_API_TOKEN+ env var takes precedence; otherwise the
+    # configured +notion_api_token+ is used. A set-but-blank env var — common
+    # with docker-compose +${NOTION_API_TOKEN}+ interpolation of an unset
+    # host variable — is treated as absent, so it never masks a valid
+    # configured token nor slips through as a blank bearer. This is the single
+    # resolution point shared by the Notion exporter, the MCP +notion_sync+
+    # tool + its registration gate, and the rake task, so all four agree on a
+    # given host.
+    #
+    # @param config [Configuration] configuration to read the fallback from
+    # @return [String, nil] the resolved token, or nil when neither source
+    #   supplies a non-blank value
+    def resolve_notion_token(config = configuration)
+      env = ENV.fetch('NOTION_API_TOKEN', nil)
+      return env unless env.nil? || env.strip.empty?
+
+      configured = config.respond_to?(:notion_api_token) ? config.notion_api_token : nil
+      return nil if configured.nil? || configured.to_s.strip.empty?
+
+      configured
+    end
+
     # Build a Retriever wired with adapters from the current configuration.
     #
     # @return [Retriever] A fully wired retriever instance

--- a/lib/woods/cache/cache_middleware.rb
+++ b/lib/woods/cache/cache_middleware.rb
@@ -359,19 +359,27 @@ module Woods
 
       # Build a cache key for an embedding text.
       #
-      # The provider's model_name and dimensions are folded into the key: a
-      # cached embedding is only valid for the exact model that produced it.
-      # Without this, a persistent shared backend (Redis/SolidCache) returns
-      # the previous model's vector after a model switch or upgrade —
-      # different dimensions error mid-batch, same dimensions silently
-      # corrupt similarity scores (which IndexValidator can't detect, since
-      # it checks provider-vs-store dims, not cache contents).
+      # The provider's model_name is folded into the key: a cached embedding
+      # is only valid for the exact model that produced it. Without this, a
+      # persistent shared backend (Redis/SolidCache) returns the previous
+      # model's vector after a model switch or upgrade — different dimensions
+      # error mid-batch, same dimensions silently corrupt similarity scores
+      # (which IndexValidator can't detect, since it checks provider-vs-store
+      # dims, not cache contents).
+      #
+      # model_name (a plain attribute) is used rather than dimensions on
+      # purpose: for every supported provider the model uniquely determines
+      # the vector dimensionality, and `Provider#dimensions` can force a live
+      # network probe (Ollama memoizes `embed('test').length`; OpenAI probes
+      # for unknown models). Keying on dimensions made every cache lookup —
+      # including hits — depend on the provider being reachable, defeating the
+      # cache exactly when the backend is down. model_name distinguishes
+      # models without any I/O.
       #
       # @param text [String]
       # @return [String]
       def embedding_key(text)
-        signature = "#{@provider.model_name}:#{@provider.dimensions}"
-        Cache.cache_key(:embeddings, signature, Digest::SHA256.hexdigest(text))
+        Cache.cache_key(:embeddings, @provider.model_name.to_s, Digest::SHA256.hexdigest(text))
       end
     end
 

--- a/lib/woods/cache/cache_middleware.rb
+++ b/lib/woods/cache/cache_middleware.rb
@@ -359,10 +359,19 @@ module Woods
 
       # Build a cache key for an embedding text.
       #
+      # The provider's model_name and dimensions are folded into the key: a
+      # cached embedding is only valid for the exact model that produced it.
+      # Without this, a persistent shared backend (Redis/SolidCache) returns
+      # the previous model's vector after a model switch or upgrade —
+      # different dimensions error mid-batch, same dimensions silently
+      # corrupt similarity scores (which IndexValidator can't detect, since
+      # it checks provider-vs-store dims, not cache contents).
+      #
       # @param text [String]
       # @return [String]
       def embedding_key(text)
-        Cache.cache_key(:embeddings, Digest::SHA256.hexdigest(text))
+        signature = "#{@provider.model_name}:#{@provider.dimensions}"
+        Cache.cache_key(:embeddings, signature, Digest::SHA256.hexdigest(text))
       end
     end
 

--- a/lib/woods/console/embedded_executor.rb
+++ b/lib/woods/console/embedded_executor.rb
@@ -458,6 +458,7 @@ module Woods
       end
 
       def handle_sample(params)
+        validate_select_columns!(params)
         model = resolve_model(params['model'])
         limit = [params.fetch('limit', 5).to_i, 25].min
         scope = apply_scope(model, params['scope'], model_name: params['model'])
@@ -563,6 +564,7 @@ module Woods
       end
 
       def handle_recent(params)
+        validate_select_columns!(params)
         model = resolve_model(params['model'])
         order_by = params.fetch('order_by', 'created_at')
         direction = params.fetch('direction', 'desc')
@@ -926,6 +928,20 @@ module Woods
       # @return [Boolean]
       def predicate_suffix?(scope)
         scope.any? { |k, _| ScopePredicateParser::SUFFIX_PATTERN.match?(k.to_s) }
+      end
+
+      # Validate that any requested +columns+ are real model columns before
+      # they reach +apply_columns+. ActiveRecord treats string args to
+      # +.select+ as raw SQL fragments, so an unvalidated column smuggles a
+      # subquery into the SELECT list (the sample/recent tools skip
+      # +check_sql!+, so this is their only gate). Mirrors +handle_pluck+.
+      #
+      # @param params [Hash] Tool params (uses 'model' and 'columns')
+      # @raise [ArgumentError] if any column is not declared on the model
+      def validate_select_columns!(params)
+        return unless params['columns']
+
+        @model_validator.validate_columns!(params['model'], params['columns'])
       end
 
       # Apply column selection to a relation.

--- a/lib/woods/console/embedded_executor.rb
+++ b/lib/woods/console/embedded_executor.rb
@@ -905,8 +905,10 @@ module Woods
         # instead of a confusing adapter-level syntax failure. It also
         # neutralises `--` line comments and PostgreSQL dollar-quoted
         # strings that could carry forbidden keywords past a naive scan.
-        # `SqlNoiseStripper` is the same module SqlValidator uses.
-        stripped = SqlNoiseStripper.strip_literals(SqlNoiseStripper.strip_comments(template))
+        # `SqlNoiseStripper` is the same module SqlValidator uses. The
+        # combined single-pass strip_noise resolves comments and literals
+        # together so a comment marker inside a literal can't hide a keyword.
+        stripped = SqlNoiseStripper.strip_noise(template)
         if SCOPE_TEMPLATE_FORBIDDEN.match?(stripped)
           raise ValidationError,
                 'scope template contains forbidden SQL keywords ' \

--- a/lib/woods/console/eval_guard.rb
+++ b/lib/woods/console/eval_guard.rb
@@ -195,11 +195,13 @@ module Woods
         # which {Woods::Ast::Parser} may normalize differently across
         # Prism/parser-gem backends. A source-level refusal is both cheap
         # and impossible to evade via AST normalization. Ruby accepts ANY
-        # non-word character as the %x delimiter (`%x/ls/`, `%x~ls~`, …),
-        # so match \W rather than a hand-picked delimiter list — as a
-        # fail-safe, over-refusing odd-but-harmless source beats letting
-        # an unlisted delimiter through.
-        if code.include?('`') || code =~ /%x[^\w\s]/
+        # non-word character as the %x delimiter — including whitespace:
+        # `%x\ncmd\n` (newline-delimited) is valid and executes. Match
+        # every non-word char (`[^\w]`, which spans newline/space/tab, not
+        # `[^\w\s]` which excluded them and let `%x\n…` slip through). As a
+        # fail-safe, over-refusing odd-but-harmless source beats letting an
+        # unlisted delimiter through.
+        if code.include?('`') || code =~ /%x[^\w]/
           raise ForbiddenExpressionError, 'payload contains a shell-execution literal (backtick or %x)'
         end
 

--- a/lib/woods/console/eval_guard.rb
+++ b/lib/woods/console/eval_guard.rb
@@ -194,8 +194,12 @@ module Woods
         # `%x{cmd}`) — the AST flavor of these is `:xstr`/`:xstr_heredoc`,
         # which {Woods::Ast::Parser} may normalize differently across
         # Prism/parser-gem backends. A source-level refusal is both cheap
-        # and impossible to evade via AST normalization.
-        if code.include?('`') || code =~ /%x[{<|!@#(\[]/
+        # and impossible to evade via AST normalization. Ruby accepts ANY
+        # non-word character as the %x delimiter (`%x/ls/`, `%x~ls~`, …),
+        # so match \W rather than a hand-picked delimiter list — as a
+        # fail-safe, over-refusing odd-but-harmless source beats letting
+        # an unlisted delimiter through.
+        if code.include?('`') || code =~ /%x[^\w\s]/
           raise ForbiddenExpressionError, 'payload contains a shell-execution literal (backtick or %x)'
         end
 

--- a/lib/woods/console/sql_noise_stripper.rb
+++ b/lib/woods/console/sql_noise_stripper.rb
@@ -82,6 +82,111 @@ module Woods
         pattern = dialect == :mysql ? SINGLE_QUOTED_MYSQL : SINGLE_QUOTED_POSTGRES
         out.gsub(pattern, "''")
       end
+
+      # Strip BOTH comments and string literals in a single left-to-right
+      # pass, so a comment marker inside a literal and a quote inside a
+      # comment are each protected by whichever construct opens first.
+      #
+      # Running {.strip_comments} then {.strip_literals} (or vice versa) is
+      # unsafe: `SELECT '-- ' FROM blocked` has its real `FROM blocked`
+      # swallowed as a line comment (the `--` sits inside a string literal),
+      # letting a blocked table slip past {TableGate}; the reverse order
+      # mis-handles an apostrophe inside a `--` comment. Only a combined scan
+      # that tracks literal/comment state correctly resolves both. This
+      # scanner backs security checks (SqlValidator, TableGate) so it must
+      # never under-detect: an unterminated literal is treated as an ordinary
+      # character rather than swallowing the rest of the statement.
+      #
+      # @param sql [String] the SQL string to process
+      # @param dialect [Symbol] `:postgres` (default) or `:mysql` — controls
+      #   single-quote escape rules (see {.strip_literals}).
+      # @return [String] a new string with comments removed and every string
+      #   literal replaced by `''`
+      # @raise [ArgumentError] if an unsupported dialect is provided
+      def self.strip_noise(sql, dialect: :postgres) # rubocop:disable Metrics/MethodLength,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity,Metrics/AbcSize
+        unless SUPPORTED_DIALECTS.include?(dialect)
+          raise ArgumentError, "Unknown dialect #{dialect.inspect}. Supported: #{SUPPORTED_DIALECTS.inspect}"
+        end
+
+        mysql = dialect == :mysql
+        out = +''
+        i = 0
+        len = sql.length
+
+        while i < len
+          ch = sql[i]
+
+          if ch == "'"
+            close = single_quote_end(sql, i, mysql: mysql)
+            if close
+              out << "''"
+              i = close
+            else
+              # Unterminated literal — never under-detect; keep the char.
+              out << ch
+              i += 1
+            end
+          elsif ch == '$' && (tag = dollar_tag_at(sql, i))
+            close = sql.index(tag, i + tag.length)
+            if close
+              out << "''"
+              i = close + tag.length
+            else
+              out << ch
+              i += 1
+            end
+          elsif ch == '-' && sql[i + 1] == '-'
+            nl = sql.index("\n", i)
+            i = nl || len
+          elsif ch == '/' && sql[i + 1] == '*'
+            close = sql.index('*/', i + 2)
+            i = close ? close + 2 : len
+          else
+            out << ch
+            i += 1
+          end
+        end
+
+        out
+      end
+
+      # Regexp matching a PostgreSQL dollar-quote opening tag (`$$` or
+      # `$tag$`) at the start of the given slice.
+      DOLLAR_TAG = /\A\$\w*\$/
+      private_constant :DOLLAR_TAG
+
+      # Return the dollar-quote tag opening at +index+, or nil.
+      #
+      # @api private
+      def self.dollar_tag_at(sql, index)
+        m = DOLLAR_TAG.match(sql[index..])
+        m && m[0]
+      end
+      private_class_method :dollar_tag_at
+
+      # Return the index just past the closing quote of the single-quoted
+      # literal that opens at +start+, honoring `''` (both dialects) and `\'`
+      # (MySQL only) escapes. Returns nil when the literal is unterminated.
+      #
+      # @api private
+      def self.single_quote_end(sql, start, mysql:)
+        i = start + 1
+        len = sql.length
+        while i < len
+          c = sql[i]
+          if mysql && c == '\\'
+            i += 2
+          elsif c == "'"
+            return i + 1 unless sql[i + 1] == "'" # closing quote
+
+            i += 2 # doubled-quote escape — literal continues
+          else
+            i += 1
+          end
+        end
+        nil
+      end
+      private_class_method :single_quote_end
     end
   end
 end

--- a/lib/woods/console/sql_noise_stripper.rb
+++ b/lib/woods/console/sql_noise_stripper.rb
@@ -140,7 +140,15 @@ module Woods
             i = nl || len
           elsif ch == '/' && sql[i + 1] == '*'
             close = sql.index('*/', i + 2)
-            i = close ? close + 2 : len
+            if close
+              i = close + 2
+            else
+              # Unterminated block comment: never under-detect. Leave it in
+              # place (over-detection is safe; the old regex also required a
+              # closing */ and left an unterminated /* untouched).
+              out << ch
+              i += 1
+            end
           else
             out << ch
             i += 1

--- a/lib/woods/console/sql_table_scanner.rb
+++ b/lib/woods/console/sql_table_scanner.rb
@@ -133,9 +133,12 @@ module Woods
       end
 
       # @api private
+      # Comments and literals must be stripped in a single combined pass —
+      # stripping them separately lets a comment marker inside a literal
+      # (`'-- '`) hide a real FROM clause from the gate. See
+      # {SqlNoiseStripper.strip_noise}.
       def self.strip_noise(sql, dialect:)
-        out = SqlNoiseStripper.strip_comments(sql)
-        SqlNoiseStripper.strip_literals(out, dialect: dialect)
+        SqlNoiseStripper.strip_noise(sql, dialect: dialect)
       end
       private_class_method :strip_noise
 

--- a/lib/woods/console/sql_table_scanner.rb
+++ b/lib/woods/console/sql_table_scanner.rb
@@ -109,23 +109,33 @@ module Woods
       # stripped before scanning. Both JOIN-style and ANSI-89 comma-join syntax
       # are handled.
       #
+      # Literals are stripped under BOTH supported dialects and the scans
+      # unioned. This scanner backs TableGate, so it may over-detect but must
+      # never under-detect: stripping with the wrong dialect's escape rules
+      # can swallow a real FROM clause — e.g. MySQL's `\'` escape applied on
+      # a PostgreSQL host (where backslash is literal under
+      # standard_conforming_strings) folds `'x\' FROM blocked WHERE y = '`
+      # into one literal, hiding `blocked` from the gate while PostgreSQL
+      # genuinely reads that table.
+      #
       # @param sql [String, nil] the SQL string to scan
-      # @return [Array<String>] identifiers in the order they were encountered;
-      #   may contain duplicates if the same table is referenced multiple times
+      # @return [Array<String>] identifiers in first-encounter order, deduplicated
       def self.identifiers_in(sql)
         return [] if sql.nil? || sql.empty?
 
-        stripped = strip_noise(sql)
         results = []
-        collect_join_identifiers(stripped, results)
-        collect_from_identifiers(stripped, results)
-        results
+        %i[postgres mysql].each do |dialect|
+          stripped = strip_noise(sql, dialect: dialect)
+          collect_join_identifiers(stripped, results)
+          collect_from_identifiers(stripped, results)
+        end
+        results.uniq
       end
 
       # @api private
-      def self.strip_noise(sql)
+      def self.strip_noise(sql, dialect:)
         out = SqlNoiseStripper.strip_comments(sql)
-        SqlNoiseStripper.strip_literals(out, dialect: :mysql)
+        SqlNoiseStripper.strip_literals(out, dialect: dialect)
       end
       private_class_method :strip_noise
 

--- a/lib/woods/console/sql_validator.rb
+++ b/lib/woods/console/sql_validator.rb
@@ -152,8 +152,7 @@ module Woods
       # @param sql [String]
       # @return [Boolean]
       def contains_multiple_statements?(sql)
-        stripped = SqlNoiseStripper.strip_comments(sql)
-        stripped = SqlNoiseStripper.strip_literals(stripped)
+        stripped = SqlNoiseStripper.strip_noise(sql)
         stripped.include?(';')
       end
 

--- a/lib/woods/coordination/pipeline_lock.rb
+++ b/lib/woods/coordination/pipeline_lock.rb
@@ -69,30 +69,28 @@ module Woods
       def release
         return unless @held
 
+        # Clear @held up front so no later failure can leave this instance
+        # believing it still holds the lock.
+        @held = false
+
         # Rename first, then inspect: a plain read-then-unlink is a TOCTOU —
         # after we read our own token a takeover could replace the file, and
         # our unlink would then delete the NEW holder's lock. Renaming
-        # atomically captures whatever is at the path; if it turns out not to
-        # be ours (we were taken over), we put it back untouched.
+        # atomically captures whatever is at the path.
         graveyard = "#{@lock_path}.release.#{Process.pid}.#{SecureRandom.hex(4)}"
         begin
           File.rename(@lock_path, graveyard)
         rescue Errno::ENOENT
-          @held = false
-          return
+          return # already gone
         end
 
-        begin
-          content = JSON.parse(File.read(graveyard))
-          if content['token'] == @token
-            FileUtils.rm_f(graveyard)
-          else
-            File.rename(graveyard, @lock_path) # not ours — restore for the holder
-          end
-        rescue JSON::ParserError
-          FileUtils.rm_f(graveyard) # corrupt lock we already moved aside — discard
+        if own_lock?(graveyard)
+          FileUtils.rm_f(graveyard)
+        else
+          # We were legitimately taken over — put the successor's lock back
+          # without clobbering a still-newer holder (see {#restore_lock}).
+          restore_lock(graveyard)
         end
-        @held = false
       end
 
       # Execute a block while holding the lock.
@@ -153,8 +151,9 @@ module Woods
 
         unless stale_file?(graveyard)
           # We grabbed a lock that is no longer stale — a competitor already
-          # took over. Restore it and back off.
-          File.rename(graveyard, @lock_path)
+          # took over. Restore it (without clobbering a still-newer holder)
+          # and back off.
+          restore_lock(graveyard)
           return false
         end
 
@@ -162,6 +161,36 @@ module Woods
         true
       rescue Errno::ENOENT
         false
+      end
+
+      # Whether the lock file at +path+ carries this instance's token.
+      #
+      # @param path [String]
+      # @return [Boolean] true when the token matches, or the file is corrupt
+      #   (an unparseable lock we already renamed aside is treated as ours to
+      #   discard rather than restore).
+      def own_lock?(path)
+        JSON.parse(File.read(path))['token'] == @token
+      rescue JSON::ParserError
+        true
+      end
+
+      # Put a lock file we renamed aside back at @lock_path WITHOUT clobbering
+      # a lock another process may have O_EXCL-created in the meantime.
+      # `File.link` is atomic and fails with EEXIST if @lock_path already
+      # exists, so a newer holder always wins; the aside copy is discarded
+      # either way. A plain `File.rename` back would overwrite that newer
+      # holder's lock — reintroducing a double-hold.
+      #
+      # @param graveyard [String] path of the renamed-aside lock file
+      # @return [void]
+      def restore_lock(graveyard)
+        File.link(graveyard, @lock_path)
+      rescue Errno::EEXIST
+        # A newer holder already claimed the path — our copy is obsolete.
+        nil
+      ensure
+        FileUtils.rm_f(graveyard)
       end
 
       # Whether the file at +path+ is older than the stale timeout.

--- a/lib/woods/coordination/pipeline_lock.rb
+++ b/lib/woods/coordination/pipeline_lock.rb
@@ -69,11 +69,28 @@ module Woods
       def release
         return unless @held
 
+        # Rename first, then inspect: a plain read-then-unlink is a TOCTOU —
+        # after we read our own token a takeover could replace the file, and
+        # our unlink would then delete the NEW holder's lock. Renaming
+        # atomically captures whatever is at the path; if it turns out not to
+        # be ours (we were taken over), we put it back untouched.
+        graveyard = "#{@lock_path}.release.#{Process.pid}.#{SecureRandom.hex(4)}"
         begin
-          content = JSON.parse(File.read(@lock_path))
-          FileUtils.rm_f(@lock_path) if content['token'] == @token
-        rescue Errno::ENOENT, JSON::ParserError
-          # Lock already gone or unreadable — nothing of ours to release.
+          File.rename(@lock_path, graveyard)
+        rescue Errno::ENOENT
+          @held = false
+          return
+        end
+
+        begin
+          content = JSON.parse(File.read(graveyard))
+          if content['token'] == @token
+            FileUtils.rm_f(graveyard)
+          else
+            File.rename(graveyard, @lock_path) # not ours — restore for the holder
+          end
+        rescue JSON::ParserError
+          FileUtils.rm_f(graveyard) # corrupt lock we already moved aside — discard
         end
         @held = false
       end
@@ -121,12 +138,38 @@ module Woods
       # process may O_EXCL-create between our rename and our create, which
       # the caller's EEXIST rescue handles.
       #
-      # @return [Boolean] true if this process retired the stale lock
+      # Rename alone is not enough, though: a competitor that already passed
+      # `stale?` on the SAME original file may have retired it and created a
+      # FRESH lock before we run. Our rename would then move that fresh lock
+      # aside — and both processes would "hold" the lock. So after winning
+      # the rename we re-check the retired file's age; if it turns out to be
+      # fresh (someone beat us to the takeover), we put it back and lose the
+      # race instead of clobbering a live holder.
+      #
+      # @return [Boolean] true if this process retired a genuinely stale lock
       def retire_stale_lock
         graveyard = "#{@lock_path}.stale.#{Process.pid}.#{SecureRandom.hex(4)}"
         File.rename(@lock_path, graveyard)
+
+        unless stale_file?(graveyard)
+          # We grabbed a lock that is no longer stale — a competitor already
+          # took over. Restore it and back off.
+          File.rename(graveyard, @lock_path)
+          return false
+        end
+
         FileUtils.rm_f(graveyard)
         true
+      rescue Errno::ENOENT
+        false
+      end
+
+      # Whether the file at +path+ is older than the stale timeout.
+      #
+      # @param path [String]
+      # @return [Boolean]
+      def stale_file?(path)
+        Time.now - File.mtime(path) > @stale_timeout
       rescue Errno::ENOENT
         false
       end

--- a/lib/woods/coordination/pipeline_lock.rb
+++ b/lib/woods/coordination/pipeline_lock.rb
@@ -2,6 +2,7 @@
 
 require 'fileutils'
 require 'json'
+require 'securerandom'
 
 module Woods
   module Coordination
@@ -38,12 +39,13 @@ module Woods
       def acquire
         FileUtils.mkdir_p(@lock_dir)
 
-        # Check for stale lock first (separate from atomic creation)
         if File.exist?(@lock_path)
           return false unless stale?
-
-          # Remove stale lock
-          FileUtils.rm_f(@lock_path)
+          # Retire the stale lock atomically. A bare rm_f + create here is
+          # a TOCTOU race: two processes passing the stale check together
+          # could each delete-and-create, the second deleting the first's
+          # FRESH lock — both would then "hold" it.
+          return false unless retire_stale_lock
         end
 
         # Atomic lock creation: File::EXCL ensures this fails if file already exists
@@ -58,9 +60,21 @@ module Woods
 
       # Release the lock.
       #
+      # Deletes the lock file only if it still carries this instance's
+      # token — a run that outlived stale_timeout may have been
+      # legitimately taken over, and deleting unconditionally would drop
+      # the new holder's lock.
+      #
       # @return [void]
       def release
-        FileUtils.rm_f(@lock_path) if @held
+        return unless @held
+
+        begin
+          content = JSON.parse(File.read(@lock_path))
+          FileUtils.rm_f(@lock_path) if content['token'] == @token
+        rescue Errno::ENOENT, JSON::ParserError
+          # Lock already gone or unreadable — nothing of ours to release.
+        end
         @held = false
       end
 
@@ -100,9 +114,28 @@ module Woods
         true
       end
 
-      # @return [String] Lock file content (JSON with PID and timestamp)
+      # Atomically retire a stale lock file via rename. Rename is atomic on
+      # POSIX: of any processes racing to take over the same stale lock,
+      # exactly one rename succeeds; the losers get ENOENT and back off.
+      # Winning the rename does NOT guarantee winning the lock — another
+      # process may O_EXCL-create between our rename and our create, which
+      # the caller's EEXIST rescue handles.
+      #
+      # @return [Boolean] true if this process retired the stale lock
+      def retire_stale_lock
+        graveyard = "#{@lock_path}.stale.#{Process.pid}.#{SecureRandom.hex(4)}"
+        File.rename(@lock_path, graveyard)
+        FileUtils.rm_f(graveyard)
+        true
+      rescue Errno::ENOENT
+        false
+      end
+
+      # @return [String] Lock file content (JSON with PID, timestamp, and
+      #   an ownership token release verifies before deleting)
       def lock_content
-        JSON.generate(pid: Process.pid, locked_at: Time.now.iso8601, name: @name)
+        @token = SecureRandom.hex(8)
+        JSON.generate(pid: Process.pid, locked_at: Time.now.iso8601, name: @name, token: @token)
       end
     end
   end

--- a/lib/woods/dependency_graph.rb
+++ b/lib/woods/dependency_graph.rb
@@ -31,11 +31,19 @@ module Woods
       @to_h = nil
     end
 
-    # Register a unit in the graph
+    # Register a unit in the graph.
+    #
+    # Re-registering an identifier (incremental extraction registers into a
+    # graph loaded from disk) first removes the previous registration's
+    # reverse edges, file-map entry, and type-index entry — otherwise stale
+    # dependents accumulate across incremental runs and get persisted back
+    # to dependency_graph.json.
     #
     # @param unit [ExtractedUnit] The unit to register
     def register(unit)
       @to_h = nil
+
+      unregister(unit.identifier) if @nodes.key?(unit.identifier)
 
       @nodes[unit.identifier] = {
         type: unit.type,
@@ -54,6 +62,35 @@ module Woods
         (@reverse[dep[:target]] ||= Set.new).add(unit.identifier)
         (@reverse_via[[dep[:target], dep[:via]]] ||= Set.new).add(unit.identifier)
       end
+    end
+
+    # Remove an identifier's registration side effects: its contribution to
+    # the reverse indexes (derived from its recorded forward edges), its
+    # file-map entry, and its type-index entry. Forward node/edge data is
+    # overwritten by the caller (register), so it is not cleared here.
+    #
+    # @param identifier [String] Previously-registered unit identifier
+    # @return [void]
+    def unregister(identifier)
+      (@edges[identifier] || []).each do |edge|
+        if (set = @reverse[edge[:target]])
+          set.delete(identifier)
+          @reverse.delete(edge[:target]) if set.empty?
+        end
+
+        via_key = [edge[:target], edge[:via]]
+        next unless (set = @reverse_via[via_key])
+
+        set.delete(identifier)
+        @reverse_via.delete(via_key) if set.empty?
+      end
+
+      old_node = @nodes[identifier]
+      return unless old_node
+
+      old_path = old_node[:file_path]
+      @file_map.delete(old_path) if old_path && @file_map[old_path] == identifier
+      @type_index[old_node[:type]]&.delete(identifier)
     end
 
     # Find all units affected by changes to given files

--- a/lib/woods/embedding/text_preparer.rb
+++ b/lib/woods/embedding/text_preparer.rb
@@ -95,7 +95,12 @@ module Woods
       def append_dependency_line(lines, dependencies)
         return unless dependencies&.any?
 
-        dep_names = dependencies.map { |d| d[:target] }.compact.first(10)
+        # Dependency hashes arrive symbol-keyed from the extractor's
+        # in-memory units but string-keyed from the indexer (Indexer#build_unit
+        # reads JSON and does not symbolize dependency keys, unlike chunks).
+        # Read both forms or the whole "dependencies:" prefix silently
+        # vanishes from every embedded document on the indexing path.
+        dep_names = dependencies.filter_map { |d| d[:target] || d['target'] }.first(10)
         lines << "dependencies: #{dep_names.join(', ')}" if dep_names.any?
       end
 

--- a/lib/woods/extractor.rb
+++ b/lib/woods/extractor.rb
@@ -855,7 +855,11 @@ module Woods
         entries = JSON.parse(File.read(index_path))
         counts[File.basename(File.dirname(index_path)).to_sym] = entries.size
         chunks += entries.sum { |e| e['chunk_count'].to_i }
-      rescue JSON::ParserError
+      rescue JSON::ParserError => e
+        # An unreadable index silently drops that whole type from the manifest
+        # counts — warn rather than undercount without a trace.
+        type = File.basename(File.dirname(index_path))
+        Rails.logger.warn("[Woods] Skipping unreadable #{type}/_index.json in manifest counts: #{e.message}")
         next
       end
 

--- a/lib/woods/extractor.rb
+++ b/lib/woods/extractor.rb
@@ -8,6 +8,7 @@ require 'pathname'
 require 'set'
 
 require_relative 'filename_utils'
+require_relative 'token_utils'
 require_relative 'extracted_unit'
 require_relative 'dependency_graph'
 require_relative 'git_provenance'
@@ -527,6 +528,13 @@ module Woods
     # from disk), so units annotated in memory with metadata[:flow_paths]
     # must be re-written and their type index refreshed to pick up the
     # annotation.
+    #
+    # The index is rebuilt from the in-memory `units` (the authoritative
+    # full-extraction `@results`), NOT from a disk glob: this is a full
+    # extraction, the output dir is never wiped, and globbing would
+    # resurrect stale unit files for app classes deleted since the last run.
+    # (The incremental path, which only holds changed units in memory, still
+    # rebuilds from disk via {#regenerate_type_index}.)
     def rewrite_flow_annotated_units
       @results.each do |type, units|
         annotated = units.select { |u| u.metadata[:flow_paths] }
@@ -539,7 +547,10 @@ module Woods
             json_serialize(unit.to_h)
           )
         end
-        regenerate_type_index(type)
+        File.write(
+          type_dir.join('_index.json'),
+          json_serialize(type_index_entries(units))
+        )
       end
     end
 
@@ -734,20 +745,29 @@ module Woods
         end
 
         # Also write a type index for fast lookups
-        index = units.map do |u|
-          {
-            identifier: u.identifier,
-            file_path: u.file_path,
-            namespace: u.namespace,
-            estimated_tokens: u.estimated_tokens,
-            chunk_count: u.chunks.size
-          }
-        end
-
         File.write(
           type_dir.join('_index.json'),
-          json_serialize(index)
+          json_serialize(type_index_entries(units))
         )
+      end
+    end
+
+    # Build the `_index.json` entry list for a set of in-memory units.
+    # Shared by {#write_results} and {#rewrite_flow_annotated_units} so both
+    # emit the index from the authoritative in-memory `@results` rather than
+    # re-deriving it from disk.
+    #
+    # @param units [Array<ExtractedUnit>]
+    # @return [Array<Hash>]
+    def type_index_entries(units)
+      units.map do |u|
+        {
+          identifier: u.identifier,
+          file_path: u.file_path,
+          namespace: u.namespace,
+          estimated_tokens: u.estimated_tokens,
+          chunk_count: u.chunks.size
+        }
       end
     end
 
@@ -1001,8 +1021,8 @@ module Woods
       source = data['source_code']
       metadata = data['metadata'] || {}
 
-      source_tokens = source ? (source.length / 4.0).ceil : 0
-      metadata_tokens = metadata.any? ? (metadata.to_json.length / 4.0).ceil : 0
+      source_tokens = source ? TokenUtils.estimate_tokens(source) : 0
+      metadata_tokens = metadata.any? ? TokenUtils.estimate_tokens(metadata.to_json) : 0
       source_tokens + metadata_tokens
     end
 

--- a/lib/woods/extractor.rb
+++ b/lib/woods/extractor.rb
@@ -316,11 +316,17 @@ module Woods
         regenerate_type_index(type_key)
       end
 
-      # Update graph, manifest, and summary
+      # Update graph, manifest, and summary. No capture_snapshot here:
+      # snapshots must hash the FULL unit set, and incremental runs only
+      # re-extract affected units (@results stays empty) — capturing would
+      # record a snapshot whose diff reports every unit as deleted.
+      # Snapshots are captured on full extraction only.
       write_dependency_graph
-      write_manifest
+      write_manifest(incremental: true)
       write_structural_summary
-      capture_snapshot
+      if Woods.configuration.enable_snapshots
+        Rails.logger.info '[Woods] Skipping snapshot capture — snapshots are captured on full extraction only'
+      end
 
       affected_ids
     end
@@ -745,12 +751,23 @@ module Woods
       )
     end
 
-    def write_manifest
+    def write_manifest(incremental: false)
       # Worktree-aware git provenance. In a linked worktree +.git+ is a file
       # pointing at the real git dir; when that dir is unreachable (e.g. an
       # unmounted host path inside a container) this resolves to "unknown"
       # rather than a stale GIT_BRANCH/GIT_SHA build arg. See GitProvenance (#137).
       provenance = GitProvenance.new(root: Rails.root).to_h
+
+      # Incremental runs never populate @results — deriving counts from
+      # memory would clobber a good manifest with zeros. Recompute from the
+      # persisted per-type _index.json files instead.
+      counts, total_chunks =
+        if incremental
+          persisted_counts
+        else
+          [@results.transform_values(&:size),
+           @results.sum { |_, units| units.sum { |u| u.chunks.size } }]
+        end
 
       manifest = {
         extracted_at: Time.current.iso8601,
@@ -758,11 +775,11 @@ module Woods
         ruby_version: RUBY_VERSION,
 
         # Counts by type
-        counts: @results.transform_values(&:size),
+        counts: counts,
 
         # Total stats
-        total_units: @results.values.sum(&:size),
-        total_chunks: @results.sum { |_, units| units.sum { |u| u.chunks.size } },
+        total_units: counts.values.sum,
+        total_chunks: total_chunks,
 
         # Git provenance (branch/sha), or "unknown" when unresolvable
         git_sha: provenance[:git_sha],
@@ -777,6 +794,26 @@ module Woods
         @output_dir.join('manifest.json'),
         json_serialize(manifest)
       )
+    end
+
+    # Unit and chunk counts derived from the per-type _index.json files on
+    # disk — the source of truth after an incremental run, where only the
+    # affected units were re-extracted.
+    #
+    # @return [Array(Hash{Symbol => Integer}, Integer)] counts by type, total chunk count
+    def persisted_counts
+      counts = {}
+      chunks = 0
+
+      Dir[@output_dir.join('*/_index.json').to_s].each do |index_path|
+        entries = JSON.parse(File.read(index_path))
+        counts[File.basename(File.dirname(index_path)).to_sym] = entries.size
+        chunks += entries.sum { |e| e['chunk_count'].to_i }
+      rescue JSON::ParserError
+        next
+      end
+
+      [counts, chunks]
     end
 
     # Capture a temporal snapshot after extraction completes.
@@ -915,7 +952,10 @@ module Woods
           identifier: data['identifier'],
           file_path: data['file_path'],
           namespace: data['namespace'],
-          estimated_tokens: data['estimated_tokens'],
+          # Unit JSON has no estimated_tokens field (ExtractedUnit#to_h
+          # doesn't emit one) — recompute it, or every unit of a type
+          # touched by an incremental run would index as null.
+          estimated_tokens: estimated_tokens_from(data),
           chunk_count: (data['chunks'] || []).size
         }
       end
@@ -924,6 +964,20 @@ module Woods
         type_dir.join('_index.json'),
         json_serialize(index)
       )
+    end
+
+    # Token estimate for a unit parsed back from JSON, mirroring
+    # ExtractedUnit#estimated_tokens (see docs/TOKEN_BENCHMARK.md).
+    #
+    # @param data [Hash] Parsed unit JSON (string keys)
+    # @return [Integer]
+    def estimated_tokens_from(data)
+      source = data['source_code']
+      metadata = data['metadata'] || {}
+
+      source_tokens = source ? (source.length / 4.0).ceil : 0
+      metadata_tokens = metadata.any? ? (metadata.to_json.length / 4.0).ceil : 0
+      source_tokens + metadata_tokens
     end
 
     # ──────────────────────────────────────────────────────────────────────
@@ -1023,11 +1077,19 @@ module Woods
 
       return unless unit
 
-      # Update dependency graph
+      # Update dependency graph. Register BEFORE normalizing the path —
+      # the graph's file_map stores absolute paths (affected_by matches
+      # changed files against them), exactly as full extraction registers
+      # in Phase 1 and only normalizes in Phase 4.5.
       @dependency_graph.register(unit)
 
       # Track which type was affected
       affected_types&.add(extractor_key)
+
+      # Unit JSON carries Rails.root-relative paths (full extraction's
+      # Phase 4.5); writing the raw absolute source_location here would
+      # leak container-absolute paths into the index after incremental runs.
+      unit.file_path = normalize_file_path(unit.file_path)
 
       # Write updated unit
       type_dir = @output_dir.join(extractor_key.to_s)

--- a/lib/woods/extractor.rb
+++ b/lib/woods/extractor.rb
@@ -249,12 +249,6 @@ module Woods
       Rails.logger.info '[Woods] Analyzing dependency graph...'
       @graph_analysis = GraphAnalyzer.new(@dependency_graph).analyze
 
-      # Phase 3.5: Precompute request flows (opt-in)
-      if Woods.configuration.precompute_flows
-        Rails.logger.info '[Woods] Precomputing request flows...'
-        precompute_flows
-      end
-
       # Phase 4: Enrich with git data
       Rails.logger.info '[Woods] Enriching with git data...'
       enrich_with_git_data
@@ -266,6 +260,17 @@ module Woods
       # Phase 5: Write output
       Rails.logger.info '[Woods] Writing output...'
       write_results
+
+      # Phase 5.5: Precompute request flows (opt-in). Must run AFTER
+      # write_results — FlowAssembler loads unit JSON from disk, so running
+      # earlier assembled every flow from absent (fresh output dir) or
+      # stale (previous run's) data. precompute_flows re-writes the
+      # controller units it annotates with metadata[:flow_paths].
+      if Woods.configuration.precompute_flows
+        Rails.logger.info '[Woods] Precomputing request flows...'
+        precompute_flows
+      end
+
       write_dependency_graph
       write_graph_analysis
       write_manifest
@@ -512,9 +517,30 @@ module Woods
       all_units = @results.values.flatten(1)
       precomputer = FlowPrecomputer.new(units: all_units, graph: @dependency_graph, output_dir: @output_dir.to_s)
       flow_map = precomputer.precompute
+      rewrite_flow_annotated_units
       Rails.logger.info "[Woods] Precomputed #{flow_map.size} request flows"
     rescue StandardError => e
       Rails.logger.error "[Woods] Flow precomputation failed: #{e.message}"
+    end
+
+    # Precompute runs after write_results (FlowAssembler reads unit JSON
+    # from disk), so units annotated in memory with metadata[:flow_paths]
+    # must be re-written and their type index refreshed to pick up the
+    # annotation.
+    def rewrite_flow_annotated_units
+      @results.each do |type, units|
+        annotated = units.select { |u| u.metadata[:flow_paths] }
+        next if annotated.empty?
+
+        type_dir = @output_dir.join(type.to_s)
+        annotated.each do |unit|
+          File.write(
+            type_dir.join(collision_safe_filename(unit.identifier)),
+            json_serialize(unit.to_h)
+          )
+        end
+        regenerate_type_index(type)
+      end
     end
 
     # ──────────────────────────────────────────────────────────────────────

--- a/lib/woods/extractors/concern_extractor.rb
+++ b/lib/woods/extractors/concern_extractor.rb
@@ -48,10 +48,8 @@ module Woods
       #
       # @return [Array<ExtractedUnit>] List of concern units
       def extract_all
-        @directories.flat_map do |dir|
-          Dir[dir.join('**/*.rb')].filter_map do |file|
-            extract_concern_file(file)
-          end
+        find_files_in_directories(@directories).filter_map do |file|
+          extract_concern_file(file)
         end
       end
 
@@ -285,7 +283,7 @@ module Woods
         deps.concat(scan_service_dependencies(source))
         deps.concat(scan_job_dependencies(source))
 
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
     end
   end

--- a/lib/woods/extractors/configuration_extractor.rb
+++ b/lib/woods/extractors/configuration_extractor.rb
@@ -36,10 +36,8 @@ module Woods
       #
       # @return [Array<ExtractedUnit>] List of configuration units
       def extract_all
-        units = @directories.flat_map do |dir|
-          Dir[dir.join('**/*.rb')].filter_map do |file|
-            extract_configuration_file(file)
-          end
+        units = find_files_in_directories(@directories).filter_map do |file|
+          extract_configuration_file(file)
         end
 
         profile = BehavioralProfile.new.extract
@@ -212,7 +210,7 @@ module Woods
 
         deps.concat(scan_service_dependencies(source))
 
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
     end
   end

--- a/lib/woods/extractors/controller_extractor.rb
+++ b/lib/woods/extractors/controller_extractor.rb
@@ -320,7 +320,7 @@ module Woods
           deps.concat(scan_navigation_dependencies(source, via_type: :redirect_to))
         end
 
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
 
       # ──────────────────────────────────────────────────────────────────────

--- a/lib/woods/extractors/database_view_extractor.rb
+++ b/lib/woods/extractors/database_view_extractor.rb
@@ -271,7 +271,7 @@ module Woods
           deps << { type: :model, target: model_name, via: :table_name }
         end
 
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
     end
   end

--- a/lib/woods/extractors/decorator_extractor.rb
+++ b/lib/woods/extractors/decorator_extractor.rb
@@ -49,10 +49,8 @@ module Woods
       #
       # @return [Array<ExtractedUnit>] List of decorator units
       def extract_all
-        @directories.flat_map do |dir|
-          Dir[dir.join('**/*.rb')].filter_map do |file|
-            extract_decorator_file(file)
-          end
+        find_files_in_directories(@directories).filter_map do |file|
+          extract_decorator_file(file)
         end
       end
 
@@ -246,7 +244,7 @@ module Woods
 
         deps.concat(scan_common_dependencies(source))
 
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
     end
   end

--- a/lib/woods/extractors/event_extractor.rb
+++ b/lib/woods/extractors/event_extractor.rb
@@ -42,7 +42,7 @@ module Woods
       def extract_all
         event_map = {}
 
-        @directories.flat_map { |dir| Dir[dir.join('**/*.rb')] }.each do |file_path|
+        find_files_in_directories(@directories).each do |file_path|
           scan_file(file_path, event_map)
         end
 
@@ -204,7 +204,7 @@ module Woods
       # @return [Array<Hash>]
       def build_dependencies(combined_source)
         deps = scan_common_dependencies(combined_source)
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
     end
   end

--- a/lib/woods/extractors/factory_extractor.rb
+++ b/lib/woods/extractors/factory_extractor.rb
@@ -35,9 +35,7 @@ module Woods
       #
       # @return [Array<ExtractedUnit>] List of factory units
       def extract_all
-        @directories.flat_map do |dir|
-          Dir[dir.join('**/*.rb')].flat_map { |file| extract_factory_file(file) }
-        end
+        find_files_in_directories(@directories).flat_map { |file| extract_factory_file(file) }
       end
 
       # Extract factory definitions from a single factory file.
@@ -282,7 +280,7 @@ module Woods
           deps << { type: :factory, target: assoc, via: :factory_association }
         end
 
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
     end
   end

--- a/lib/woods/extractors/graphql_extractor.rb
+++ b/lib/woods/extractors/graphql_extractor.rb
@@ -770,7 +770,7 @@ module Woods
           deps << { type: :graphql_resolver, target: resolver, via: :field_resolver }
         end
 
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
 
       # ──────────────────────────────────────────────────────────────────────

--- a/lib/woods/extractors/i18n_extractor.rb
+++ b/lib/woods/extractors/i18n_extractor.rb
@@ -2,6 +2,8 @@
 
 require 'yaml'
 
+require_relative 'shared_utility_methods'
+
 module Woods
   module Extractors
     # I18nExtractor handles internationalization locale file extraction.
@@ -16,6 +18,8 @@ module Woods
     #   en = units.find { |u| u.identifier == "en.yml" }
     #
     class I18nExtractor
+      include SharedUtilityMethods
+
       # Directories to scan for locale files
       I18N_DIRECTORIES = %w[
         config/locales
@@ -30,10 +34,8 @@ module Woods
       #
       # @return [Array<ExtractedUnit>] List of i18n units
       def extract_all
-        @directories.flat_map do |dir|
-          Dir[dir.join('**/*.yml')].filter_map do |file|
-            extract_i18n_file(file)
-          end
+        find_files_in_directories(@directories, '**/*.yml').filter_map do |file|
+          extract_i18n_file(file)
         end
       end
 

--- a/lib/woods/extractors/job_extractor.rb
+++ b/lib/woods/extractors/job_extractor.rb
@@ -46,11 +46,9 @@ module Woods
         units = []
 
         # File-based discovery (catches everything)
-        @directories.each do |dir|
-          Dir[dir.join('**/*.rb')].each do |file|
-            unit = extract_job_file(file)
-            units << unit if unit
-          end
+        find_files_in_directories(@directories).each do |file|
+          unit = extract_job_file(file)
+          units << unit if unit
         end
 
         # Also try class-based discovery for ActiveJob
@@ -356,7 +354,7 @@ module Woods
 
         deps << { type: :infrastructure, target: :redis, via: :code_reference } if source.match?(/Redis\.current|REDIS/)
 
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
 
       # Scan source for job class enqueue calls and return the list of enqueued job names.

--- a/lib/woods/extractors/lib_extractor.rb
+++ b/lib/woods/extractors/lib_extractor.rb
@@ -211,7 +211,7 @@ module Woods
       # @return [Array<Hash>] Dependency hashes with :type, :target, :via
       def extract_dependencies(source)
         deps = scan_common_dependencies(source)
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
     end
   end

--- a/lib/woods/extractors/mailer_extractor.rb
+++ b/lib/woods/extractors/mailer_extractor.rb
@@ -243,7 +243,7 @@ module Woods
           deps << { type: :route, target: route, via: :url_helper }
         end
 
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
 
       # ──────────────────────────────────────────────────────────────────────

--- a/lib/woods/extractors/manager_extractor.rb
+++ b/lib/woods/extractors/manager_extractor.rb
@@ -40,10 +40,8 @@ module Woods
       #
       # @return [Array<ExtractedUnit>] List of manager units
       def extract_all
-        @directories.flat_map do |dir|
-          Dir[dir.join('**/*.rb')].filter_map do |file|
-            extract_manager_file(file)
-          end
+        find_files_in_directories(@directories).filter_map do |file|
+          extract_manager_file(file)
         end
       end
 
@@ -181,7 +179,7 @@ module Woods
 
         deps.concat(scan_common_dependencies(source))
 
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
     end
   end

--- a/lib/woods/extractors/migration_extractor.rb
+++ b/lib/woods/extractors/migration_extractor.rb
@@ -462,7 +462,7 @@ module Woods
         # Scan data migration code for common dependencies
         deps.concat(scan_common_dependencies(source))
 
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
     end
   end

--- a/lib/woods/extractors/model_extractor.rb
+++ b/lib/woods/extractors/model_extractor.rb
@@ -975,7 +975,10 @@ module Woods
 
       def callback_count(model)
         %i[validation save create update destroy commit rollback].sum do |type|
-          model.send("_#{type}_callbacks").size
+          # CallbackChain includes Enumerable but defines no #size on any
+          # supported Rails version — #size raises and the rescue would
+          # zero the count. #count is the only correct API here.
+          model.send("_#{type}_callbacks").count
         rescue StandardError
           0
         end

--- a/lib/woods/extractors/model_extractor.rb
+++ b/lib/woods/extractors/model_extractor.rb
@@ -654,7 +654,7 @@ module Woods
           end
         end
 
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
 
       # Enrich callback metadata with side-effect analysis.

--- a/lib/woods/extractors/model_extractor.rb
+++ b/lib/woods/extractors/model_extractor.rb
@@ -501,7 +501,7 @@ module Woods
               options: v.options.except(:if, :unless, :on),
               conditions: format_validation_conditions(v)
             }
-            entry[:implicit_belongs_to] = true if implicit_belongs_to_validator?(v)
+            entry[:implicit_belongs_to] = true if implicit_belongs_to_validator?(model, v)
             entry
           end
         end
@@ -922,17 +922,30 @@ module Woods
         conditions
       end
 
-      # Detect Rails-generated implicit belongs_to presence validators
+      # Detect Rails-generated implicit belongs_to presence validators.
       #
+      # `belongs_to` (with belongs_to_required_by_default, Rails 5+)
+      # registers an ActiveRecord PresenceValidator on the association
+      # attribute. Reflection offers no declaration provenance — the
+      # validator class and its #validate source_location are identical for
+      # an explicit `validates :assoc, presence: true` — so this flags any
+      # AR presence validator whose attributes are all belongs_to
+      # association names. (The previous source_location heuristic matched
+      # EVERY AR presence validator, since PresenceValidator#validate is
+      # always defined in the gem, never under Rails.root.)
+      #
+      # @param model [Class] The ActiveRecord model class
       # @param validator [ActiveModel::Validator]
       # @return [Boolean]
-      def implicit_belongs_to_validator?(validator)
-        if defined?(ActiveRecord::Validations::PresenceValidator) && !validator.is_a?(ActiveRecord::Validations::PresenceValidator)
-          return false
-        end
+      def implicit_belongs_to_validator?(model, validator)
+        return false unless defined?(ActiveRecord::Validations::PresenceValidator)
+        return false unless validator.is_a?(ActiveRecord::Validations::PresenceValidator)
 
-        loc = validator.class.instance_method(:validate).source_location&.first
-        loc && !loc.start_with?(Rails.root.to_s)
+        belongs_to_names = model.reflect_on_all_associations(:belongs_to).map { |r| r.name.to_sym }
+        return false if belongs_to_names.empty?
+
+        attributes = validator.respond_to?(:attributes) ? Array(validator.attributes) : []
+        attributes.any? && attributes.all? { |a| belongs_to_names.include?(a.to_sym) }
       rescue StandardError
         false
       end

--- a/lib/woods/extractors/phlex_extractor.rb
+++ b/lib/woods/extractors/phlex_extractor.rb
@@ -254,7 +254,7 @@ module Woods
         deps.concat(scan_navigation_dependencies(source))
         deps.concat(scan_form_dependencies(source))
 
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
     end
   end

--- a/lib/woods/extractors/policy_extractor.rb
+++ b/lib/woods/extractors/policy_extractor.rb
@@ -43,10 +43,8 @@ module Woods
       #
       # @return [Array<ExtractedUnit>] List of policy units
       def extract_all
-        @directories.flat_map do |dir|
-          Dir[dir.join('**/*.rb')].filter_map do |file|
-            extract_policy_file(file)
-          end
+        find_files_in_directories(@directories).filter_map do |file|
+          extract_policy_file(file)
         end
       end
 
@@ -184,7 +182,7 @@ module Woods
         deps.concat(scan_service_dependencies(source))
         deps.concat(scan_job_dependencies(source))
 
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
     end
   end

--- a/lib/woods/extractors/poro_extractor.rb
+++ b/lib/woods/extractors/poro_extractor.rb
@@ -222,7 +222,7 @@ module Woods
       # @return [Array<Hash>] Dependency hashes with :type, :target, :via
       def extract_dependencies(source)
         deps = scan_common_dependencies(source)
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
     end
   end

--- a/lib/woods/extractors/pundit_extractor.rb
+++ b/lib/woods/extractors/pundit_extractor.rb
@@ -38,10 +38,8 @@ module Woods
       #
       # @return [Array<ExtractedUnit>] List of Pundit policy units
       def extract_all
-        @directories.flat_map do |dir|
-          Dir[dir.join('**/*.rb')].filter_map do |file|
-            extract_pundit_file(file)
-          end
+        find_files_in_directories(@directories).filter_map do |file|
+          extract_pundit_file(file)
         end
       end
 
@@ -216,7 +214,7 @@ module Woods
         deps.concat(scan_model_dependencies(source))
         deps.concat(scan_service_dependencies(source))
 
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
     end
   end

--- a/lib/woods/extractors/rake_task_extractor.rb
+++ b/lib/woods/extractors/rake_task_extractor.rb
@@ -34,9 +34,7 @@ module Woods
       #
       # @return [Array<ExtractedUnit>] List of rake task units
       def extract_all
-        @directories.flat_map do |dir|
-          Dir[dir.join('**/*.rake')].flat_map { |file| extract_rake_file(file) }
-        end
+        find_files_in_directories(@directories, '**/*.rake').flat_map { |file| extract_rake_file(file) }
       end
 
       # Extract rake tasks from a single .rake file.
@@ -336,7 +334,7 @@ module Woods
           deps << { type: :rake_task, target: dep, via: :task_dependency }
         end
 
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
     end
   end

--- a/lib/woods/extractors/serializer_extractor.rb
+++ b/lib/woods/extractors/serializer_extractor.rb
@@ -52,11 +52,9 @@ module Woods
         units = []
 
         # File-based discovery (catches everything in known directories)
-        @directories.each do |dir|
-          Dir[dir.join('**/*.rb')].each do |file|
-            unit = extract_serializer_file(file)
-            units << unit if unit
-          end
+        find_files_in_directories(@directories).each do |file|
+          unit = extract_serializer_file(file)
+          units << unit if unit
         end
 
         # Class-based discovery for loaded gems
@@ -332,7 +330,7 @@ module Woods
 
         deps.concat(scan_service_dependencies(source))
 
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
     end
   end

--- a/lib/woods/extractors/service_extractor.rb
+++ b/lib/woods/extractors/service_extractor.rb
@@ -44,10 +44,8 @@ module Woods
       #
       # @return [Array<ExtractedUnit>] List of service units
       def extract_all
-        @directories.flat_map do |dir|
-          Dir[dir.join('**/*.rb')].filter_map do |file|
-            extract_service_file(file)
-          end
+        find_files_in_directories(@directories).filter_map do |file|
+          extract_service_file(file)
         end
       end
 
@@ -210,7 +208,7 @@ module Woods
           deps << { type: :infrastructure, target: :redis, via: :code_reference }
         end
 
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
     end
   end

--- a/lib/woods/extractors/shared_dependency_scanner.rb
+++ b/lib/woods/extractors/shared_dependency_scanner.rb
@@ -23,7 +23,7 @@ module Woods
     #     def extract_dependencies(source)
     #       deps = scan_common_dependencies(source)
     #       deps << { type: :custom, target: "Bar", via: :special }
-    #       deps.uniq { |d| [d[:type], d[:target]] }
+    #       consolidate_dependencies(deps)
     #     end
     #   end
     #
@@ -141,12 +141,27 @@ module Woods
       # @param source [String] Ruby source code to scan
       # @return [Array<Hash>] Deduplicated dependency hashes
       def scan_common_dependencies(source)
-        deps = []
-        deps.concat(scan_model_dependencies(source))
-        deps.concat(scan_service_dependencies(source))
-        deps.concat(scan_job_dependencies(source))
-        deps.concat(scan_mailer_dependencies(source))
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(
+          scan_model_dependencies(source),
+          scan_service_dependencies(source),
+          scan_job_dependencies(source),
+          scan_mailer_dependencies(source)
+        )
+      end
+
+      # Merge dependency arrays and deduplicate by +[type, target]+.
+      #
+      # Centralizes the `deps.uniq { |d| [d[:type], d[:target]] }` chain
+      # duplicated at the end of most extractors' +extract_dependencies+
+      # methods. Arrays are flattened one level and nils removed; the first
+      # occurrence of each +[type, target]+ pair wins, so the first +:via+
+      # label recorded is preserved — identical to the inline chains this
+      # replaces.
+      #
+      # @param dependency_arrays [Array<Array<Hash>>] One or more dependency arrays
+      # @return [Array<Hash>] Flattened, nil-free, deduplicated dependency hashes
+      def consolidate_dependencies(*dependency_arrays)
+        dependency_arrays.flatten(1).compact.uniq { |d| [d[:type], d[:target]] }
       end
 
       # Match _path/_url route helpers anywhere in source.

--- a/lib/woods/extractors/shared_dependency_scanner.rb
+++ b/lib/woods/extractors/shared_dependency_scanner.rb
@@ -45,22 +45,26 @@ module Woods
       # @param via [Symbol] Relationship label (default: :code_reference)
       # @return [Array<Hash>] Dependency hashes with :type, :target, :via
       def scan_model_dependencies(source, via: :code_reference)
+        # Strip `#` line comments before scanning so references inside
+        # YARD docstrings / TODO comments don't generate ghost edges.
+        # Applied to ALL passes — a commented `Library::Book` previously
+        # still produced an edge through the full-name pass, which the
+        # stripping was added to prevent. The negative lookahead `(?!\{)`
+        # keeps Ruby's `#{...}` string interpolation intact — stripping
+        # blindly would eat every model reference inside
+        # `"Book: #{Library::Book.new}"` etc., which is a common
+        # ERB/Phlex/string pattern.
+        scannable = source.gsub(/#(?!\{)[^\n]*/, '')
+
         targets = Set.new
-        source.scan(ModelNameCache.model_names_regex).each { |m| targets << m }
-        extract_constantize_targets(source).each { |t| targets << t }
+        scannable.scan(ModelNameCache.model_names_regex).each { |m| targets << m }
+        extract_constantize_targets(scannable).each { |t| targets << t }
 
         # Short-name + constantize resolution are additive passes guarded
         # by `respond_to?` so partial test doubles that only stub
         # `model_names_regex` still work. Real extraction runs always
         # have the full API.
         if ModelNameCache.respond_to?(:short_names_regex) && ModelNameCache.respond_to?(:resolve_short_name)
-          # Strip `#` line comments before scanning so references inside
-          # YARD docstrings / TODO comments don't generate ghost edges.
-          # The negative lookahead `(?!\{)` keeps Ruby's `#{...}` string
-          # interpolation intact — stripping blindly would eat every model
-          # reference inside `"Book: #{Library::Book.new}"` etc., which
-          # is a common ERB/Phlex/string pattern.
-          scannable = source.gsub(/#(?!\{)[^\n]*/, '')
           scannable.scan(ModelNameCache.short_names_regex).each do |short|
             resolved = ModelNameCache.resolve_short_name(short)
             targets << resolved if resolved

--- a/lib/woods/extractors/shared_dependency_scanner.rb
+++ b/lib/woods/extractors/shared_dependency_scanner.rb
@@ -82,10 +82,12 @@ module Woods
       # `redirect "/posts#comments"; Post.touch` at the in-string `#`,
       # silently dropping the `Post` reference. This scanner walks each line
       # tracking quote state so only a genuine (unquoted) `#` starts a
-      # comment. Escapes (`\"`, `\'`) inside literals are honored. Heredocs
-      # and `%`-literals are not modeled — a `#` inside those is rare in the
-      # constant-bearing code this scans, and treating it as a comment only
-      # risks a missed edge, never a crash.
+      # comment. Escapes (`\"`, `\'`) inside literals are honored. Heredocs,
+      # `%`-literals, and character literals whose char is a quote (`?'`,
+      # `?"`) are not modeled — these are rare in the constant-bearing code
+      # this scans, and mis-reading one only risks a spurious edge (a comment
+      # left unstripped) or a missed edge, never a crash or a dropped-but-real
+      # reference outside those constructs.
       #
       # @param source [String] Ruby source code
       # @return [String] source with unquoted `#` comments removed

--- a/lib/woods/extractors/shared_dependency_scanner.rb
+++ b/lib/woods/extractors/shared_dependency_scanner.rb
@@ -47,14 +47,15 @@ module Woods
       def scan_model_dependencies(source, via: :code_reference)
         # Strip `#` line comments before scanning so references inside
         # YARD docstrings / TODO comments don't generate ghost edges.
-        # Applied to ALL passes — a commented `Library::Book` previously
-        # still produced an edge through the full-name pass, which the
-        # stripping was added to prevent. The negative lookahead `(?!\{)`
-        # keeps Ruby's `#{...}` string interpolation intact — stripping
-        # blindly would eat every model reference inside
-        # `"Book: #{Library::Book.new}"` etc., which is a common
-        # ERB/Phlex/string pattern.
-        scannable = source.gsub(/#(?!\{)[^\n]*/, '')
+        # Applied to ALL passes — a commented `Library::Book` should not
+        # produce an edge through the full-name pass. Stripping is
+        # string-literal-aware: a `#` inside a `"..."`/`'...'` literal is
+        # NOT a comment, so a line like `link_to "Tag #ruby", Article.recent`
+        # keeps its `Article` reference (a plain `#...` regex would have
+        # eaten the rest of the line and dropped the edge). String
+        # interpolation (`"Book: #{Library::Book.new}"`) is preserved for the
+        # same reason — the `#{...}` lives inside the literal.
+        scannable = strip_ruby_line_comments(source)
 
         targets = Set.new
         scannable.scan(ModelNameCache.model_names_regex).each { |m| targets << m }
@@ -72,6 +73,56 @@ module Woods
         end
 
         targets.map { |model_name| { type: :model, target: model_name, via: via } }
+      end
+
+      # Remove `#` line comments from Ruby source without touching `#`
+      # characters that sit inside single- or double-quoted string literals.
+      #
+      # A naive `gsub(/#.*/, '')` truncates lines like
+      # `redirect "/posts#comments"; Post.touch` at the in-string `#`,
+      # silently dropping the `Post` reference. This scanner walks each line
+      # tracking quote state so only a genuine (unquoted) `#` starts a
+      # comment. Escapes (`\"`, `\'`) inside literals are honored. Heredocs
+      # and `%`-literals are not modeled — a `#` inside those is rare in the
+      # constant-bearing code this scans, and treating it as a comment only
+      # risks a missed edge, never a crash.
+      #
+      # @param source [String] Ruby source code
+      # @return [String] source with unquoted `#` comments removed
+      def strip_ruby_line_comments(source)
+        source.each_line.map { |line| strip_line_comment(line) }.join
+      end
+
+      # Strip a trailing `#` comment from a single line, ignoring `#` inside
+      # string literals. Preserves the line's trailing newline.
+      #
+      # @param line [String]
+      # @return [String]
+      def strip_line_comment(line)
+        in_single = false
+        in_double = false
+        i = 0
+        len = line.length
+        while i < len
+          ch = line[i]
+          if (in_single || in_double) && ch == '\\'
+            i += 2 # skip escaped char inside a literal
+            next
+          elsif in_single
+            in_single = false if ch == "'"
+          elsif in_double
+            in_double = false if ch == '"'
+          elsif ch == "'"
+            in_single = true
+          elsif ch == '"'
+            in_double = true
+          elsif ch == '#'
+            trailing = line[i..].end_with?("\n") ? "\n" : ''
+            return line[0...i] + trailing
+          end
+          i += 1
+        end
+        line
       end
 
       # Extract string-literal arguments passed to `.constantize` or

--- a/lib/woods/extractors/shared_utility_methods.rb
+++ b/lib/woods/extractors/shared_utility_methods.rb
@@ -20,6 +20,20 @@ module Woods
     #   end
     #
     module SharedUtilityMethods
+      # Glob files matching a pattern across a list of directories.
+      #
+      # Centralizes the `Dir[dir.join('**/*.rb')]` loop duplicated across
+      # the directory-scanning extractors. Directories are globbed in order
+      # and the per-directory results concatenated, matching the original
+      # per-directory iteration semantics.
+      #
+      # @param directories [Array<Pathname>] Directories to glob
+      # @param pattern [String] Glob pattern relative to each directory
+      # @return [Array<String>] Matching file paths
+      def find_files_in_directories(directories, pattern = '**/*.rb')
+        directories.flat_map { |dir| Dir[dir.join(pattern).to_s] }
+      end
+
       # Check whether a path points to application source (under app_root, but
       # not inside vendor/ or node_modules/ directories).
       #

--- a/lib/woods/extractors/state_machine_extractor.rb
+++ b/lib/woods/extractors/state_machine_extractor.rb
@@ -36,9 +36,7 @@ module Woods
       #
       # @return [Array<ExtractedUnit>] List of state machine units
       def extract_all
-        @directories.flat_map do |dir|
-          Dir[dir.join('**/*.rb')].flat_map { |file| extract_model_file(file) }
-        end
+        find_files_in_directories(@directories).flat_map { |file| extract_model_file(file) }
       end
 
       # Extract state machine definitions from a single model file.
@@ -391,7 +389,7 @@ module Woods
         deps = [{ type: :model, target: class_name, via: :state_machine }]
         deps.concat(scan_service_dependencies(source, via: :state_machine_callback))
         deps.concat(scan_job_dependencies(source, via: :state_machine_callback))
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
     end
   end

--- a/lib/woods/extractors/validator_extractor.rb
+++ b/lib/woods/extractors/validator_extractor.rb
@@ -41,10 +41,8 @@ module Woods
       #
       # @return [Array<ExtractedUnit>] List of validator units
       def extract_all
-        @directories.flat_map do |dir|
-          Dir[dir.join('**/*.rb')].filter_map do |file|
-            extract_validator_file(file)
-          end
+        find_files_in_directories(@directories).filter_map do |file|
+          extract_validator_file(file)
         end
       end
 
@@ -204,7 +202,7 @@ module Woods
           deps << { type: :validator, target: validator, via: :code_reference }
         end
 
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
     end
   end

--- a/lib/woods/extractors/view_component_extractor.rb
+++ b/lib/woods/extractors/view_component_extractor.rb
@@ -315,7 +315,7 @@ module Woods
           deps << { type: :route, target: route, via: :url_helper }
         end
 
-        deps.uniq { |d| [d[:type], d[:target]] }
+        consolidate_dependencies(deps)
       end
     end
   end

--- a/lib/woods/filename_utils.rb
+++ b/lib/woods/filename_utils.rb
@@ -8,12 +8,41 @@ module Woods
   # Used by Extractor (writing) and IndexValidator (reading) to ensure
   # filename generation is consistent across both sides.
   module FilenameUtils
+    # Normalize a single identifier segment for use in a filename: replace
+    # `::` with `__` and every other non-`[a-zA-Z0-9_-]` character with `_`.
+    # This is the one character transform shared by {#safe_filename},
+    # {#collision_safe_filename}, and the precomputed-flow reader/writer
+    # (via {.flow_filename}) so the sides of each filename contract cannot
+    # drift. Also usable as a module method (`FilenameUtils.safe_segment`)
+    # for callers that don't mix the module in.
+    #
+    # @param identifier [String]
+    # @return [String]
+    def self.safe_segment(identifier)
+      identifier.to_s.gsub('::', '__').gsub(/[^a-zA-Z0-9_-]/, '_')
+    end
+
+    # Filename for a precomputed request-flow document, combining the
+    # controller identifier and action name — each normalized via
+    # {.safe_segment}. Used by both {Woods::FlowPrecomputer} (writing) and the
+    # MCP server's `trace_flow` (reading) so a name containing an
+    # out-of-charset character is written and looked up under the SAME file
+    # (the writer previously left the action raw while the reader allow-listed
+    # it, so such flows were written under one name and never found).
+    #
+    # @param controller_id [String] e.g. "Admin::UsersController"
+    # @param action [String] e.g. "index"
+    # @return [String] e.g. "Admin__UsersController_index.json"
+    def self.flow_filename(controller_id, action)
+      "#{safe_segment(controller_id)}_#{safe_segment(action)}.json"
+    end
+
     # Convert an identifier to a safe filename (legacy format).
     #
     # @param identifier [String] The unit identifier (e.g., "Admin::UsersController")
     # @return [String] A filesystem-safe filename (e.g., "Admin__UsersController.json")
     def safe_filename(identifier)
-      "#{identifier.gsub('::', '__').gsub(/[^a-zA-Z0-9_-]/, '_')}.json"
+      "#{FilenameUtils.safe_segment(identifier)}.json"
     end
 
     # Convert an identifier to a collision-safe filename (current format).
@@ -24,7 +53,7 @@ module Woods
     # @param identifier [String] The unit identifier
     # @return [String] Collision-safe filename (e.g., "Admin__UsersController_a1b2c3d4.json")
     def collision_safe_filename(identifier)
-      base = identifier.gsub('::', '__').gsub(/[^a-zA-Z0-9_-]/, '_')
+      base = FilenameUtils.safe_segment(identifier)
       digest = Digest::SHA256.hexdigest(identifier)[0, 8]
       "#{base}_#{digest}.json"
     end

--- a/lib/woods/flow_assembler.rb
+++ b/lib/woods/flow_assembler.rb
@@ -60,19 +60,26 @@ module Woods
 
     # Recursively expand a unit into flow steps.
     #
+    # A cycle is a re-encounter on the CURRENT recursion path (tracked in
+    # +path+, popped on exit — the gray set of a DFS). A unit already
+    # expanded via a sibling branch (a DAG diamond: two services calling
+    # the same model) is plain dedup, not a cycle — it is skipped silently
+    # rather than mislabeled with a cycle marker.
+    #
     # @param identifier [String] Unit identifier (may include #method)
     # @param steps [Array<Hash>] Accumulator for step hashes
-    # @param visited [Set<String>] Visited unit identifiers for cycle detection
+    # @param visited [Set<String>] Already-expanded unit identifiers (dedup)
     # @param depth [Integer] Current recursion depth
     # @param max_depth [Integer] Maximum recursion depth
-    def expand(identifier, steps, visited, depth:, max_depth:)
+    # @param path [Set<String>] Identifiers on the current recursion path
+    def expand(identifier, steps, visited, depth:, max_depth:, path: Set.new)
       return if depth > max_depth
 
       # Parse identifier into unit name and optional method
       unit_id, method_name = parse_identifier(identifier)
 
-      if visited.include?(unit_id)
-        # Cycle detected - emit a marker step
+      if path.include?(unit_id)
+        # Genuine cycle — the unit is an ancestor of itself on this path.
         steps << {
           unit: unit_id,
           type: 'cycle',
@@ -81,34 +88,44 @@ module Woods
         return
       end
 
+      # Already expanded through another branch — dedup, not a cycle.
+      return if visited.include?(unit_id)
+
       visited.add(unit_id)
+      path.add(unit_id)
 
-      # Load the unit data from disk
-      unit_data = load_unit(unit_id)
-      return unless unit_data
+      begin
+        # Load the unit data from disk
+        unit_data = load_unit(unit_id)
+        return unless unit_data
 
-      source_code = unit_data[:source_code]
-      return unless source_code && !source_code.empty?
+        source_code = unit_data[:source_code]
+        return unless source_code && !source_code.empty?
 
-      metadata = unit_data[:metadata] || {}
-      unit_type = unit_data[:type]&.to_s
-      file_path = unit_data[:file_path]
+        metadata = unit_data[:metadata] || {}
+        unit_type = unit_data[:type]&.to_s
+        file_path = unit_data[:file_path]
 
-      # Extract operations from the relevant method
-      operations = extract_operations(source_code, method_name, metadata, unit_type)
+        # Extract operations from the relevant method
+        operations = extract_operations(source_code, method_name, metadata, unit_type)
 
-      step = {
-        unit: identifier,
-        type: unit_type,
-        file_path: file_path,
-        operations: operations
-      }
+        step = {
+          unit: identifier,
+          type: unit_type,
+          file_path: file_path,
+          operations: operations
+        }
 
-      steps << step
+        steps << step
 
-      # Recursively expand targets that resolve to known units
-      operations.each do |op|
-        expand_operation(op, identifier, steps, visited, depth: depth, max_depth: max_depth)
+        # Recursively expand targets that resolve to known units
+        operations.each do |op|
+          expand_operation(op, identifier, steps, visited, depth: depth, max_depth: max_depth, path: path)
+        end
+      ensure
+        # Pop on every exit (including the early returns above) — a unit
+        # left on the path would make sibling branches report false cycles.
+        path.delete(unit_id)
       end
     end
 
@@ -178,7 +195,7 @@ module Woods
     # @param visited [Set<String>] Visited unit identifiers for cycle detection
     # @param depth [Integer] Current recursion depth
     # @param max_depth [Integer] Maximum recursion depth
-    def expand_operation(op, current_unit, steps, visited, depth:, max_depth:)
+    def expand_operation(op, current_unit, steps, visited, depth:, max_depth:, path: Set.new)
       case op[:type]
       when :call, :async
         target = op[:target]
@@ -187,14 +204,14 @@ module Woods
         candidate = resolve_target(target)
         return unless candidate
 
-        expand(candidate, steps, visited, depth: depth + 1, max_depth: max_depth)
+        expand(candidate, steps, visited, depth: depth + 1, max_depth: max_depth, path: path)
       when :transaction
         (op[:nested] || []).each do |nested_op|
-          expand_operation(nested_op, current_unit, steps, visited, depth: depth, max_depth: max_depth)
+          expand_operation(nested_op, current_unit, steps, visited, depth: depth, max_depth: max_depth, path: path)
         end
       when :conditional
         ((op[:then_ops] || []) + (op[:else_ops] || [])).each do |branch_op|
-          expand_operation(branch_op, current_unit, steps, visited, depth: depth, max_depth: max_depth)
+          expand_operation(branch_op, current_unit, steps, visited, depth: depth, max_depth: max_depth, path: path)
         end
       end
     end

--- a/lib/woods/flow_precomputer.rb
+++ b/lib/woods/flow_precomputer.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 require 'fileutils'
+require_relative 'filename_utils'
 require_relative 'flow_assembler'
 
 module Woods
@@ -80,7 +81,7 @@ module Woods
     def assemble_and_write(assembler, entry_point, controller_id, action)
       flow = assembler.assemble(entry_point, max_depth: @max_depth)
 
-      filename = "#{controller_id.gsub('::', '__')}_#{action}.json"
+      filename = Woods::FilenameUtils.flow_filename(controller_id, action)
       flow_path = File.join(@flows_dir, filename)
 
       File.write(flow_path, canonical_json(flow.to_h))

--- a/lib/woods/index_artifact.rb
+++ b/lib/woods/index_artifact.rb
@@ -127,7 +127,11 @@ module Woods
       target_real = target.exist? ? target.realpath.to_s : ''
       # Resolve symlinks on both sides before comparing (handles macOS /tmp → /private/var)
       root_resolved = Pathname.new(root_real).exist? ? Pathname.new(root_real).realpath.to_s : root_real
-      unless target.exist? && target_real.start_with?(root_resolved)
+      # Prefix must end at a path boundary — a bare start_with? would accept
+      # sibling directories like "dumps-backup" or "dumpsevil", and the
+      # basename-only pointer written below would then name a directory that
+      # doesn't exist under dumps_root.
+      unless target.exist? && target_real.start_with?("#{root_resolved}#{File::SEPARATOR}")
         raise ArgumentError,
               'dump_dir must exist inside dumps_root. ' \
               "Got: #{dump_dir.inspect}, dumps_root: #{dumps_root}"

--- a/lib/woods/mcp/server.rb
+++ b/lib/woods/mcp/server.rb
@@ -7,6 +7,7 @@ require 'open3'
 require 'time'
 require 'set'
 require_relative '../tasks'
+require_relative '../filename_utils'
 require_relative 'index_reader'
 require_relative 'tool_response_renderer'
 
@@ -161,15 +162,18 @@ module Woods
         end
 
         # Notion export needs both an API token and at least one database ID.
-        # NOTION_API_TOKEN env var overrides the config token (see
-        # docs/NOTION_EXPORT.md).
+        # A non-blank NOTION_API_TOKEN env var overrides the config token (see
+        # docs/NOTION_EXPORT.md). Resolution goes through
+        # Woods.resolve_notion_token so a blank env var is treated as absent
+        # (rather than masking a valid configured token) — matching the
+        # exporter and the notion_sync handler.
         def notion_wired?
           config = Woods.configuration
           return false unless config
 
-          token = ENV['NOTION_API_TOKEN'] || (config.respond_to?(:notion_api_token) ? config.notion_api_token : nil)
+          token = Woods.resolve_notion_token(config)
           ids = config.respond_to?(:notion_database_ids) ? config.notion_database_ids : nil
-          token && !token.empty? && ids && !ids.empty?
+          !token.nil? && ids && !ids.empty?
         end
 
         def text_response(text)
@@ -264,13 +268,11 @@ module Woods
           controller, action = entry_point.split('#', 2)
           return nil if controller.empty? || action.empty?
 
-          # entry_point is client input — allow-list both parts (the same
-          # character set FilenameUtils uses) so `/` and `..` can't traverse
-          # outside flows/. For legitimate controller/action names this is
-          # the identity transform, matching what FlowPrecomputer wrote.
-          safe_controller = controller.gsub('::', '__').gsub(/[^a-zA-Z0-9_-]/, '_')
-          safe_action = action.gsub(/[^a-zA-Z0-9_-]/, '_')
-          filename = "#{safe_controller}_#{safe_action}.json"
+          # entry_point is client input — FilenameUtils.flow_filename
+          # allow-lists both parts (so `/` and `..` can't traverse outside
+          # flows/) using the SAME transform FlowPrecomputer writes with, so a
+          # legitimately precomputed flow always resolves to the file on disk.
+          filename = Woods::FilenameUtils.flow_filename(controller, action)
           path = File.join(index_dir, 'flows', filename)
           return nil unless File.exist?(path)
 
@@ -1343,10 +1345,11 @@ module Woods
           ) do |server_context:|
             config = Woods.configuration
             # Mirror notion_wired? (which gates registration) and the
-            # Exporter: the NOTION_API_TOKEN env var satisfies the token
-            # requirement. Reading config alone rejected ENV-only hosts even
-            # though the tool was registered for them.
-            if (ENV['NOTION_API_TOKEN'] || config.notion_api_token).to_s.empty?
+            # Exporter via the shared resolver: a non-blank NOTION_API_TOKEN
+            # env var satisfies the token requirement (reading config alone
+            # rejected ENV-only hosts even though the tool was registered for
+            # them), while a blank env var is treated as absent.
+            if Woods.resolve_notion_token(config).nil?
               next respond_err.call(
                 'notion_api_token is not configured. Set it in Woods.configure or via the NOTION_API_TOKEN env var.',
                 code: :not_configured,

--- a/lib/woods/mcp/server.rb
+++ b/lib/woods/mcp/server.rb
@@ -881,11 +881,33 @@ module Woods
             description: 'Trigger a codebase extraction pipeline run. Checks rate limits before proceeding.',
             input_schema: {
               properties: {
-                incremental: { type: 'boolean', description: 'Run incremental extraction (default: false)' }
+                incremental: { type: 'boolean', description: 'Run incremental extraction (default: false)' },
+                changed_files: {
+                  type: 'array',
+                  items: { type: 'string' },
+                  description: 'Required when incremental is true: repo-relative paths of changed files ' \
+                               '(the MCP server has no git context to compute them itself).'
+                }
               }
             }
-          ) do |server_context:, incremental: nil|
+          ) do |server_context:, incremental: nil, changed_files: nil|
             next op_missing.call('pipeline_extract') unless operator
+
+            # Incremental extraction re-extracts only the units affected by
+            # the given files. The MCP server has no git-diff context (unlike
+            # the rake task, which derives them from CHANGED_FILES / CI env),
+            # so an empty list would re-extract nothing while still bumping
+            # the manifest timestamp — a silent no-op reporting success.
+            # Require the caller to supply the changed files explicitly.
+            files = Array(changed_files).map(&:to_s).reject(&:empty?)
+            if incremental && files.empty?
+              next respond_err.call(
+                'Incremental extraction requires a non-empty changed_files list. ' \
+                'Pass the changed paths, or run `rake woods:incremental` which derives them from git.',
+                code: :invalid_params,
+                tool: 'pipeline_extract'
+              )
+            end
 
             guard = operator[:pipeline_guard]
             if guard && !guard.allow?(:extraction)
@@ -916,7 +938,7 @@ module Woods
               extractor = Woods::Extractor.new(
                 output_dir: Woods.configuration.output_dir
               )
-              incremental ? extractor.extract_changed([]) : extractor.extract_all
+              incremental ? extractor.extract_changed(files) : extractor.extract_all
             rescue StandardError => e
               logger = defined?(Rails) ? Rails.logger : Logger.new($stderr)
               logger.error("[Woods] Pipeline extract failed: #{e.message}")
@@ -1054,9 +1076,11 @@ module Woods
               )
             end
 
+            # Pass the client-supplied class name so class-keyed patterns
+            # (Timeout, Net::, Errno::ENOENT, …) match — a bare
+            # StandardError would classify everything as :unknown.
             error = StandardError.new(error_message)
-            # Set the class name in the error string for pattern matching
-            result = escalator.classify(error)
+            result = escalator.classify(error, class_name: error_class)
             result[:original_class] = error_class
             respond.call(JSON.pretty_generate(result))
           end
@@ -1308,7 +1332,11 @@ module Woods
             }
           ) do |server_context:|
             config = Woods.configuration
-            unless config.notion_api_token
+            # Mirror notion_wired? (which gates registration) and the
+            # Exporter: the NOTION_API_TOKEN env var satisfies the token
+            # requirement. Reading config alone rejected ENV-only hosts even
+            # though the tool was registered for them.
+            if (ENV['NOTION_API_TOKEN'] || config.notion_api_token).to_s.empty?
               next respond_err.call(
                 'notion_api_token is not configured. Set it in Woods.configure or via the NOTION_API_TOKEN env var.',
                 code: :not_configured,

--- a/lib/woods/mcp/server.rb
+++ b/lib/woods/mcp/server.rb
@@ -27,6 +27,15 @@ module Woods
     #   transport.open
     #
     module Server
+      # Module-level pipeline serialization state, eagerly initialized at load
+      # time (self == Server here). The HTTP transport dispatches tool handlers
+      # concurrently, so a lazy `@pipeline_mutex ||= Mutex.new` inside
+      # pipeline_start would let two handlers each create a DIFFERENT mutex and
+      # synchronize on separate locks — defeating the exclusion and allowing two
+      # concurrent pipelines of the same kind.
+      @pipeline_mutex = Mutex.new
+      @pipeline_in_flight = {}
+
       class << self
         # Build a configured MCP::Server with all tools and resources.
         #
@@ -1015,8 +1024,9 @@ module Woods
         # pipeline). Module-level state — a single MCP server process
         # serializes its own pipelines.
         def pipeline_start(kind)
-          @pipeline_mutex ||= Mutex.new
-          @pipeline_in_flight ||= {}
+          # @pipeline_mutex / @pipeline_in_flight are initialized eagerly in
+          # the module body — no lazy `||=` here, which would race under the
+          # concurrent HTTP transport.
           @pipeline_mutex.synchronize do
             return false if @pipeline_in_flight[kind]
 
@@ -1026,7 +1036,7 @@ module Woods
         end
 
         def pipeline_finish(kind)
-          @pipeline_mutex&.synchronize { @pipeline_in_flight&.delete(kind) }
+          @pipeline_mutex.synchronize { @pipeline_in_flight.delete(kind) }
         end
 
         def define_pipeline_status_tool(server, operator, respond, respond_err, op_missing)

--- a/lib/woods/mcp/server.rb
+++ b/lib/woods/mcp/server.rb
@@ -255,7 +255,13 @@ module Woods
           controller, action = entry_point.split('#', 2)
           return nil if controller.empty? || action.empty?
 
-          filename = "#{controller.gsub('::', '__')}_#{action}.json"
+          # entry_point is client input — allow-list both parts (the same
+          # character set FilenameUtils uses) so `/` and `..` can't traverse
+          # outside flows/. For legitimate controller/action names this is
+          # the identity transform, matching what FlowPrecomputer wrote.
+          safe_controller = controller.gsub('::', '__').gsub(/[^a-zA-Z0-9_-]/, '_')
+          safe_action = action.gsub(/[^a-zA-Z0-9_-]/, '_')
+          filename = "#{safe_controller}_#{safe_action}.json"
           path = File.join(index_dir, 'flows', filename)
           return nil unless File.exist?(path)
 

--- a/lib/woods/model_name_cache.rb
+++ b/lib/woods/model_name_cache.rb
@@ -87,7 +87,12 @@ module Woods
         names = model_names
         return /(?!)/ if names.empty? # never-matching regex
 
-        /\b(?:#{names.map { |n| Regexp.escape(n) }.join('|')})\b/
+        # Longest-first: regex alternation is ordered, not longest-match.
+        # Without the sort, a reference to Library::Book::Chapter can match
+        # the shorter Library::Book alternative (\b is satisfied at the
+        # following ":"), emitting an edge to the wrong model.
+        sorted = names.sort_by { |n| -n.length }
+        /\b(?:#{sorted.map { |n| Regexp.escape(n) }.join('|')})\b/
       end
 
       # Build short-name → full-name mapping. A short name that appears on

--- a/lib/woods/notion/client.rb
+++ b/lib/woods/notion/client.rb
@@ -4,6 +4,7 @@ require 'json'
 require 'net/http'
 require 'uri'
 require 'woods'
+require_relative '../retry_after'
 require_relative 'rate_limiter'
 
 module Woods
@@ -135,7 +136,9 @@ module Woods
 
           if response.code == '429' && retries < MAX_RETRIES
             retries += 1
-            wait_time = (response['Retry-After'] || retries).to_f
+            # Retry-After may be an HTTP-date, which .to_f would collapse to
+            # 0.0 — honoring it as-is would hammer a throttling server.
+            wait_time = Woods::RetryAfter.seconds(response['Retry-After'], fallback: retries)
             sleep(wait_time)
             next
           end

--- a/lib/woods/notion/exporter.rb
+++ b/lib/woods/notion/exporter.rb
@@ -25,11 +25,13 @@ module Woods
       # @param reader [Object, nil] IndexReader instance (auto-created from index_dir if nil)
       # @raise [ConfigurationError] if notion_api_token is not configured
       def initialize(index_dir:, config: Woods.configuration, client: nil, reader: nil)
-        # NOTION_API_TOKEN overrides the configured token (documented
-        # contract; also what the MCP notion_wired? gate keys on). Resolve
-        # it here, the single consumption point, so the MCP tool and rake
-        # task behave identically on an ENV-only host.
-        api_token = ENV['NOTION_API_TOKEN'] || config.notion_api_token
+        # A non-blank NOTION_API_TOKEN overrides the configured token
+        # (documented contract; also what the MCP notion_wired? gate keys on).
+        # Resolve via the shared Woods.resolve_notion_token so the exporter,
+        # the MCP tool, and the rake task treat a blank env var identically —
+        # a set-but-empty NOTION_API_TOKEN must not mask a configured token or
+        # pass through as a blank bearer.
+        api_token = Woods.resolve_notion_token(config)
         raise ConfigurationError, 'notion_api_token is required for Notion export' unless api_token
 
         @database_ids = config.notion_database_ids || {}

--- a/lib/woods/notion/exporter.rb
+++ b/lib/woods/notion/exporter.rb
@@ -25,7 +25,11 @@ module Woods
       # @param reader [Object, nil] IndexReader instance (auto-created from index_dir if nil)
       # @raise [ConfigurationError] if notion_api_token is not configured
       def initialize(index_dir:, config: Woods.configuration, client: nil, reader: nil)
-        api_token = config.notion_api_token
+        # NOTION_API_TOKEN overrides the configured token (documented
+        # contract; also what the MCP notion_wired? gate keys on). Resolve
+        # it here, the single consumption point, so the MCP tool and rake
+        # task behave identically on an ENV-only host.
+        api_token = ENV['NOTION_API_TOKEN'] || config.notion_api_token
         raise ConfigurationError, 'notion_api_token is required for Notion export' unless api_token
 
         @database_ids = config.notion_database_ids || {}

--- a/lib/woods/operator/error_escalator.rb
+++ b/lib/woods/operator/error_escalator.rb
@@ -37,22 +37,33 @@ module Woods
 
       # Classify an error by severity and suggest remediation.
       #
+      # Most patterns key on the error's class name, so a caller that only
+      # has the class name as a string (e.g. the pipeline_diagnose MCP tool,
+      # which receives error_class over the wire and can't reconstruct the
+      # real exception class) must pass +class_name:+ — otherwise the
+      # synthesized StandardError makes every class-keyed pattern miss and
+      # the error falls through to :unknown.
+      #
       # @param error [StandardError] The error to classify
+      # @param class_name [String, nil] Override for the class name used in
+      #   pattern matching and reported as :error_class (defaults to
+      #   error.class.name)
       # @return [Hash] :severity (:transient or :permanent), :category, :remediation, :error_class, :message
-      def classify(error)
-        error_string = "#{error.class} #{error.message}"
+      def classify(error, class_name: nil)
+        resolved_class = class_name || error.class.name
+        error_string = "#{resolved_class} #{error.message}"
 
         match = find_match(error_string, TRANSIENT_PATTERNS, :transient) ||
                 find_match(error_string, PERMANENT_PATTERNS, :permanent)
 
         if match
-          match.merge(error_class: error.class.name, message: error.message)
+          match.merge(error_class: resolved_class, message: error.message)
         else
           {
             severity: :unknown,
             category: 'unclassified',
             remediation: 'Investigate error details and check logs',
-            error_class: error.class.name,
+            error_class: resolved_class,
             message: error.message
           }
         end

--- a/lib/woods/resilience/circuit_breaker.rb
+++ b/lib/woods/resilience/circuit_breaker.rb
@@ -76,14 +76,14 @@ module Woods
         rescue StandardError => e
           @mutex.synchronize do
             @half_open_probe_in_flight = false if probing
-            record_failure
+            record_failure(probing)
           end
           raise e
         end
 
         @mutex.synchronize do
           @half_open_probe_in_flight = false if probing
-          record_success
+          record_success(probing)
         end
         result
       end
@@ -132,21 +132,37 @@ module Woods
       end
 
       # Record a failure and potentially open the circuit. A failure while
-      # half_open reopens immediately, regardless of the failure threshold.
-      def record_failure
+      # half_open reopens immediately, regardless of the failure threshold —
+      # but only when it is the genuine in-flight probe. A stale call
+      # admitted while the circuit was still closed, completing after the
+      # transition to half_open, is not the probe and must not decide
+      # recovery (its outcome reflects the pre-outage attempt, not the
+      # current one).
+      #
+      # @param probing [Boolean] whether this call was admitted as the probe
+      def record_failure(probing)
+        return if @state == :half_open && !probing
+
         @failure_count += 1
         @last_failure_time = monotonic_now
         @success_count = 0
         @state = :open if @state == :half_open || @failure_count >= @threshold
       end
 
-      # Record a success. In half_open, close only after enough consecutive
-      # successful probes; in closed, a success clears accumulated failures.
-      def record_success
+      # Record a success. In half_open, only the in-flight probe advances
+      # recovery — a stale non-probe success (a call admitted while closed
+      # that resolves after the circuit went half_open) must not count toward
+      # the success threshold or close the circuit. In closed, a success
+      # clears accumulated failures.
+      #
+      # @param probing [Boolean] whether this call was admitted as the probe
+      def record_success(probing)
         if @state == :half_open
+          return unless probing
+
           @success_count += 1
           reset! if @success_count >= @success_threshold
-        else
+        elsif @state == :closed
           @failure_count = 0
         end
       end

--- a/lib/woods/resilience/circuit_breaker.rb
+++ b/lib/woods/resilience/circuit_breaker.rb
@@ -36,50 +36,93 @@ module Woods
 
       # @param threshold [Integer] Number of consecutive failures before opening the circuit
       # @param reset_timeout [Numeric] Seconds to wait before transitioning from open to half_open
-      def initialize(threshold: 5, reset_timeout: 60)
+      # @param success_threshold [Integer] Number of consecutive successful probes required to
+      #   close the circuit from half_open (default 1). Higher values reduce flapping when a
+      #   recovering service is still intermittently failing.
+      def initialize(threshold: 5, reset_timeout: 60, success_threshold: 1)
         @threshold = threshold
         @reset_timeout = reset_timeout
+        @success_threshold = success_threshold
         @state = :closed
         @failure_count = 0
+        @success_count = 0
         @last_failure_time = nil
+        @half_open_probe_in_flight = false
         @mutex = Mutex.new
       end
 
       # Execute a block through the circuit breaker.
       #
+      # In half_open, only a SINGLE probe is admitted at a time: concurrent
+      # calls are rejected with {CircuitOpenError} until the probe resolves.
+      # This prevents a thundering herd of probes against a still-recovering
+      # service, and — because probes can't overlap — removes the race where a
+      # slow probe's success would wipe failures recorded by a concurrent one.
+      #
       # @yield The block to execute
       # @return [Object] The return value of the block
-      # @raise [CircuitOpenError] if the circuit is open and the timeout has not elapsed
+      # @raise [CircuitOpenError] if the circuit is open, or half_open with a probe already in flight
       # @raise [StandardError] re-raises any error from the block
       def call(&block)
-        # Phase 1: Check state under mutex
-        @mutex.synchronize do
-          case @state
-          when :open
-            unless monotonic_now - @last_failure_time >= @reset_timeout
-              raise CircuitOpenError, "Circuit breaker is open (#{@failure_count} failures)"
-            end
+        probing = admit_call!
 
-            @state = :half_open
+        begin
+          result = block.call
+        rescue CircuitOpenError
+          # A nested breaker tripped — release our probe slot but don't count
+          # it as this breaker's own failure.
+          @mutex.synchronize { @half_open_probe_in_flight = false if probing }
+          raise
+        rescue StandardError => e
+          @mutex.synchronize do
+            @half_open_probe_in_flight = false if probing
+            record_failure
           end
+          raise e
         end
 
-        # Phase 2: Execute outside mutex
-        result = block.call
-
-        # Phase 3: Record success under mutex
-        @mutex.synchronize { reset! }
-
+        @mutex.synchronize do
+          @half_open_probe_in_flight = false if probing
+          record_success
+        end
         result
-      rescue CircuitOpenError
-        raise
-      rescue StandardError => e
-        # Phase 4: Record failure under mutex
-        @mutex.synchronize { record_failure }
-        raise e
       end
 
       private
+
+      # Decide whether this call may proceed, transitioning open→half_open when
+      # the reset timeout has elapsed. Runs entirely under the mutex.
+      #
+      # @return [Boolean] true when this call is the half_open probe (so the
+      #   caller knows to release the probe slot when it finishes)
+      # @raise [CircuitOpenError] when the circuit is open, or half_open with a
+      #   probe already in flight
+      def admit_call!
+        @mutex.synchronize do
+          case @state
+          when :open
+            raise CircuitOpenError, "Circuit breaker is open (#{@failure_count} failures)" unless reset_timeout_elapsed?
+
+            # First caller after the timeout becomes the single half_open probe.
+            @state = :half_open
+            @half_open_probe_in_flight = true
+            true
+          when :half_open
+            raise CircuitOpenError, 'Circuit breaker is half-open (probe in flight)' if @half_open_probe_in_flight
+
+            @half_open_probe_in_flight = true
+            true
+          else
+            false
+          end
+        end
+      end
+
+      # @return [Boolean] whether enough time has passed since the last failure
+      #   to attempt a recovery probe
+      def reset_timeout_elapsed?
+        @last_failure_time && (monotonic_now - @last_failure_time >= @reset_timeout)
+      end
 
       # Monotonic clock reading — immune to NTP slews and DST adjustments.
       #
@@ -88,18 +131,33 @@ module Woods
         Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end
 
-      # Record a failure and potentially open the circuit.
+      # Record a failure and potentially open the circuit. A failure while
+      # half_open reopens immediately, regardless of the failure threshold.
       def record_failure
         @failure_count += 1
         @last_failure_time = monotonic_now
-        @state = :open if @failure_count >= @threshold
+        @success_count = 0
+        @state = :open if @state == :half_open || @failure_count >= @threshold
+      end
+
+      # Record a success. In half_open, close only after enough consecutive
+      # successful probes; in closed, a success clears accumulated failures.
+      def record_success
+        if @state == :half_open
+          @success_count += 1
+          reset! if @success_count >= @success_threshold
+        else
+          @failure_count = 0
+        end
       end
 
       # Reset the circuit breaker to closed state with zero failures.
       def reset!
         @state = :closed
         @failure_count = 0
+        @success_count = 0
         @last_failure_time = nil
+        @half_open_probe_in_flight = false
       end
     end
   end

--- a/lib/woods/resolved_config.rb
+++ b/lib/woods/resolved_config.rb
@@ -203,7 +203,10 @@ module Woods
         obj.each { |v| deep_freeze(v) }
         obj.frozen? ? obj : obj.freeze
       when String
-        obj.frozen? ? obj : obj.dup.freeze
+        # Freeze in place — returning a frozen dup would be discarded by the
+        # Hash/Array branches above (they recurse for side effects only),
+        # leaving every nested string mutable.
+        obj.frozen? ? obj : obj.freeze
       else
         obj
       end

--- a/lib/woods/retrieval/ranker.rb
+++ b/lib/woods/retrieval/ranker.rb
@@ -256,7 +256,7 @@ module Woods
         return 0.5 unless unit
         return 0.5 unless classification.target_type
 
-        unit_type = dig_metadata(unit, :type) || unit[:type]
+        unit_type = dig_metadata(unit, :type)
         unit_type&.to_sym == classification.target_type ? 1.0 : 0.3
       end
 
@@ -297,17 +297,55 @@ module Woods
         penalty
       end
 
-      # Dig into unit metadata, handling both hash and object access.
+      # Dig a value out of a unit's metadata, tolerating both symbol and
+      # string keys at every level.
+      #
+      # Units come from the metadata store, which returns STRING keys on
+      # every real backend (SQLite round-trips through JSON.parse;
+      # InMemory#store calls stringify_keys). The previous implementation
+      # probed only symbol keys, so recency/importance/type_match/diversity
+      # silently scored every unit at their neutral fallback in production —
+      # the specs passed only because they stub symbol-keyed units.
+      #
+      # Looks under the `metadata` wrapper first, then falls back to a
+      # top-level field for single-key lookups (namespace/type live on the
+      # unit itself, not under metadata).
       #
       # @param unit [Hash, Object] Unit data
-      # @param keys [Array<Symbol>] Key path
+      # @param keys [Array<Symbol>] Key path within metadata
       # @return [Object, nil]
       def dig_metadata(unit, *keys)
-        if keys.size == 1
-          unit.is_a?(Hash) ? (unit.dig(:metadata, keys[0]) || unit[keys[0]]) : nil
-        else
-          unit.is_a?(Hash) ? unit.dig(:metadata, *keys) : nil
+        return nil unless unit.is_a?(Hash)
+
+        nested = dig_either(fetch_either(unit, :metadata), keys)
+        return nested unless nested.nil?
+
+        keys.size == 1 ? fetch_either(unit, keys.first) : nil
+      end
+
+      # Walk a key path through nested hashes, trying both key forms.
+      #
+      # @param hash [Object] Starting hash (nil-safe)
+      # @param keys [Array<Symbol>] Key path
+      # @return [Object, nil]
+      def dig_either(hash, keys)
+        keys.reduce(hash) do |acc, key|
+          break nil unless acc.is_a?(Hash)
+
+          fetch_either(acc, key)
         end
+      end
+
+      # Fetch a key trying its symbol form, then its string form.
+      #
+      # @param hash [Object] Hash to read (nil-safe)
+      # @param key [Symbol, String] Key to fetch
+      # @return [Object, nil]
+      def fetch_either(hash, key)
+        return nil unless hash.is_a?(Hash)
+
+        value = hash[key]
+        value.nil? ? hash[key.to_s] : value
       end
 
       # Build a Candidate struct compatible with SearchExecutor::Candidate.

--- a/lib/woods/retry_after.rb
+++ b/lib/woods/retry_after.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'time' # Time.httpdate
+
+module Woods
+  # Parse an HTTP +Retry-After+ header into a number of seconds to wait.
+  #
+  # Per RFC 9110 the header is either a non-negative integer count of seconds
+  # or an HTTP-date. Calling +.to_f+ on the header directly (the naive
+  # approach) turns the HTTP-date form into +0.0+, so a client honoring it
+  # would retry immediately and hammer a server that is actively asking it to
+  # back off. This helper handles both forms and falls back to a caller-supplied
+  # value when the header is absent or unparseable.
+  module RetryAfter
+    module_function
+
+    # @param header [String, nil] the raw +Retry-After+ header value
+    # @param fallback [Numeric] seconds to use when the header is missing or unparseable
+    # @param now [Time] reference time for the HTTP-date form (injectable for tests)
+    # @return [Float] non-negative seconds to wait
+    def seconds(header, fallback:, now: Time.now)
+      value = header.to_s.strip
+      return fallback.to_f if value.empty?
+
+      # delta-seconds form: a bare non-negative integer.
+      return value.to_f if value.match?(/\A\d+\z/)
+
+      # HTTP-date form: wait until that instant, never negative.
+      begin
+        [Time.httpdate(value) - now, 0.0].max
+      rescue ArgumentError
+        fallback.to_f
+      end
+    end
+  end
+end

--- a/lib/woods/unblocked/client.rb
+++ b/lib/woods/unblocked/client.rb
@@ -4,6 +4,7 @@ require 'json'
 require 'net/http'
 require 'uri'
 require 'woods'
+require_relative '../retry_after'
 require_relative 'rate_limiter'
 
 module Woods
@@ -175,7 +176,9 @@ module Woods
 
           if response.code == '429' && retries < MAX_RETRIES
             retries += 1
-            wait_time = (response['Retry-After'] || (retries * 2)).to_f
+            # Retry-After may be an HTTP-date, which .to_f would collapse to
+            # 0.0 — honoring it as-is would hammer a throttling server.
+            wait_time = Woods::RetryAfter.seconds(response['Retry-After'], fallback: retries * 2)
             sleep(wait_time)
             next
           end

--- a/spec/cache/cache_store_spec.rb
+++ b/spec/cache/cache_store_spec.rb
@@ -300,6 +300,20 @@ RSpec.describe Woods::Cache::CachedEmbeddingProvider do
       expect(result).to eq([0.9, 0.8, 0.7])
       expect(other_provider).to have_received(:embed).once
     end
+
+    it 'builds the cache key without probing provider#dimensions (no network on lookup)' do
+      # For Ollama, #dimensions performs a live embed('test'); keying on it
+      # made every cache hit depend on the backend being reachable. The key
+      # must use model_name (a plain attribute) only.
+      probing_provider = instance_double('EmbeddingProvider', model_name: 'test-model')
+      allow(probing_provider).to receive(:dimensions).and_raise('network down')
+      allow(probing_provider).to receive(:embed).with('hello').and_return([0.1, 0.2])
+      cached = described_class.new(provider: probing_provider, cache_store: cache_store, ttl: 3600)
+
+      expect { cached.embed('hello') }.not_to raise_error # miss: stores
+      expect(cached.embed('hello')).to eq([0.1, 0.2]) # hit: reads
+      expect(probing_provider).not_to have_received(:dimensions)
+    end
   end
 
   describe '#embed_batch' do

--- a/spec/cache/cache_store_spec.rb
+++ b/spec/cache/cache_store_spec.rb
@@ -284,6 +284,22 @@ RSpec.describe Woods::Cache::CachedEmbeddingProvider do
 
       expect(provider).to have_received(:embed).twice
     end
+
+    it 'does not serve one model\'s cached vector to a different model' do
+      # A shared persistent backend must not hand a switched/upgraded model
+      # the previous model's vector for the same text.
+      allow(provider).to receive(:embed).with('hello').and_return([0.1, 0.2])
+      cached_provider.embed('hello')
+
+      other_provider = instance_double('EmbeddingProvider', dimensions: 1536, model_name: 'other-model')
+      allow(other_provider).to receive(:embed).with('hello').and_return([0.9, 0.8, 0.7])
+      other_cached = described_class.new(provider: other_provider, cache_store: cache_store, ttl: 3600)
+
+      result = other_cached.embed('hello')
+
+      expect(result).to eq([0.9, 0.8, 0.7])
+      expect(other_provider).to have_received(:embed).once
+    end
   end
 
   describe '#embed_batch' do

--- a/spec/console/embedded_executor_spec.rb
+++ b/spec/console/embedded_executor_spec.rb
@@ -628,6 +628,21 @@ RSpec.describe Woods::Console::EmbeddedExecutor do
 
         expect(ordered).to have_received(:limit).with(25)
       end
+
+      it 'rejects columns that are not real model columns (SQL fragment injection)' do
+        # relation.select treats string args as raw SQL — a crafted column
+        # would smuggle a subquery into the SELECT list.
+        response = executor.send_request({
+                                           'tool' => 'sample',
+                                           'params' => {
+                                             'model' => 'User',
+                                             'columns' => ['(SELECT secret FROM api_tokens LIMIT 1) AS email']
+                                           }
+                                         })
+
+        expect(response['ok']).to be false
+        expect(response['error']).to match(/Unknown column/)
+      end
     end
 
     context 'find tool' do
@@ -919,6 +934,19 @@ RSpec.describe Woods::Console::EmbeddedExecutor do
 
         expect(response['ok']).to be false
         expect(response['error']).to match(/Unknown column 'nonexistent'/)
+      end
+
+      it 'rejects columns that are not real model columns (SQL fragment injection)' do
+        response = executor.send_request({
+                                           'tool' => 'recent',
+                                           'params' => {
+                                             'model' => 'Post',
+                                             'columns' => ['(SELECT secret FROM api_tokens LIMIT 1) AS title']
+                                           }
+                                         })
+
+        expect(response['ok']).to be false
+        expect(response['error']).to match(/Unknown column/)
       end
 
       it 'caps limit at 50' do

--- a/spec/console/eval_guard_spec.rb
+++ b/spec/console/eval_guard_spec.rb
@@ -205,6 +205,13 @@ RSpec.describe Woods::Console::EvalGuard do
         end
       end
 
+      it 'rejects %x literals with whitespace (newline) delimiters' do
+        # A newline is a valid %x delimiter and executes: `%x\nwhoami\n`
+        # runs a shell command. `[^\w\s]` excluded it; `[^\w]` catches it.
+        expect { described_class.check!("%x\nwhoami\n") }
+          .to raise_error(Woods::Console::ForbiddenExpressionError, /shell-execution/)
+      end
+
       it 'rejects Kernel system/exec/spawn methods' do
         expect { described_class.check!('system("ls")') }
           .to raise_error(Woods::Console::ForbiddenExpressionError, /system/)

--- a/spec/console/eval_guard_spec.rb
+++ b/spec/console/eval_guard_spec.rb
@@ -195,6 +195,16 @@ RSpec.describe Woods::Console::EvalGuard do
           .to raise_error(Woods::Console::ForbiddenExpressionError, /shell-execution/)
       end
 
+      it 'rejects %x literals with non-brace delimiters' do
+        # Ruby accepts any non-word char as the %x delimiter; the guard
+        # must not key off a hand-picked delimiter list.
+        ['%x/ls/', '%x~ls~', '%x!ls!', '%x.ls.'].each do |payload|
+          expect { described_class.check!(payload) }
+            .to raise_error(Woods::Console::ForbiddenExpressionError, /shell-execution/),
+                "expected #{payload} to be refused"
+        end
+      end
+
       it 'rejects Kernel system/exec/spawn methods' do
         expect { described_class.check!('system("ls")') }
           .to raise_error(Woods::Console::ForbiddenExpressionError, /system/)

--- a/spec/console/sql_table_scanner_spec.rb
+++ b/spec/console/sql_table_scanner_spec.rb
@@ -205,6 +205,25 @@ RSpec.describe Woods::Console::SqlTableScanner do
       end
     end
 
+    context 'when a comment marker sits inside a string literal (must not hide FROM)' do
+      # The `--` is inside a literal, so it is NOT a comment: the real
+      # `FROM blocked` must be detected. Stripping comments before literals
+      # swallowed it, letting a blocked table slip past TableGate.
+      let(:sql) { "SELECT 'a -- b' FROM blocked" }
+
+      it 'still detects the real table after the literal' do
+        expect(identifiers).to include('blocked')
+      end
+    end
+
+    context 'when an apostrophe sits inside a line comment (must not hide FROM)' do
+      let(:sql) { "SELECT 1 -- it's fine\nFROM real_table" }
+
+      it 'detects the table on the line after the comment' do
+        expect(identifiers).to include('real_table')
+      end
+    end
+
     context 'when content is hidden inside PG dollar-quoted literals' do
       let(:sql) { 'SELECT $tag$FROM authorizations$tag$ AS literal FROM users' }
 

--- a/spec/console/sql_table_scanner_spec.rb
+++ b/spec/console/sql_table_scanner_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Woods::Console::SqlTableScanner do
       # reads FROM blocked. Stripping with only the MySQL dialect (where
       # \' continues the string) folded the real FROM clause into a
       # literal, hiding the table from TableGate.
-      let(:sql) { %q{SELECT 'x\' FROM blocked WHERE secret LIKE 'a%'} }
+      let(:sql) { %q(SELECT 'x\' FROM blocked WHERE secret LIKE 'a%') }
 
       it 'still detects the table read by a PostgreSQL server' do
         expect(identifiers).to include('blocked')

--- a/spec/console/sql_table_scanner_spec.rb
+++ b/spec/console/sql_table_scanner_spec.rb
@@ -224,6 +224,16 @@ RSpec.describe Woods::Console::SqlTableScanner do
       end
     end
 
+    context 'with an unterminated block comment (must never under-detect)' do
+      # A `/*` with no closing `*/` must not swallow the rest of the statement
+      # — over-detection is safe for the gate, under-detection is not.
+      let(:sql) { 'SELECT 1 /* FROM blocked' }
+
+      it 'still surfaces the table after the unterminated comment' do
+        expect(identifiers).to include('blocked')
+      end
+    end
+
     context 'when content is hidden inside PG dollar-quoted literals' do
       let(:sql) { 'SELECT $tag$FROM authorizations$tag$ AS literal FROM users' }
 

--- a/spec/console/sql_table_scanner_spec.rb
+++ b/spec/console/sql_table_scanner_spec.rb
@@ -27,6 +27,19 @@ RSpec.describe Woods::Console::SqlTableScanner do
       end
     end
 
+    context 'with a FROM clause hidden by MySQL-only escape rules (PostgreSQL bypass)' do
+      # On PostgreSQL (standard_conforming_strings on), backslash is
+      # literal: the server parses `'x\'` as one literal and genuinely
+      # reads FROM blocked. Stripping with only the MySQL dialect (where
+      # \' continues the string) folded the real FROM clause into a
+      # literal, hiding the table from TableGate.
+      let(:sql) { %q{SELECT 'x\' FROM blocked WHERE secret LIKE 'a%'} }
+
+      it 'still detects the table read by a PostgreSQL server' do
+        expect(identifiers).to include('blocked')
+      end
+    end
+
     context 'with nil input' do
       let(:sql) { nil }
 

--- a/spec/coordination/pipeline_lock_spec.rb
+++ b/spec/coordination/pipeline_lock_spec.rb
@@ -105,6 +105,52 @@ RSpec.describe Woods::Coordination::PipelineLock do
     end
   end
 
+  describe 'release ownership' do
+    let(:lock_path) { File.join(lock_dir, 'extraction.lock') }
+
+    it 'does not delete a lock file that was taken over by another holder' do
+      lock.acquire
+      # Simulate a legitimate takeover after this holder went stale:
+      # the file now carries someone else's token.
+      File.write(lock_path, JSON.generate(pid: 99_999, token: 'someone-elses-token'))
+
+      lock.release
+
+      expect(File.exist?(lock_path)).to be true
+    end
+
+    it 'deletes the lock file when it still owns it' do
+      lock.acquire
+      lock.release
+
+      expect(File.exist?(lock_path)).to be false
+    end
+
+    it 'handles the lock file already being gone' do
+      lock.acquire
+      FileUtils.rm_f(lock_path)
+
+      expect { lock.release }.not_to raise_error
+      expect(lock.locked?).to be false
+    end
+  end
+
+  describe 'stale takeover race' do
+    let(:lock_path) { File.join(lock_dir, 'extraction.lock') }
+
+    it 'backs off when another process retires the stale lock first' do
+      File.write(lock_path, '{}')
+      FileUtils.touch(lock_path, mtime: Time.now - 7200)
+
+      # The racing process wins the atomic rename between our stale check
+      # and our retirement attempt.
+      allow(File).to receive(:rename).and_raise(Errno::ENOENT)
+
+      expect(lock.acquire).to be false
+      expect(lock.locked?).to be false
+    end
+  end
+
   describe 'concurrent acquisition' do
     it 'only allows one thread to acquire the lock' do
       results = []

--- a/spec/coordination/pipeline_lock_spec.rb
+++ b/spec/coordination/pipeline_lock_spec.rb
@@ -164,6 +164,21 @@ RSpec.describe Woods::Coordination::PipelineLock do
       expect(File.exist?(lock_path)).to be true
       expect(JSON.parse(File.read(lock_path))['token']).to eq('competitor-fresh')
     end
+
+    it 'restore_lock does not clobber a lock created in the gap' do
+      # After we rename a captured lock aside, a newer holder may O_EXCL-create
+      # at @lock_path. Restoring via rename would overwrite it (double-hold);
+      # the link-based restore must leave the newer holder untouched and simply
+      # discard our aside copy.
+      graveyard = "#{lock_path}.grave"
+      File.write(graveyard, JSON.generate(token: 'ours-captured'))
+      File.write(lock_path, JSON.generate(token: 'newer-holder'))
+
+      lock.send(:restore_lock, graveyard)
+
+      expect(JSON.parse(File.read(lock_path))['token']).to eq('newer-holder')
+      expect(File.exist?(graveyard)).to be false
+    end
   end
 
   describe 'concurrent acquisition' do

--- a/spec/coordination/pipeline_lock_spec.rb
+++ b/spec/coordination/pipeline_lock_spec.rb
@@ -97,7 +97,10 @@ RSpec.describe Woods::Coordination::PipelineLock do
       # Create a lock file so File.exist? returns true
       File.write(lock_path, '{}')
 
-      # Simulate the race: File.exist? sees the file, but File.mtime raises ENOENT
+      # Simulate the race: File.exist? sees the file, but File.mtime raises
+      # ENOENT for the lock path (other paths, e.g. a graveyard file, behave
+      # normally).
+      allow(File).to receive(:mtime).and_call_original
       allow(File).to receive(:mtime).with(lock_path).and_raise(Errno::ENOENT)
 
       new_lock = described_class.new(lock_dir: lock_dir, name: 'extraction')
@@ -148,6 +151,18 @@ RSpec.describe Woods::Coordination::PipelineLock do
 
       expect(lock.acquire).to be false
       expect(lock.locked?).to be false
+    end
+
+    it 'restores the file and backs off if the retired lock is no longer stale' do
+      # Simulates a competitor that already retired the stale lock and
+      # created a FRESH one between our stale? check and our rename: retiring
+      # blindly would clobber a live holder's lock and let both processes run.
+      File.write(lock_path, JSON.generate(token: 'competitor-fresh'))
+      # mtime is now (fresh), i.e. not older than stale_timeout.
+
+      expect(lock.send(:retire_stale_lock)).to be false
+      expect(File.exist?(lock_path)).to be true
+      expect(JSON.parse(File.read(lock_path))['token']).to eq('competitor-fresh')
     end
   end
 

--- a/spec/dependency_graph_spec.rb
+++ b/spec/dependency_graph_spec.rb
@@ -48,6 +48,63 @@ RSpec.describe Woods::DependencyGraph do
       expect(graph.dependents_of('User')).to include('Order')
       expect(graph.dependencies_of('Order')).to include('User')
     end
+
+    it 'removes stale reverse edges when a unit is re-registered with different dependencies' do
+      graph.register(make_unit(type: :model, identifier: 'User'))
+      graph.register(make_unit(type: :model, identifier: 'Account'))
+
+      order_v1 = make_unit(
+        type: :model,
+        identifier: 'Order',
+        dependencies: [{ type: :model, target: 'User', via: :belongs_to }]
+      )
+      graph.register(order_v1)
+      expect(graph.dependents_of('User')).to include('Order')
+
+      # The Order source dropped its User dependency — incremental
+      # re-extraction registers into the already-loaded graph.
+      order_v2 = make_unit(
+        type: :model,
+        identifier: 'Order',
+        dependencies: [{ type: :model, target: 'Account', via: :belongs_to }]
+      )
+      graph.register(order_v2)
+
+      expect(graph.dependents_of('User')).not_to include('Order')
+      expect(graph.dependents_of('User', via: :belongs_to)).not_to include('Order')
+      expect(graph.dependents_of('Account')).to include('Order')
+    end
+
+    it 'updates the file map when a unit is re-registered under a new path' do
+      graph.register(make_unit(type: :model, identifier: 'User', file_path: '/app/models/user.rb'))
+      graph.register(
+        make_unit(
+          type: :model,
+          identifier: 'Consumer',
+          dependencies: [{ type: :model, target: 'User', via: :code_reference }]
+        )
+      )
+      graph.register(make_unit(type: :model, identifier: 'User', file_path: '/app/models/core/user.rb'))
+
+      expect(graph.affected_by(['/app/models/user.rb'])).to be_empty
+      expect(graph.affected_by(['/app/models/core/user.rb'])).to contain_exactly('User', 'Consumer')
+    end
+
+    it 'cleans stale reverse edges when re-registering into a graph loaded from JSON' do
+      order = make_unit(
+        type: :model,
+        identifier: 'Order',
+        dependencies: [{ type: :model, target: 'User', via: :belongs_to }]
+      )
+      graph.register(make_unit(type: :model, identifier: 'User'))
+      graph.register(order)
+
+      loaded = described_class.from_h(JSON.parse(JSON.generate(graph.to_h)))
+      order_v2 = make_unit(type: :model, identifier: 'Order', dependencies: [])
+      loaded.register(order_v2)
+
+      expect(loaded.dependents_of('User')).not_to include('Order')
+    end
   end
 
   describe '#affected_by' do

--- a/spec/embedding/text_preparer_spec.rb
+++ b/spec/embedding/text_preparer_spec.rb
@@ -110,6 +110,29 @@ RSpec.describe Woods::Embedding::TextPreparer do
       end
     end
 
+    context 'with string-keyed dependencies (Indexer#build_unit shape)' do
+      # The indexer reads unit JSON and leaves dependency keys as strings,
+      # so the embedded text must still surface them.
+      let(:unit_with_string_deps) do
+        Woods::ExtractedUnit.new(
+          type: :model,
+          identifier: 'Order',
+          file_path: 'app/models/order.rb'
+        ).tap do |u|
+          u.source_code = 'class Order; end'
+          u.dependencies = [
+            { 'type' => 'model', 'target' => 'User' },
+            { 'type' => 'service', 'target' => 'ChargeService' }
+          ]
+        end
+      end
+
+      it 'includes dependency names from string-keyed hashes' do
+        result = preparer.prepare(unit_with_string_deps)
+        expect(result).to include('dependencies: User, ChargeService')
+      end
+    end
+
     context 'with more than 10 dependencies' do
       let(:many_deps_unit) do
         deps = (1..15).map { |i| { type: :model, target: "Model#{i}" } }

--- a/spec/extractor_spec.rb
+++ b/spec/extractor_spec.rb
@@ -289,6 +289,94 @@ RSpec.describe Woods::Extractor do
     end
   end
 
+  # ── extract_all phase ordering ──────────────────────────────────────
+
+  describe '#extract_all flow precompute ordering' do
+    before do
+      require 'woods'
+      @original_config = Woods.configuration
+      Woods.configuration = Woods::Configuration.new
+      Woods.configuration.concurrent_extraction = false
+      Woods.configuration.precompute_flows = true
+    end
+
+    after do
+      Woods.configuration = @original_config
+    end
+
+    it 'precomputes flows only after write_results has written unit JSON to disk' do
+      # FlowAssembler loads unit JSON from disk — precomputing before
+      # write_results assembled every flow from absent or stale data.
+      %i[setup_output_directory safe_eager_load! extract_all_sequential
+         deduplicate_results resolve_dependents enrich_with_git_data
+         normalize_file_paths write_dependency_graph write_graph_analysis
+         write_manifest write_structural_summary capture_snapshot
+         log_summary].each do |phase|
+        allow(extractor).to receive(phase)
+      end
+      allow(Woods::ModelNameCache).to receive(:reset!)
+      allow(Woods::GraphAnalyzer).to receive(:new).and_return(double('GraphAnalyzer', analyze: {}))
+
+      expect(extractor).to receive(:write_results).ordered
+      expect(extractor).to receive(:precompute_flows).ordered
+
+      extractor.extract_all
+    end
+  end
+
+  # ── rewrite_flow_annotated_units ────────────────────────────────────
+
+  describe '#rewrite_flow_annotated_units' do
+    before do
+      require 'woods'
+      @original_config = Woods.configuration
+      Woods.configuration = Woods::Configuration.new
+    end
+
+    after do
+      Woods.configuration = @original_config
+    end
+
+    it 're-writes units annotated with flow_paths and refreshes the type index' do
+      output_dir = File.join(tmpdir, 'output')
+      type_dir = File.join(output_dir, 'controllers')
+      FileUtils.mkdir_p(type_dir)
+
+      annotated = Woods::ExtractedUnit.new(
+        type: :controller, identifier: 'OrdersController', file_path: 'app/controllers/orders_controller.rb'
+      )
+      annotated.metadata = { flow_paths: { 'create' => 'flows/OrdersController_create.json' } }
+      plain = Woods::ExtractedUnit.new(
+        type: :controller, identifier: 'UsersController', file_path: 'app/controllers/users_controller.rb'
+      )
+      extractor.instance_variable_set(:@results, { controllers: [annotated, plain] })
+
+      extractor.send(:rewrite_flow_annotated_units)
+
+      written = Dir[File.join(type_dir, '*.json')].reject { |f| File.basename(f) == '_index.json' }
+      expect(written.size).to eq(1)
+      unit_json = JSON.parse(File.read(written.first))
+      expect(unit_json['identifier']).to eq('OrdersController')
+      expect(unit_json.dig('metadata', 'flow_paths', 'create')).to eq('flows/OrdersController_create.json')
+
+      index = JSON.parse(File.read(File.join(type_dir, '_index.json')))
+      expect(index.map { |e| e['identifier'] }).to eq(['OrdersController'])
+    end
+
+    it 'does nothing when no unit carries flow_paths' do
+      output_dir = File.join(tmpdir, 'output')
+      FileUtils.mkdir_p(File.join(output_dir, 'controllers'))
+      plain = Woods::ExtractedUnit.new(
+        type: :controller, identifier: 'UsersController', file_path: 'app/controllers/users_controller.rb'
+      )
+      extractor.instance_variable_set(:@results, { controllers: [plain] })
+
+      extractor.send(:rewrite_flow_annotated_units)
+
+      expect(Dir[File.join(output_dir, 'controllers', '*.json')]).to be_empty
+    end
+  end
+
   # ── regenerate_type_index ───────────────────────────────────────────
 
   describe '#regenerate_type_index' do

--- a/spec/extractor_spec.rb
+++ b/spec/extractor_spec.rb
@@ -239,6 +239,93 @@ RSpec.describe Woods::Extractor do
       expect(manifest['git_branch']).to eq('unknown')
       expect(manifest['git_sha']).to eq('unknown')
     end
+
+    it 'derives counts from persisted _index.json files in incremental mode, not the empty @results' do
+      allow(Rails).to receive(:version).and_return('7.1.0')
+      allow(Time).to receive(:current).and_return(Time.now)
+      output_dir = File.join(tmpdir, 'output')
+      FileUtils.mkdir_p(File.join(output_dir, 'models'))
+      FileUtils.mkdir_p(File.join(output_dir, 'controllers'))
+      File.write(
+        File.join(output_dir, 'models', '_index.json'),
+        JSON.generate([{ identifier: 'User', chunk_count: 2 }, { identifier: 'Post', chunk_count: 1 }])
+      )
+      File.write(
+        File.join(output_dir, 'controllers', '_index.json'),
+        JSON.generate([{ identifier: 'UsersController', chunk_count: 3 }])
+      )
+      # Incremental runs never populate @results — the manifest must not zero out.
+      extractor.instance_variable_set(:@results, {})
+
+      provenance = instance_double(Woods::GitProvenance, to_h: { git_branch: 'main', git_sha: 'abc' })
+      allow(Woods::GitProvenance).to receive(:new).and_return(provenance)
+
+      extractor.send(:write_manifest, incremental: true)
+
+      manifest = JSON.parse(File.read(File.join(output_dir, 'manifest.json')))
+      expect(manifest['counts']).to eq('models' => 2, 'controllers' => 1)
+      expect(manifest['total_units']).to eq(3)
+      expect(manifest['total_chunks']).to eq(6)
+    end
+
+    it 'still derives counts from @results in full mode' do
+      allow(Rails).to receive(:version).and_return('7.1.0')
+      allow(Time).to receive(:current).and_return(Time.now)
+      output_dir = File.join(tmpdir, 'output')
+      FileUtils.mkdir_p(output_dir)
+      unit = Woods::ExtractedUnit.new(type: :model, identifier: 'User', file_path: 'app/models/user.rb')
+      unit.chunks = [{ chunk_index: 0 }]
+      extractor.instance_variable_set(:@results, { models: [unit] })
+
+      provenance = instance_double(Woods::GitProvenance, to_h: { git_branch: 'main', git_sha: 'abc' })
+      allow(Woods::GitProvenance).to receive(:new).and_return(provenance)
+
+      extractor.send(:write_manifest)
+
+      manifest = JSON.parse(File.read(File.join(output_dir, 'manifest.json')))
+      expect(manifest['counts']).to eq('models' => 1)
+      expect(manifest['total_units']).to eq(1)
+      expect(manifest['total_chunks']).to eq(1)
+    end
+  end
+
+  # ── regenerate_type_index ───────────────────────────────────────────
+
+  describe '#regenerate_type_index' do
+    before do
+      require 'woods'
+      @original_config = Woods.configuration
+      Woods.configuration = Woods::Configuration.new
+    end
+
+    after do
+      Woods.configuration = @original_config
+    end
+
+    it 'recomputes estimated_tokens from unit JSON instead of indexing null' do
+      output_dir = File.join(tmpdir, 'output')
+      type_dir = File.join(output_dir, 'models')
+      FileUtils.mkdir_p(type_dir)
+      # Unit JSON as written by ExtractedUnit#to_h — no estimated_tokens key.
+      File.write(
+        File.join(type_dir, 'User.json'),
+        JSON.generate(
+          identifier: 'User',
+          file_path: 'app/models/user.rb',
+          namespace: nil,
+          source_code: 'x' * 40,
+          metadata: {},
+          chunks: [{ chunk_index: 0 }]
+        )
+      )
+
+      extractor.send(:regenerate_type_index, :models)
+
+      index = JSON.parse(File.read(File.join(type_dir, '_index.json')))
+      expect(index.size).to eq(1)
+      expect(index.first['estimated_tokens']).to eq(10) # 40 chars / 4.0
+      expect(index.first['chunk_count']).to eq(1)
+    end
   end
 
   # ── extract_all_concurrent — warning survival ──────────────────────
@@ -246,6 +333,15 @@ RSpec.describe Woods::Extractor do
   describe '#extract_all_concurrent' do
     before do
       require 'woods'
+      # The extraction threads call Time.current for timing logs. In a Rails
+      # host it's always defined, but in this suite it only works if another
+      # spec happened to load the exts first — require them here so this
+      # example doesn't depend on suite ordering (the thread's rescue would
+      # otherwise swallow the NameError and @extractors would never be
+      # populated). isolated_execution_state backs Time.zone, which
+      # Time.current consults before falling back to Time.now.
+      require 'active_support/isolated_execution_state'
+      require 'active_support/core_ext/time'
       Woods.configuration ||= Woods::Configuration.new
       Woods.configuration.concurrent_extraction = true
     end

--- a/spec/extractor_spec.rb
+++ b/spec/extractor_spec.rb
@@ -359,7 +359,35 @@ RSpec.describe Woods::Extractor do
       expect(unit_json['identifier']).to eq('OrdersController')
       expect(unit_json.dig('metadata', 'flow_paths', 'create')).to eq('flows/OrdersController_create.json')
 
+      # The refreshed index is built from the in-memory @results (both
+      # units), not from the on-disk files (only the annotated one was
+      # rewritten here) — matching what write_results emitted for this type.
       index = JSON.parse(File.read(File.join(type_dir, '_index.json')))
+      expect(index.map { |e| e['identifier'] }).to eq(%w[OrdersController UsersController])
+    end
+
+    it 'refreshes the type index from @results, not a disk glob (no stale-unit resurrection)' do
+      output_dir = File.join(tmpdir, 'output')
+      type_dir = File.join(output_dir, 'controllers')
+      FileUtils.mkdir_p(type_dir)
+
+      # A stale unit file from a previous run for a controller since deleted
+      # from the app. It is NOT present in @results.
+      File.write(
+        File.join(type_dir, 'DeletedController_abc1.json'),
+        JSON.generate(identifier: 'DeletedController', file_path: 'x', namespace: nil, chunks: [])
+      )
+
+      annotated = Woods::ExtractedUnit.new(
+        type: :controller, identifier: 'OrdersController', file_path: 'app/controllers/orders_controller.rb'
+      )
+      annotated.metadata = { flow_paths: { 'create' => 'flows/OrdersController_create.json' } }
+      extractor.instance_variable_set(:@results, { controllers: [annotated] })
+
+      extractor.send(:rewrite_flow_annotated_units)
+
+      index = JSON.parse(File.read(File.join(type_dir, '_index.json')))
+      # The deleted controller's stale file must NOT be resurrected into the index.
       expect(index.map { |e| e['identifier'] }).to eq(['OrdersController'])
     end
 

--- a/spec/extractors/model_extractor_spec.rb
+++ b/spec/extractors/model_extractor_spec.rb
@@ -68,6 +68,63 @@ RSpec.describe Woods::Extractors::ModelExtractor do
     end
   end
 
+  # ── implicit_belongs_to_validator? ────────────────────────────────
+
+  describe '#implicit_belongs_to_validator?' do
+    # A stand-in for ActiveRecord::Validations::PresenceValidator; is_a?
+    # checks need a real class, not a double.
+    let(:presence_validator_class) do
+      Class.new do
+        attr_reader :attributes
+
+        def initialize(attributes)
+          @attributes = attributes
+        end
+      end
+    end
+
+    before do
+      stub_const('ActiveRecord::Validations::PresenceValidator', presence_validator_class)
+    end
+
+    def model_with_belongs_to(*names)
+      reflections = names.map { |n| double('Reflection', name: n) }
+      model = double('Model')
+      allow(model).to receive(:reflect_on_all_associations).with(:belongs_to).and_return(reflections)
+      model
+    end
+
+    it 'flags a presence validator on a belongs_to association attribute' do
+      model = model_with_belongs_to(:author)
+      validator = presence_validator_class.new([:author])
+
+      expect(extractor.send(:implicit_belongs_to_validator?, model, validator)).to be true
+    end
+
+    it 'does not flag a presence validator on a plain attribute' do
+      # The previous source_location heuristic flagged EVERY AR presence
+      # validator — PresenceValidator#validate always lives in the gem.
+      model = model_with_belongs_to(:author)
+      validator = presence_validator_class.new([:title])
+
+      expect(extractor.send(:implicit_belongs_to_validator?, model, validator)).to be false
+    end
+
+    it 'does not flag when the model has no belongs_to associations' do
+      model = model_with_belongs_to
+      validator = presence_validator_class.new([:title])
+
+      expect(extractor.send(:implicit_belongs_to_validator?, model, validator)).to be false
+    end
+
+    it 'does not flag non-presence validators' do
+      model = model_with_belongs_to(:author)
+      other = double('FormatValidator')
+
+      expect(extractor.send(:implicit_belongs_to_validator?, model, other)).to be false
+    end
+  end
+
   # ── extract_scopes ────────────────────────────────────────────────
 
   describe '#extract_scopes' do

--- a/spec/extractors/model_extractor_spec.rb
+++ b/spec/extractors/model_extractor_spec.rb
@@ -28,6 +28,46 @@ RSpec.describe Woods::Extractors::ModelExtractor do
     end
   end
 
+  # ── callback_count ────────────────────────────────────────────────
+
+  describe '#callback_count' do
+    # Mirrors ActiveSupport::Callbacks::CallbackChain: it includes
+    # Enumerable (so #count works) but defines NO #size. Stubbing with a
+    # plain Array here would mask a regression to #size — Arrays have both.
+    let(:chain_class) do
+      Class.new do
+        include Enumerable
+
+        def initialize(callbacks)
+          @callbacks = callbacks
+        end
+
+        def each(&block)
+          @callbacks.each(&block)
+        end
+      end
+    end
+
+    it 'sums callbacks across chains using an API CallbackChain actually has' do
+      model = double('Model')
+      %i[validation save create update destroy commit rollback].each do |type|
+        allow(model).to receive(:"_#{type}_callbacks").and_return(chain_class.new(%i[a b]))
+      end
+
+      expect(extractor.send(:callback_count, model)).to eq(14)
+    end
+
+    it 'counts a chain type as zero when reading it raises' do
+      model = double('Model')
+      %i[validation save create update destroy commit rollback].each do |type|
+        allow(model).to receive(:"_#{type}_callbacks").and_return(chain_class.new([:a]))
+      end
+      allow(model).to receive(:_commit_callbacks).and_raise(NoMethodError)
+
+      expect(extractor.send(:callback_count, model)).to eq(6)
+    end
+  end
+
   # ── extract_scopes ────────────────────────────────────────────────
 
   describe '#extract_scopes' do

--- a/spec/extractors/shared_dependency_scanner_spec.rb
+++ b/spec/extractors/shared_dependency_scanner_spec.rb
@@ -65,6 +65,23 @@ RSpec.describe Woods::Extractors::SharedDependencyScanner do
       result = scanner.scan_model_dependencies(source)
       expect(result).to eq([])
     end
+
+    it 'ignores fully-qualified references inside comments' do
+      source = <<~RUBY
+        # TODO: migrate User to the new schema
+        post = Post.first
+      RUBY
+      targets = scanner.scan_model_dependencies(source).map { |d| d[:target] }
+      expect(targets).to eq(['Post'])
+    end
+
+    it 'still matches references inside string interpolation' do
+      # rubocop:disable Lint/InterpolationCheck -- the #{} is source under test, not spec interpolation
+      source = 'label = "owner: #{User.find(id).name}"'
+      # rubocop:enable Lint/InterpolationCheck
+      targets = scanner.scan_model_dependencies(source).map { |d| d[:target] }
+      expect(targets).to eq(['User'])
+    end
   end
 
   # ── #scan_service_dependencies ──────────────────────────────────

--- a/spec/extractors/shared_dependency_scanner_spec.rb
+++ b/spec/extractors/shared_dependency_scanner_spec.rb
@@ -82,6 +82,21 @@ RSpec.describe Woods::Extractors::SharedDependencyScanner do
       targets = scanner.scan_model_dependencies(source).map { |d| d[:target] }
       expect(targets).to eq(['User'])
     end
+
+    it 'keeps a model reference that follows a # inside a string literal' do
+      # A literal `#` (URL fragment, hex color, "Tag #ruby") is not a Ruby
+      # comment; comment-stripping must be string-literal-aware or the rest
+      # of the line — including the model reference — is silently dropped.
+      source = 'link_to "Tag #ruby", User.recent'
+      targets = scanner.scan_model_dependencies(source).map { |d| d[:target] }
+      expect(targets).to eq(['User'])
+    end
+
+    it 'strips a real trailing comment while keeping code on the same line' do
+      source = 'post = Post.first # see User for the join'
+      targets = scanner.scan_model_dependencies(source).map { |d| d[:target] }
+      expect(targets).to eq(['Post'])
+    end
   end
 
   # ── #scan_service_dependencies ──────────────────────────────────

--- a/spec/extractors/shared_dependency_scanner_spec.rb
+++ b/spec/extractors/shared_dependency_scanner_spec.rb
@@ -269,6 +269,60 @@ RSpec.describe Woods::Extractors::SharedDependencyScanner do
     end
   end
 
+  # ── #consolidate_dependencies ────────────────────────────────────
+
+  describe '#consolidate_dependencies' do
+    it 'merges multiple dependency arrays' do
+      models = [{ type: :model, target: 'User', via: :code_reference }]
+      services = [{ type: :service, target: 'BillingService', via: :code_reference }]
+
+      result = scanner.consolidate_dependencies(models, services)
+      expect(result).to contain_exactly(
+        { type: :model, target: 'User', via: :code_reference },
+        { type: :service, target: 'BillingService', via: :code_reference }
+      )
+    end
+
+    it 'deduplicates by [type, target], keeping the first occurrence' do
+      first = { type: :model, target: 'User', via: :belongs_to }
+      second = { type: :model, target: 'User', via: :code_reference }
+
+      result = scanner.consolidate_dependencies([first], [second])
+      expect(result).to eq([first])
+    end
+
+    it 'keeps entries with the same target but different types' do
+      deps = [
+        { type: :model, target: 'Payment', via: :code_reference },
+        { type: :service, target: 'Payment', via: :code_reference }
+      ]
+
+      result = scanner.consolidate_dependencies(deps)
+      expect(result.size).to eq(2)
+    end
+
+    it 'removes nil entries' do
+      deps = [{ type: :model, target: 'User', via: :code_reference }, nil]
+
+      result = scanner.consolidate_dependencies(deps)
+      expect(result).to eq([{ type: :model, target: 'User', via: :code_reference }])
+    end
+
+    it 'accepts a single pre-built array as a drop-in for the inline uniq chain' do
+      deps = [
+        { type: :model, target: 'User', via: :code_reference },
+        { type: :model, target: 'User', via: :render }
+      ]
+
+      result = scanner.consolidate_dependencies(deps)
+      expect(result.size).to eq(1)
+    end
+
+    it 'returns an empty array when given only empty arrays' do
+      expect(scanner.consolidate_dependencies([], [])).to eq([])
+    end
+  end
+
   # ── #scan_navigation_dependencies ────────────────────────────────
 
   describe '#scan_navigation_dependencies' do

--- a/spec/extractors/shared_utility_methods_spec.rb
+++ b/spec/extractors/shared_utility_methods_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'fileutils'
+require 'pathname'
+require 'tmpdir'
 require 'woods/extractors/shared_utility_methods'
 
 RSpec.describe Woods::Extractors::SharedUtilityMethods do
@@ -12,6 +15,54 @@ RSpec.describe Woods::Extractors::SharedUtilityMethods do
   end
 
   subject(:utility) { test_class.new }
+
+  # ── #find_files_in_directories ────────────────────────────────
+
+  describe '#find_files_in_directories' do
+    let(:root) { Pathname.new(Dir.mktmpdir) }
+    let(:dir_a) { root.join('a').tap(&:mkpath) }
+    let(:dir_b) { root.join('b').tap(&:mkpath) }
+
+    before do
+      dir_a.join('one.rb').write('# one')
+      dir_a.join('nested').mkpath
+      dir_a.join('nested/two.rb').write('# two')
+      dir_a.join('notes.yml').write('---')
+      dir_b.join('three.rb').write('# three')
+    end
+
+    after do
+      FileUtils.remove_entry(root)
+    end
+
+    it 'globs Ruby files across all directories with the default pattern' do
+      files = utility.find_files_in_directories([dir_a, dir_b])
+      expect(files).to contain_exactly(
+        dir_a.join('one.rb').to_s,
+        dir_a.join('nested/two.rb').to_s,
+        dir_b.join('three.rb').to_s
+      )
+    end
+
+    it 'excludes files that do not match the default pattern' do
+      files = utility.find_files_in_directories([dir_a])
+      expect(files).not_to include(dir_a.join('notes.yml').to_s)
+    end
+
+    it 'accepts a custom glob pattern' do
+      files = utility.find_files_in_directories([dir_a], '**/*.yml')
+      expect(files).to contain_exactly(dir_a.join('notes.yml').to_s)
+    end
+
+    it 'concatenates results in directory order' do
+      files = utility.find_files_in_directories([dir_b, dir_a])
+      expect(files.first).to eq(dir_b.join('three.rb').to_s)
+    end
+
+    it 'returns an empty array for an empty directory list' do
+      expect(utility.find_files_in_directories([])).to eq([])
+    end
+  end
 
   # ── #app_source? ──────────────────────────────────────────────
 

--- a/spec/filename_utils_spec.rb
+++ b/spec/filename_utils_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'woods/filename_utils'
+
+RSpec.describe Woods::FilenameUtils do
+  describe '.safe_segment' do
+    it 'replaces :: with __ and other non-[A-Za-z0-9_-] chars with _' do
+      expect(described_class.safe_segment('Admin::Users')).to eq('Admin__Users')
+      expect(described_class.safe_segment('sign_in!')).to eq('sign_in_')
+    end
+
+    it 'is the identity transform for conventional identifiers' do
+      expect(described_class.safe_segment('PostsController')).to eq('PostsController')
+    end
+  end
+
+  describe '.flow_filename' do
+    it 'joins the normalized controller and action with a .json suffix' do
+      expect(described_class.flow_filename('Admin::UsersController', 'index'))
+        .to eq('Admin__UsersController_index.json')
+    end
+
+    it 'produces the SAME name the reader and writer both derive for exotic actions' do
+      # Regression: the writer previously left the action raw while the reader
+      # allow-listed it, so a flow for `sign_in!` was written under one name
+      # and looked up under another. Both now route through flow_filename.
+      writer_name = described_class.flow_filename('SessionsController', 'sign_in!')
+      # The reader derives the same value from the entry point.
+      controller, action = 'SessionsController#sign_in!'.split('#', 2)
+      reader_name = described_class.flow_filename(controller, action)
+      expect(writer_name).to eq(reader_name)
+      expect(writer_name).to eq('SessionsController_sign_in_.json')
+    end
+  end
+
+  describe 'mixed-in instance API' do
+    subject(:host) { Class.new { include Woods::FilenameUtils }.new }
+
+    it 'still exposes safe_filename and collision_safe_filename' do
+      expect(host.safe_filename('Admin::Users')).to eq('Admin__Users.json')
+      expect(host.collision_safe_filename('Admin::Users')).to match(/\AAdmin__Users_[0-9a-f]{8}\.json\z/)
+    end
+  end
+end

--- a/spec/flow_assembler_spec.rb
+++ b/spec/flow_assembler_spec.rb
@@ -139,6 +139,54 @@ RSpec.describe Woods::FlowAssembler do
       expect(cycle_step[:unit]).to eq('ServiceA')
     end
 
+    it 'does not emit a cycle marker for a shared (diamond) dependency' do
+      # Controller calls two services that both call AuditLog — a DAG, not
+      # a cycle. The second encounter is dedup, not circular execution.
+      write_unit('OrdersController', source_code: <<~RUBY)
+        class OrdersController < ApplicationController
+          def create
+            BillingService.call
+            ShippingService.call
+          end
+        end
+      RUBY
+
+      write_unit('BillingService', type: 'service', source_code: <<~RUBY)
+        class BillingService
+          def call
+            AuditLog.record!
+          end
+        end
+      RUBY
+
+      write_unit('ShippingService', type: 'service', source_code: <<~RUBY)
+        class ShippingService
+          def call
+            AuditLog.record!
+          end
+        end
+      RUBY
+
+      write_unit('AuditLog', type: 'service', source_code: <<~RUBY)
+        class AuditLog
+          def record!
+            true
+          end
+        end
+      RUBY
+
+      stub_graph_defaults
+      %w[BillingService ShippingService AuditLog].each do |id|
+        allow(graph).to receive(:node_exists?).with(id).and_return(true)
+      end
+
+      assembler = described_class.new(graph: graph, extracted_dir: extracted_dir)
+      flow = assembler.assemble('OrdersController#create')
+
+      expect(flow.steps.map { |s| s[:type] }).not_to include('cycle')
+      expect(flow.steps.count { |s| s[:unit] == 'AuditLog' }).to eq(1)
+    end
+
     it 'respects max_depth limit' do
       write_unit('A', type: 'service', source_code: <<~RUBY)
         class A

--- a/spec/index_artifact_spec.rb
+++ b/spec/index_artifact_spec.rb
@@ -207,6 +207,16 @@ RSpec.describe Woods::IndexArtifact do
       FileUtils.rm_rf(outside.to_s) if outside
     end
 
+    it 'raises ArgumentError for a sibling directory whose name merely prefixes with dumps_root' do
+      # ".../dumps-evil" passes a bare start_with?(".../dumps") check; the
+      # containment test must require a path-separator boundary.
+      sibling = Pathname.new("#{artifact.dumps_root}-evil")
+      FileUtils.mkdir_p(sibling.to_s)
+      expect { artifact.promote(sibling) }.to raise_error(ArgumentError, /dumps_root/)
+    ensure
+      FileUtils.rm_rf(sibling.to_s) if sibling
+    end
+
     it 'raises ArgumentError when dump_dir does not exist' do
       ghost = artifact.dumps_root.join('2099-01-01T00-00-00Z')
       expect { artifact.promote(ghost) }.to raise_error(ArgumentError)

--- a/spec/mcp/cli_integration_spec.rb
+++ b/spec/mcp/cli_integration_spec.rb
@@ -15,6 +15,14 @@ require 'tmpdir'
 # is exercised here as a boot-smoke test: we spawn it against a fixture,
 # let it block on stdin, then verify it produced no boot-time errors on stderr.
 RSpec.describe 'MCP CLI integration' do
+  # Subprocess output arrives in the locale's default external encoding.
+  # Under a POSIX/C locale (common in containers and CI) that's US-ASCII,
+  # and the server's boot log contains UTF-8 punctuation — matching a
+  # Regexp against it would raise ArgumentError. Normalize before matching.
+  def utf8(output)
+    output.force_encoding(Encoding::UTF_8).scrub
+  end
+
   let(:gem_root) { File.expand_path('../..', __dir__) }
   let(:wrapper) { File.join(gem_root, 'exe/woods-mcp-start') }
   let(:ruby_bin) { File.join(gem_root, 'exe/woods-mcp') }
@@ -28,16 +36,16 @@ RSpec.describe 'MCP CLI integration' do
       _out, err, status = Open3.capture3({ 'WOODS_DIR' => nil }, wrapper)
 
       expect(status.exitstatus).to eq(1)
-      expect(err).to match(/No index directory specified/i)
-      expect(err).to match(/Usage:/)
+      expect(utf8(err)).to match(/No index directory specified/i)
+      expect(utf8(err)).to match(/Usage:/)
     end
 
     it 'exits non-zero with a clear message when the index directory does not exist' do
       _out, err, status = Open3.capture3(wrapper, '/definitely/not/a/real/woods/dir')
 
       expect(status.exitstatus).to eq(1)
-      expect(err).to match(/does not exist/i)
-      expect(err).to match(/bundle exec rake woods:extract/)
+      expect(utf8(err)).to match(/does not exist/i)
+      expect(utf8(err)).to match(/bundle exec rake woods:extract/)
     end
 
     it 'exits non-zero when the directory is missing manifest.json' do
@@ -45,8 +53,8 @@ RSpec.describe 'MCP CLI integration' do
         _out, err, status = Open3.capture3(wrapper, empty_dir)
 
         expect(status.exitstatus).to eq(1)
-        expect(err).to match(/No manifest\.json/)
-        expect(err).to match(/bundle exec rake woods:extract/)
+        expect(utf8(err)).to match(/No manifest\.json/)
+        expect(utf8(err)).to match(/bundle exec rake woods:extract/)
       end
     end
   end
@@ -66,7 +74,7 @@ RSpec.describe 'MCP CLI integration' do
       Process.kill('TERM', wait_thr.pid) if wait_thr.alive?
       wait_thr.join(5)
 
-      stderr_output = stderr.read
+      stderr_output = utf8(stderr.read)
       stdin.close
       stdout.close
       stderr.close
@@ -105,7 +113,7 @@ RSpec.describe 'MCP CLI integration' do
         booted = wait_thr.alive?
         Process.kill('TERM', wait_thr.pid) if wait_thr.alive?
         wait_thr.join(5)
-        err = stderr.read
+        err = utf8(stderr.read)
         stdin.close
         stdout.close
         stderr.close
@@ -120,7 +128,7 @@ RSpec.describe 'MCP CLI integration' do
       _out, err, status = Open3.capture3(env, 'bundle', 'exec', 'ruby', ruby_bin, '/no/such/path')
 
       expect(status.exitstatus).to eq(1)
-      expect(err).to match(/Index directory does not exist/i)
+      expect(utf8(err)).to match(/Index directory does not exist/i)
     end
 
     it 'exits non-zero when the directory is missing manifest.json' do
@@ -129,7 +137,7 @@ RSpec.describe 'MCP CLI integration' do
         _out, err, status = Open3.capture3(env, 'bundle', 'exec', 'ruby', ruby_bin, empty_dir)
 
         expect(status.exitstatus).to eq(1)
-        expect(err).to match(/No manifest\.json/)
+        expect(utf8(err)).to match(/No manifest\.json/)
       end
     end
 
@@ -161,8 +169,8 @@ RSpec.describe 'MCP CLI integration' do
           _out, err, status = Open3.capture3(env, 'bundle', 'exec', 'ruby', ruby_bin, dir)
 
           expect(status.exitstatus).to eq(2)
-          expect(err).to match(/MissingArtifact/)
-          expect(err).to match(/WOODS_REQUIRE_INDEX/)
+          expect(utf8(err)).to match(/MissingArtifact/)
+          expect(utf8(err)).to match(/WOODS_REQUIRE_INDEX/)
         end
       end
     end

--- a/spec/mcp/server_spec.rb
+++ b/spec/mcp/server_spec.rb
@@ -1013,6 +1013,43 @@ RSpec.describe Woods::MCP::Server do
     end
   end
 
+  describe 'pipeline serialization (pipeline_start/pipeline_finish)' do
+    after do
+      # Release any lock this group's examples may have left held.
+      described_class.send(:pipeline_finish, :extraction)
+    end
+
+    it 'has an eagerly-initialized mutex (no lazy ||= race under the HTTP transport)' do
+      expect(described_class.instance_variable_get(:@pipeline_mutex)).to be_a(Mutex)
+    end
+
+    it 'admits exactly one starter for a given kind until it finishes' do
+      expect(described_class.send(:pipeline_start, :extraction)).to be(true)
+      expect(described_class.send(:pipeline_start, :extraction)).to be(false)
+
+      described_class.send(:pipeline_finish, :extraction)
+      expect(described_class.send(:pipeline_start, :extraction)).to be(true)
+    end
+
+    it 'admits exactly one starter under concurrent contention' do
+      described_class.send(:pipeline_finish, :extraction) # ensure released
+      results = Queue.new
+      barrier = Queue.new
+
+      threads = 25.times.map do
+        Thread.new do
+          barrier.pop # release all threads together
+          results << described_class.send(:pipeline_start, :extraction)
+        end
+      end
+      25.times { barrier << true }
+      threads.each(&:join)
+
+      admitted = Array.new(25) { results.pop }.count(true)
+      expect(admitted).to eq(1)
+    end
+  end
+
   describe '.coerce_integer' do
     it 'passes Integer through unchanged' do
       expect(described_class.send(:coerce_integer, 7)).to eq(7)

--- a/spec/mcp/server_spec.rb
+++ b/spec/mcp/server_spec.rb
@@ -988,6 +988,18 @@ RSpec.describe Woods::MCP::Server do
         File.write(File.join(tmp_dir, 'flows', 'X_y.json'), 'not json')
         expect(described_class.send(:load_precomputed_flow, tmp_dir, 'X#y')).to be_nil
       end
+
+      it 'does not read files outside flows/ for traversal-shaped entry points' do
+        # "../evil#x" used to resolve to <tmp_dir>/flows/../evil_x.json —
+        # i.e. a file OUTSIDE the flows dir. The allow-list must neutralize
+        # path separators and dots.
+        FileUtils.mkdir_p(File.join(tmp_dir, 'flows'))
+        File.write(
+          File.join(tmp_dir, 'evil_x.json'),
+          JSON.pretty_generate(entry_point: 'stolen', steps: [])
+        )
+        expect(described_class.send(:load_precomputed_flow, tmp_dir, '../evil#x')).to be_nil
+      end
     end
   end
 

--- a/spec/mcp/server_spec.rb
+++ b/spec/mcp/server_spec.rb
@@ -784,9 +784,19 @@ RSpec.describe Woods::MCP::Server do
       Woods.configuration = nil
     end
 
-    it 'calls extract_changed when incremental is true' do
-      wait_for_threads { call_tool(server_with_operator, 'pipeline_extract', incremental: true) }
-      expect(mock_extractor).to have_received(:extract_changed).with([])
+    it 'calls extract_changed with the supplied changed_files when incremental is true' do
+      wait_for_threads do
+        call_tool(server_with_operator, 'pipeline_extract',
+                  incremental: true, changed_files: ['app/models/user.rb'])
+      end
+      expect(mock_extractor).to have_received(:extract_changed).with(['app/models/user.rb'])
+    end
+
+    it 'rejects incremental without changed_files instead of silently re-extracting nothing' do
+      response = call_tool(server_with_operator, 'pipeline_extract', incremental: true)
+
+      expect(response_text(response)).to include('changed_files')
+      expect(mock_extractor).not_to have_received(:extract_changed)
     end
 
     it 'calls extract_all when incremental is false' do

--- a/spec/model_name_cache_spec.rb
+++ b/spec/model_name_cache_spec.rb
@@ -41,6 +41,20 @@ RSpec.describe Woods::ModelNameCache do
       # The dot should be literal, not match any character
       expect('App::V2XUser').not_to match(regex)
     end
+
+    it 'matches the longest name when one model name prefixes another' do
+      # Alternation is ordered, not longest-match: with Library::Book first,
+      # "Library::Book::Chapter" would match the shorter name (\b holds at
+      # the ":"), producing a dependency edge to the wrong model.
+      stub_const(
+        'ActiveRecord::Base',
+        double('AR::Base', descendants: [double(name: 'Library::Book'), double(name: 'Library::Book::Chapter')])
+      )
+
+      regex = described_class.model_names_regex
+      expect('Library::Book::Chapter.create!(book: b)'[regex]).to eq('Library::Book::Chapter')
+      expect('Library::Book.find(1)'[regex]).to eq('Library::Book')
+    end
   end
 
   describe '.reset!' do

--- a/spec/notion/exporter_spec.rb
+++ b/spec/notion/exporter_spec.rb
@@ -96,8 +96,8 @@ RSpec.describe Woods::Notion::Exporter do
   describe '#initialize' do
     it 'raises ConfigurationError when notion_api_token is missing' do
       # Ensure no ambient ENV token satisfies the (new) ENV-override path.
-      allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with('NOTION_API_TOKEN').and_return(nil)
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('NOTION_API_TOKEN', nil).and_return(nil)
       bad_config = double('Configuration', notion_api_token: nil, notion_database_ids: {})
       expect do
         described_class.new(index_dir: index_dir, config: bad_config, reader: reader)
@@ -111,13 +111,27 @@ RSpec.describe Woods::Notion::Exporter do
     it 'accepts the NOTION_API_TOKEN env var when config has no token' do
       # Documented override: an ENV-only host must construct successfully,
       # matching what the MCP notion_wired? gate promises.
-      allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with('NOTION_API_TOKEN').and_return('secret_env_token')
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('NOTION_API_TOKEN', nil).and_return('secret_env_token')
       env_config = double('Configuration', notion_api_token: nil, notion_database_ids: { 'data_models' => 'db1' })
 
       expect do
         described_class.new(index_dir: index_dir, config: env_config, reader: reader)
       end.not_to raise_error
+    end
+
+    it 'treats a blank NOTION_API_TOKEN env var as absent, using the configured token' do
+      # A set-but-empty env var (docker-compose ${VAR} of an unset host var)
+      # must not mask a valid configured token nor pass through as a blank
+      # bearer that only fails later with 401s.
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('NOTION_API_TOKEN', nil).and_return('')
+      built = nil
+
+      expect do
+        built = described_class.new(index_dir: index_dir, config: config, reader: reader)
+      end.not_to raise_error
+      expect(built).to be_a(described_class)
     end
   end
 

--- a/spec/notion/exporter_spec.rb
+++ b/spec/notion/exporter_spec.rb
@@ -95,6 +95,9 @@ RSpec.describe Woods::Notion::Exporter do
 
   describe '#initialize' do
     it 'raises ConfigurationError when notion_api_token is missing' do
+      # Ensure no ambient ENV token satisfies the (new) ENV-override path.
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('NOTION_API_TOKEN').and_return(nil)
       bad_config = double('Configuration', notion_api_token: nil, notion_database_ids: {})
       expect do
         described_class.new(index_dir: index_dir, config: bad_config, reader: reader)
@@ -103,6 +106,18 @@ RSpec.describe Woods::Notion::Exporter do
 
     it 'succeeds with valid config' do
       expect(exporter).to be_a(described_class)
+    end
+
+    it 'accepts the NOTION_API_TOKEN env var when config has no token' do
+      # Documented override: an ENV-only host must construct successfully,
+      # matching what the MCP notion_wired? gate promises.
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('NOTION_API_TOKEN').and_return('secret_env_token')
+      env_config = double('Configuration', notion_api_token: nil, notion_database_ids: { 'data_models' => 'db1' })
+
+      expect do
+        described_class.new(index_dir: index_dir, config: env_config, reader: reader)
+      end.not_to raise_error
     end
   end
 

--- a/spec/operator/error_escalator_spec.rb
+++ b/spec/operator/error_escalator_spec.rb
@@ -59,6 +59,23 @@ RSpec.describe Woods::Operator::ErrorEscalator do
       end
     end
 
+    context 'with a class_name override (pipeline_diagnose over-the-wire path)' do
+      it 'matches class-keyed patterns using the supplied class name, not the object class' do
+        # The MCP tool only has the class name as a string and hands a bare
+        # StandardError — without the override this misclassified as :unknown.
+        result = escalator.classify(StandardError.new('connection timed out'), class_name: 'Timeout::Error')
+        expect(result[:severity]).to eq(:transient)
+        expect(result[:category]).to eq('timeout')
+        expect(result[:error_class]).to eq('Timeout::Error')
+      end
+
+      it 'reports the supplied class name for unclassified errors too' do
+        result = escalator.classify(StandardError.new('weird'), class_name: 'Some::CustomError')
+        expect(result[:severity]).to eq(:unknown)
+        expect(result[:error_class]).to eq('Some::CustomError')
+      end
+    end
+
     it 'always includes error_class and message' do
       result = escalator.classify(RuntimeError.new('boom'))
       expect(result[:error_class]).to eq('RuntimeError')

--- a/spec/resilience/circuit_breaker_spec.rb
+++ b/spec/resilience/circuit_breaker_spec.rb
@@ -119,6 +119,66 @@ RSpec.describe Woods::Resilience::CircuitBreaker do
 
         expect(breaker.state).to eq(:open)
       end
+
+      it 'admits only a single probe at a time, rejecting concurrent calls' do
+        probe_started = Queue.new
+        release_probe = Queue.new
+        rejected = nil
+
+        probe = Thread.new do
+          breaker.call do
+            probe_started << true
+            release_probe.pop # hold the half_open probe in flight
+            'recovered'
+          end
+        end
+
+        probe_started.pop # ensure the probe is executing (state is half_open)
+        begin
+          breaker.call { 'second probe' }
+        rescue Woods::Resilience::CircuitOpenError => e
+          rejected = e
+        end
+
+        release_probe << true
+        probe.join
+
+        expect(rejected).to be_a(Woods::Resilience::CircuitOpenError)
+        expect(breaker.state).to eq(:closed) # the single probe succeeded and closed the circuit
+      end
+    end
+
+    context 'when half_open with a success_threshold > 1' do
+      subject(:breaker) { described_class.new(threshold: 2, reset_timeout: 0.1, success_threshold: 2) }
+
+      before do
+        2.times do
+          breaker.call { raise StandardError, 'fail' }
+        rescue StandardError
+          nil
+        end
+        sleep 0.3
+      end
+
+      it 'requires the configured number of consecutive successful probes to close' do
+        breaker.call { 'probe 1' }
+        expect(breaker.state).to eq(:half_open) # not closed after a single success
+
+        breaker.call { 'probe 2' }
+        expect(breaker.state).to eq(:closed)
+      end
+
+      it 'reopens and resets progress if a probe fails mid-recovery' do
+        breaker.call { 'probe 1' }
+        expect(breaker.state).to eq(:half_open)
+
+        begin
+          breaker.call { raise StandardError, 'regressed' }
+        rescue StandardError
+          nil
+        end
+        expect(breaker.state).to eq(:open)
+      end
     end
   end
 

--- a/spec/resilience/circuit_breaker_spec.rb
+++ b/spec/resilience/circuit_breaker_spec.rb
@@ -148,6 +148,55 @@ RSpec.describe Woods::Resilience::CircuitBreaker do
       end
     end
 
+    context 'when a call admitted while closed completes after the circuit went half_open' do
+      subject(:breaker) { described_class.new(threshold: 3, reset_timeout: 0.1) }
+
+      it 'does not let the stale non-probe success close the circuit' do
+        stale_started = Queue.new
+        stale_release = Queue.new
+        probe_started = Queue.new
+        probe_release = Queue.new
+
+        # A call admitted while the circuit is still CLOSED, held in flight.
+        stale = Thread.new do
+          breaker.call do
+            stale_started << true
+            stale_release.pop
+            'pre-outage success'
+          end
+        end
+        stale_started.pop
+
+        # Drive the circuit open with failures while the stale call is in flight.
+        3.times do
+          breaker.call { raise StandardError, 'fail' }
+        rescue StandardError
+          nil
+        end
+        sleep 0.4 # let reset_timeout elapse
+
+        # A genuine probe is admitted (state -> half_open) and held in flight.
+        probe = Thread.new do
+          breaker.call do
+            probe_started << true
+            probe_release.pop
+            'probe success'
+          end
+        end
+        probe_started.pop
+        expect(breaker.state).to eq(:half_open)
+
+        # The stale (non-probe) call now completes successfully. It must NOT
+        # count as the recovery probe and must NOT close the circuit.
+        stale_release << true
+        stale.join
+        expect(breaker.state).to eq(:half_open)
+
+        probe_release << true
+        probe.join
+      end
+    end
+
     context 'when half_open with a success_threshold > 1' do
       subject(:breaker) { described_class.new(threshold: 2, reset_timeout: 0.1, success_threshold: 2) }
 

--- a/spec/resolved_config_spec.rb
+++ b/spec/resolved_config_spec.rb
@@ -266,6 +266,20 @@ RSpec.describe Woods::ResolvedConfig do
       config = described_class.from_hash(v1_hash)
       expect(config.stores).to be_frozen
     end
+
+    it 'freezes nested string values, not just the containing hash' do
+      # A frozen hash still allows `hash[:model] << "-v2"` if the string
+      # itself is mutable — build the input with unfrozen strings to prove
+      # deep_freeze reaches them.
+      mutable = v1_hash.merge(
+        'embedding_provider' => v1_hash['embedding_provider'].merge('model' => +'nomic-embed-text')
+      )
+      config = described_class.from_hash(mutable)
+
+      model = config.embedding_provider[:model]
+      expect(model).to be_frozen
+      expect { model << '-v2' }.to raise_error(FrozenError)
+    end
   end
 
   describe '.from_configuration' do

--- a/spec/retrieval/ranker_spec.rb
+++ b/spec/retrieval/ranker_spec.rb
@@ -190,6 +190,55 @@ RSpec.describe Woods::Retrieval::Ranker do
     end
   end
 
+  # The metadata store returns STRING keys on every real backend (SQLite
+  # via JSON.parse, InMemory via stringify_keys). These specs use that
+  # shape — with symbol-only key access, all four metadata signals scored
+  # every unit at its neutral fallback and these would fail.
+  describe 'string-keyed metadata (real store shape)' do
+    it 'scores recency from string-keyed git metadata' do
+      hot_meta = { 'metadata' => { 'git' => { 'change_frequency' => 'hot' } } }
+      dormant_meta = { 'metadata' => { 'git' => { 'change_frequency' => 'dormant' } } }
+      allow(metadata_store).to receive(:find).with('Hot').and_return(hot_meta)
+      allow(metadata_store).to receive(:find).with('Dormant').and_return(dormant_meta)
+
+      hot = candidate(identifier: 'Hot', score: 0.5)
+      dormant = candidate(identifier: 'Dormant', score: 0.5)
+
+      result = ranker.rank([dormant, hot], classification: classification)
+
+      expect(result.first.identifier).to eq('Hot')
+    end
+
+    it 'scores importance from string-keyed metadata' do
+      allow(metadata_store).to receive(:find).with('Important')
+                                             .and_return({ 'metadata' => { 'importance' => 'high' } })
+      allow(metadata_store).to receive(:find).with('Trivial')
+                                             .and_return({ 'metadata' => { 'importance' => 'low' } })
+
+      important = candidate(identifier: 'Important', score: 0.5)
+      trivial = candidate(identifier: 'Trivial', score: 0.5)
+
+      result = ranker.rank([trivial, important], classification: classification)
+
+      expect(result.first.identifier).to eq('Important')
+    end
+
+    it 'matches target_type from the string-keyed top-level type field' do
+      allow(metadata_store).to receive(:find).with('UserModel')
+                                             .and_return({ 'type' => 'model', 'metadata' => {} })
+      allow(metadata_store).to receive(:find).with('UserController')
+                                             .and_return({ 'type' => 'controller', 'metadata' => {} })
+
+      model_unit = candidate(identifier: 'UserModel', score: 0.5)
+      controller_unit = candidate(identifier: 'UserController', score: 0.5)
+
+      cls = classification(target_type: :model)
+      result = ranker.rank([controller_unit, model_unit], classification: cls)
+
+      expect(result.first.identifier).to eq('UserModel')
+    end
+  end
+
   describe 'pagerank importance integration' do
     let(:graph_store) { instance_double(Woods::Storage::GraphStore::Interface) }
     let(:ranker) { described_class.new(metadata_store: metadata_store, graph_store: graph_store) }

--- a/spec/retry_after_spec.rb
+++ b/spec/retry_after_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'woods/retry_after'
+
+RSpec.describe Woods::RetryAfter do
+  describe '.seconds' do
+    it 'parses the delta-seconds (integer) form' do
+      expect(described_class.seconds('30', fallback: 5)).to eq(30.0)
+    end
+
+    it 'returns the fallback when the header is absent' do
+      expect(described_class.seconds(nil, fallback: 7)).to eq(7.0)
+    end
+
+    it 'returns the fallback when the header is blank' do
+      expect(described_class.seconds('   ', fallback: 3)).to eq(3.0)
+    end
+
+    it 'parses the HTTP-date form as seconds until that instant' do
+      now = Time.utc(2026, 7, 1, 12, 0, 0)
+      future = (now + 45).httpdate # RFC 9110 HTTP-date, 45s ahead
+
+      expect(described_class.seconds(future, fallback: 5, now: now)).to be_within(0.001).of(45.0)
+    end
+
+    it 'never returns a negative wait for an HTTP-date in the past' do
+      now = Time.utc(2026, 7, 1, 12, 0, 0)
+      past = (now - 60).httpdate
+
+      expect(described_class.seconds(past, fallback: 5, now: now)).to eq(0.0)
+    end
+
+    it 'does NOT collapse an HTTP-date to 0.0 the way .to_f would' do
+      now = Time.utc(2026, 7, 1, 12, 0, 0)
+      future = (now + 120).httpdate
+
+      # The bug being fixed: `future.to_f` == 0.0.
+      expect(future.to_f).to eq(0.0)
+      expect(described_class.seconds(future, fallback: 5, now: now)).to be > 0
+    end
+
+    it 'falls back when the header is neither an integer nor a valid HTTP-date' do
+      expect(described_class.seconds('soon-ish', fallback: 9)).to eq(9.0)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

A multi-pass audit of the gem for bugs, security issues, DRY opportunities, and documentation drift. Every fix ships with a regression test; the full suite is green (5114 examples, 0 failures) and rubocop is clean across the tree.

All work is on the single designated audit branch (per this environment's branch policy), but the commits are organized into **focused, independently-reviewable groups** — listed below so reviewers can read them in isolation. Happy to split into separate PRs if preferred.

## Motivation

Runtime-introspection extraction, the two MCP servers, and the retrieval/embedding pipeline had a cluster of latent correctness bugs — several stemming from symbol-vs-string key mismatches between in-memory fixtures and the string-keyed data every real backend returns, which let the unit suite pass while the production path silently degraded. The console MCP surface also had exploitable input-validation gaps.

Closes #139 (in-container Index Server docs). Advances #83 (backend doc corrections). Fixes 3 of 5 items in #150. Files #147–#150 for backend findings that need adapter-level work + live-backend validation out of scope here.

## Changes

Grouped by theme (each is one or more commits):

**Security** (`5afd7e7`)
- Console `sample`/`recent`: validate `columns` before `.select` (SQL-fragment injection).
- `trace_flow`: allow-list the entry point before building the flow path (path traversal).
- TableGate: strip SQL literals under both dialects (PostgreSQL bypass).
- `EvalGuard`: match `%x` with any delimiter.
- `PipelineLock`: atomic stale-takeover + ownership-checked release (TOCTOU / cross-holder delete).

**Extraction / graph / flow correctness** (`77bf7bb`, `a5810f3`, `e5ff776`, `04431a6`, `4068a5d`)
- `callback_count` used the nonexistent `CallbackChain#size`; `ResolvedConfig#deep_freeze` left nested strings mutable.
- Incremental extraction clobbered `manifest.json`, poisoned temporal snapshots, wrote absolute paths, and null-tokened re-indexed units.
- Stale reverse edges on re-registration; prefix-matched model names; unsafe `promote` containment; DAG diamonds mislabeled as flow cycles.
- `FlowPrecomputer` ran before unit JSON was written.
- `implicit_belongs_to` flagged every presence validator; comment-stripping skipped two of three dependency-scan passes.

**Retrieval / embedding / MCP correctness** (`7f8d371`)
- Ranker read symbol keys against string-keyed store data (four dead signals); embedding cache key omitted the model; `pipeline_extract(incremental:)` was a silent no-op; `pipeline_diagnose` discarded the error class; `notion_sync` ignored `NOTION_API_TOKEN`; embedded docs dropped the `dependencies:` line.

**Resilience / robustness** (`3ded7f6`) — fixes 3 of 5 items in #150
- `CircuitBreaker` half-open now admits a single probe at a time (rejects concurrent probes; removes the overlap-reset race; adds `success_threshold`).
- `Retry-After` HTTP-date form no longer collapses to `0.0` (shared `Woods::RetryAfter` helper, used by both the Notion and Unblocked clients).
- The MCP pipeline lock's `@pipeline_mutex ||=` init race is fixed via eager initialization.

**DRY refactor** (`086f65c`)
- `find_files_in_directories` + `consolidate_dependencies` shared helpers swept across ~24 extractors (behavior-preserving).

**Docs & spec infra** (`7782651`, `2277329`, `2fa0184`, `23dd1ef`, `bc38d59`)
- In-container Index Server docs (#139); corrected tool counts and backend config examples (#83); undocumented rake tasks; UTF-8 CLI-spec fix; CHANGELOG; backlog tracking for #147–#150.

## Testing

- `bin/rspec` (this environment's `bundle exec rake spec` equivalent): **5114 examples, 0 failures, 2 pending** (pre-existing tiktoken-absent skips).
- `bin/rubocop`: clean across the tree.
- Every fix has a regression spec that fails on the pre-fix code (encoded in the commit that introduces it), including concurrent-contention tests for the circuit breaker and the pipeline lock.

## Checklist

- [x] Tests added/updated
- [x] `bundle exec rake spec` passes
- [x] `bundle exec rubocop` passes
- [x] CHANGELOG.md updated
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArdhBwMxtn3CiMSbGLqok8