### PR TITLE
feat(plugin): package user skills as woods-plugin + MCP update awareness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Woods is a Ruby gem that extracts structured data from Rails applications via ru
 | [docs/AGENT_GUIDE.md](docs/AGENT_GUIDE.md) | Deep reference for agents using the MCP tools |
 | [docs/MCP_SERVERS.md](docs/MCP_SERVERS.md) | Full tool catalog, setup for all clients |
 | [docs/MCP_TOOL_COOKBOOK.md](docs/MCP_TOOL_COOKBOOK.md) | Scenario-based tool usage examples |
+| [plugin/skills/](plugin/skills/) | User-facing Claude Code guide skills (`woods-setup`, `woods-mcp-config`, `woods-diagnose`), published via the [`lost-in-the/plugins`](https://github.com/lost-in-the/plugins) suite |
 
 ## MCP Server Setup
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MCP update awareness.** A new `Woods::UpdateCheck` module performs a best-effort,
+  24h-cached RubyGems lookup for a newer `woods` release (disable with
+  `WOODS_NO_UPDATE_CHECK=1`). The Index Server's `woods_status` tool now reports
+  `server.update` (`current_version` / `latest_version` / `update_available`), and a call to a
+  tool the installed gem doesn't define now returns version-aware guidance ("not available in
+  the installed Woods vX — run `bundle update woods`") instead of a bare "Tool not found". This
+  keeps agents that follow a newer guide skill from silently failing against an older gem.
 - **Claude Code plugin.** The three user-facing guide skills (`woods-setup`,
   `woods-mcp-config`, `woods-diagnose`) are now packaged as the `woods-plugin`, distributed
   from the [`lost-in-the/plugins`](https://github.com/lost-in-the/plugins) marketplace suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Claude Code plugin.** The three user-facing guide skills (`woods-setup`,
+  `woods-mcp-config`, `woods-diagnose`) are now packaged as the `woods-plugin`, distributed
+  from the [`lost-in-the/plugins`](https://github.com/lost-in-the/plugins) marketplace suite
+  via a `git-subdir` source (installs fetch only the `plugin/` subtree, not the whole gem).
+  Install with `/plugin marketplace add lost-in-the/plugins` then
+  `/plugin install woods-plugin@lost-in-the-plugins`. Each skill gained a **Version Preflight**
+  step so agents operate only against the installed Woods version (≥ 1.5.0) instead of
+  suggesting tools or tasks an older gem lacks.
+
+### Changed
+
+- The user-facing guide skills moved from `docs/skills/` to `plugin/skills/` to form a valid
+  Claude Code plugin root (`plugin/.claude-plugin/plugin.json`). In-repo dev-workflow skills
+  under `.claude/skills/` are unaffected and remain undistributed.
+
 ### Security
 
 - **Console `sample`/`recent` tools now validate `columns` against the model's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,36 @@ Open an issue describing:
 5. Ensure the test suite passes: `bundle exec rake spec`
 6. Ensure code style passes: `bundle exec rubocop`
 7. Update CHANGELOG.md with your changes
-8. Open a pull request
+8. Complete the **Pre-PR requirements** below
+9. Open a pull request
+
+### Pre-PR requirements
+
+These are hard gates — a PR that fails either is incomplete:
+
+1. **Documentation must be current.** Any doc affected by the change — README, `docs/`, the
+   `plugin/skills/` user guides, `CHANGELOG.md` — must be updated in the *same* PR. Don't ship
+   behavior the docs still describe the old way.
+2. **Investigate plugin-functionality impact.** If the change touches anything the distributed
+   user skills rely on — a rake task, MCP tool or its arguments, an executable (`woods-mcp`,
+   `woods-mcp-start`, `woods-console-mcp`, `woods-mcp-http`), a config key, or setup steps —
+   investigate whether `plugin/skills/{woods-setup,woods-mcp-config,woods-diagnose}` need to
+   change.
+
+### Claude Code plugin changes
+
+`plugin/` is distributed as the `woods-plugin` via the
+[`lost-in-the/plugins`](https://github.com/lost-in-the/plugins) marketplace (a `git-subdir`
+reference to this subtree). Installed users may run an **older** gem than `main`, so:
+
+- If a change adds/removes/renames a tool, task, executable, or config key that a skill
+  documents, **update the skill in the same PR**.
+- The skills carry a Version Preflight (operate only against the installed version). **Land the
+  skill change with the release that ships the capability** — never document a feature in a
+  skill before the version that provides it is released. Bump `plugin/.claude-plugin/plugin.json`
+  `version` when the skill content changes.
+- If the change requires a new marketplace entry, `ref` pin, or metadata edit, open a **paired
+  PR against `lost-in-the/plugins`** and link it from this PR.
 
 ## Development Setup
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,31 @@ Static tools miss `status_active?`, `status_pending?`, `build_line_item`, `creat
 
 ---
 
+## Claude Code plugin
+
+Woods publishes three **user-facing guide skills** as a Claude Code plugin so agents can walk
+you through setup, MCP configuration, and troubleshooting without leaving your editor:
+
+- `woods-setup` — install, configure, extract, verify, connect MCP servers
+- `woods-mcp-config` — generate a correct `.mcp.json` for your environment
+- `woods-diagnose` — systematic troubleshooting for extraction/MCP/embedding/storage
+
+The plugin ships from the [`lost-in-the/plugins`](https://github.com/lost-in-the/plugins)
+marketplace suite, which references this repo's `plugin/` subtree via a `git-subdir` source —
+so installing fetches only the skill files, not the whole gem:
+
+```bash
+# In Claude Code:
+/plugin marketplace add lost-in-the/plugins
+/plugin install woods-plugin@lost-in-the-plugins
+```
+
+The skill files live in this repo under [`plugin/skills/`](plugin/skills/) (the plugin root is
+[`plugin/`](plugin/), with its manifest at `plugin/.claude-plugin/plugin.json`). Each skill
+opens with a Version Preflight so agents operate only against your installed Woods version. To
+test a local checkout: `claude --plugin-dir /path/to/woods/plugin`. Requires **Woods ≥ 1.5.0**.
+The internal dev-workflow skills under `.claude/skills/` are **not** part of this plugin.
+
 ## Connect to Your AI Tool
 
 Woods ships two MCP servers. Most users only need the **Index Server**.

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -237,7 +237,7 @@ Use `framework` to search the Rails/gem source installed in the app — not docu
 
 | Tool | Key Parameters | Description |
 |------|---------------|-------------|
-| `woods_status` | _(none)_ | Diagnose whether the server is ready. Returns extraction metadata (last run, unit counts, git SHA, staleness seconds), retriever/embedding configuration, and feature flags. **Call first on cold connect.** |
+| `woods_status` | _(none)_ | Diagnose whether the server is ready. Returns extraction metadata (last run, unit counts, git SHA, staleness seconds), retriever/embedding configuration, feature flags, and `server.update` (installed vs. latest published gem version + an `update_available` flag). **Call first on cold connect.** |
 | `lookup` | `identifier`, `include_source`, `sections` | Full unit by exact identifier. `sections` filters which fields to return. |
 | `search` | `query`, `types`, `fields`, `limit` | Regex search across identifiers, source, or metadata. Returns `{ results: [...], note?, partial? }` — `note` flags broad patterns (>50% of a directory matched), `partial` means the phase-2 scan cap (`WOODS_SEARCH_MAX_SCAN`, default 500) was hit. Invalid regex falls back to literal match. Follow up with `lookup`. |
 | `dependencies` | `identifier`, `depth`, `types`, `via` | Forward dependency tree (BFS). What a unit depends on. |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -663,5 +663,8 @@ For a single-call health snapshot, call the Index Server's `woods_status` tool. 
 - Console-bridge reachability
 - Which optional features are configured (embedding provider, Notion, session tracer)
 - Per-feature config-key hints for anything missing
+- `server.update` — the installed gem version, the latest published version, and an `update_available` flag (a best-effort RubyGems check, cached 24h; disable with `WOODS_NO_UPDATE_CHECK=1`)
 
 Agents cold-connecting to a server should call `woods_status` before any other tool — it eliminates most "why is this empty?" guesswork.
+
+If a tool call fails with **"Tool not found: … not available in the installed Woods v…"**, the client is asking for a tool a newer gem provides. Run `bundle update woods` and reconnect the MCP server, then retry.

--- a/lib/woods/mcp/server.rb
+++ b/lib/woods/mcp/server.rb
@@ -8,8 +8,10 @@ require 'time'
 require 'set'
 require_relative '../tasks'
 require_relative '../filename_utils'
+require_relative '../update_check'
 require_relative 'index_reader'
 require_relative 'tool_response_renderer'
+require_relative 'version_aware_tool_dispatch'
 
 module Woods
   module MCP
@@ -97,6 +99,9 @@ module Woods
             resources: resources,
             resource_templates: resource_templates
           )
+          # Rewrite "Tool not found" into version-aware update guidance for agents
+          # running against an older gem than the skill they're following assumes.
+          server.singleton_class.prepend(VersionAwareToolDispatch)
 
           define_lookup_tool(server, reader, respond, respond_err, renderer)
           define_search_tool(server, reader, respond, respond_err, renderer)
@@ -1468,7 +1473,8 @@ module Woods
             server: {
               name: 'woods',
               version: Woods::VERSION,
-              index_dir: index_dir.to_s
+              index_dir: index_dir.to_s,
+              update: Woods::UpdateCheck.status_hash
             },
             index: index_section(manifest, extracted_at, staleness, index_dir),
             retriever: {

--- a/lib/woods/mcp/version_aware_tool_dispatch.rb
+++ b/lib/woods/mcp/version_aware_tool_dispatch.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative '../update_check'
+
+module Woods
+  module MCP
+    # Prepended onto a built +MCP::Server+ instance so that a call to a tool the
+    # installed gem does not define produces version-aware, self-healing
+    # guidance instead of a bare "Tool not found".
+    #
+    # An agent following a newer version of the distributed guide skills may try
+    # to call a tool that only exists in a later Woods release. The upstream
+    # +mcp+ gem raises +RequestHandlerError("Tool not found: X")+ with no seam to
+    # customize the message, so we intercept the built server's +call_tool+
+    # (dispatched directly by +handle_request+, so a prepend on the instance is
+    # honored on both the stdio and HTTP transports) and re-raise with the
+    # installed version plus an update hint the agent can relay to the user.
+    #
+    # Only the genuine tool-not-found case is rewritten; every other
+    # +RequestHandlerError+ (missing/invalid arguments, internal errors) is
+    # re-raised untouched.
+    module VersionAwareToolDispatch
+      # @param request [Hash] the tools/call params (carries +:name+)
+      # @return [MCP::Tool::Response] the tool result
+      # @raise [MCP::Server::RequestHandlerError] rewritten for unknown tools
+      def call_tool(request, **)
+        super
+      rescue ::MCP::Server::RequestHandlerError => e
+        raise unless tool_not_found_error?(e)
+
+        raise ::MCP::Server::RequestHandlerError.new(
+          Woods::UpdateCheck.tool_not_found_message(request[:name]),
+          request,
+          error_type: :invalid_params,
+          original_error: e
+        )
+      end
+
+      private
+
+      # The gem raises exactly this shape for an unregistered tool name.
+      def tool_not_found_error?(error)
+        error.error_type == :invalid_params && error.message.to_s.start_with?('Tool not found:')
+      end
+    end
+  end
+end

--- a/lib/woods/update_check.rb
+++ b/lib/woods/update_check.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'json'
+require 'time'
+require 'tmpdir'
+require_relative 'version'
+
+module Woods
+  # Best-effort "is a newer Woods release available?" check.
+  #
+  # Modeled on grove's background update notifier: it queries RubyGems for the
+  # latest published +woods+ version, caches the answer on disk for 24h, and is
+  # fully non-fatal — any network, parse, or filesystem failure degrades to
+  # "no update signal" rather than raising. It exists so the MCP server can tell
+  # an agent (and, through it, the user) that the installed gem is behind, which
+  # matters because the distributed guide skills operate against whatever version
+  # is installed.
+  #
+  # Two surfaces consume this:
+  #   * {Woods::MCP::Server.build_status} embeds {status_hash} under
+  #     +server.update+ so +woods_status+ reports update availability.
+  #   * {Woods::MCP::VersionAwareToolDispatch} uses {tool_not_found_message} to
+  #     turn a bare "Tool not found" into version-aware, self-healing guidance.
+  #
+  # Disable entirely with +WOODS_NO_UPDATE_CHECK=1+.
+  #
+  # @example
+  #   Woods::UpdateCheck.status_hash
+  #   # => { current_version: "1.5.0", latest_version: "1.6.0", update_available: true }
+  module UpdateCheck
+    # RubyGems endpoint returning +{ "version": "x.y.z" }+ for the latest release.
+    RUBYGEMS_LATEST_URL = 'https://rubygems.org/api/v1/versions/woods/latest.json'
+    # How long a cached result is trusted before a re-fetch is attempted.
+    CACHE_TTL = 24 * 60 * 60
+    # Open/read timeout for the (best-effort) network probe, in seconds.
+    HTTP_TIMEOUT = 1.5
+
+    module_function
+
+    # Resolve update availability, using the on-disk cache when fresh and
+    # otherwise fetching once and caching the result.
+    #
+    # @param current [String] Installed version (defaults to {Woods::VERSION})
+    # @param cache_path [String] Path to the JSON cache file
+    # @param ttl [Integer] Cache lifetime in seconds
+    # @param now [Time] Injected clock (for deterministic specs)
+    # @param fetcher [#call] Callable taking the URL and returning a version
+    #   string or nil; injectable for tests
+    # @return [Hash] +{ current:, latest:, update_available: }+ (latest may be nil)
+    def check(current: Woods::VERSION, cache_path: default_cache_path, ttl: CACHE_TTL,
+              now: Time.now, fetcher: method(:fetch_latest_version))
+      return result(current, nil) if disabled?
+
+      latest = cached_latest(cache_path, ttl, now)
+      latest ||= refresh(cache_path, now, fetcher)
+      result(current, latest)
+    end
+
+    # The +server.update+ sub-hash for +woods_status+. Keys are snake_case to
+    # match the rest of the status payload's JSON shape.
+    #
+    # @return [Hash] +{ current_version:, latest_version:, update_available: }+
+    def status_hash(current: Woods::VERSION, **opts)
+      r = check(current: current, **opts)
+      {
+        current_version: r[:current],
+        latest_version: r[:latest],
+        update_available: r[:update_available]
+      }
+    end
+
+    # Version-aware replacement for the MCP layer's bare "Tool not found"
+    # message. Cache-only — it never triggers a network fetch, since it runs on
+    # an error path that must stay cheap.
+    #
+    # @param tool_name [String] The unrecognized tool name
+    # @param current [String] Installed version
+    # @return [String] Guidance an agent can relay to the user
+    def tool_not_found_message(tool_name, current: Woods::VERSION, cache_path: default_cache_path, fetcher: nil)
+      _ = fetcher # accepted so callers/specs can prove it is never invoked on this path
+      latest = disabled? ? nil : read_cache(cache_path)&.fetch('latest', nil)
+      msg = "Tool not found: #{tool_name}. This tool is not available in the installed " \
+            "Woods v#{current}. It may require a newer release — advise the user to run " \
+            '`bundle update woods`, then reconnect the MCP server.'
+      msg << " (latest published: #{latest})" if latest && newer?(latest, current)
+      msg
+    end
+
+    # --- internals -----------------------------------------------------------
+
+    def disabled?
+      ENV['WOODS_NO_UPDATE_CHECK'] == '1'
+    end
+
+    def result(current, latest)
+      { current: current, latest: latest, update_available: latest ? newer?(latest, current) : false }
+    end
+
+    def newer?(latest, current)
+      Gem::Version.new(latest) > Gem::Version.new(current)
+    rescue ArgumentError
+      false
+    end
+
+    # @return [String, nil] cached latest version if the cache is within TTL
+    def cached_latest(cache_path, ttl, now)
+      data = read_cache(cache_path)
+      return nil unless data
+
+      checked_at = data['checked_at']
+      return nil unless checked_at.is_a?(Numeric) && (now.to_i - checked_at) < ttl
+
+      data['latest']
+    end
+
+    # Fetch, persist, and return the latest version (nil on any failure).
+    def refresh(cache_path, now, fetcher)
+      latest = fetcher.call(RUBYGEMS_LATEST_URL)
+      write_cache(cache_path, latest, now) if latest
+      latest
+    rescue StandardError
+      nil
+    end
+
+    def read_cache(cache_path)
+      return nil unless File.exist?(cache_path)
+
+      JSON.parse(File.read(cache_path))
+    rescue StandardError
+      nil
+    end
+
+    def write_cache(cache_path, latest, now)
+      FileUtils.mkdir_p(File.dirname(cache_path))
+      File.write(cache_path, JSON.generate('latest' => latest, 'checked_at' => now.to_i))
+    rescue StandardError
+      nil
+    end
+
+    # Default per-user cache location, honoring XDG, falling back to tmpdir.
+    def default_cache_path
+      base = ENV.fetch('XDG_CACHE_HOME', nil)
+      base = File.join(Dir.home, '.cache') if base.nil? || base.empty?
+      File.join(base, 'woods', 'update_check.json')
+    rescue StandardError
+      File.join(Dir.tmpdir, 'woods-update-check.json')
+    end
+
+    # Best-effort RubyGems probe. Kept tiny and self-contained so the module has
+    # no non-stdlib dependencies.
+    #
+    # @return [String, nil] latest version string, or nil on any failure
+    def fetch_latest_version(url)
+      require 'net/http'
+      uri = URI(url)
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https',
+                                                     open_timeout: HTTP_TIMEOUT, read_timeout: HTTP_TIMEOUT) do |http|
+        http.get(uri.request_uri)
+      end
+      return nil unless response.is_a?(Net::HTTPSuccess)
+
+      version = JSON.parse(response.body)['version']
+      version if version.is_a?(String) && !version.empty?
+    rescue StandardError
+      nil
+    end
+  end
+end

--- a/lib/woods/update_check.rb
+++ b/lib/woods/update_check.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'fileutils'
 require 'json'
 require 'time'
 require 'tmpdir'
 require_relative 'version'
+require_relative 'atomic_file'
 
 module Woods
   # Best-effort "is a newer Woods release available?" check.
@@ -31,8 +31,12 @@ module Woods
   module UpdateCheck
     # RubyGems endpoint returning +{ "version": "x.y.z" }+ for the latest release.
     RUBYGEMS_LATEST_URL = 'https://rubygems.org/api/v1/versions/woods/latest.json'
-    # How long a cached result is trusted before a re-fetch is attempted.
+    # How long a successful result is trusted before a re-fetch is attempted.
     CACHE_TTL = 24 * 60 * 60
+    # A *failed* probe is cached for a shorter window, so an unreachable or slow
+    # RubyGems throttles retries (rather than re-blocking on every call) without
+    # hiding a real update for a full day once connectivity returns.
+    FAILURE_TTL = 60 * 60
     # Open/read timeout for the (best-effort) network probe, in seconds.
     HTTP_TIMEOUT = 1.5
 
@@ -52,9 +56,7 @@ module Woods
               now: Time.now, fetcher: method(:fetch_latest_version))
       return result(current, nil) if disabled?
 
-      latest = cached_latest(cache_path, ttl, now)
-      latest ||= refresh(cache_path, now, fetcher)
-      result(current, latest)
+      result(current, cached_or_refreshed_latest(cache_path, ttl, now, fetcher))
     end
 
     # The +server.update+ sub-hash for +woods_status+. Keys are snake_case to
@@ -103,37 +105,56 @@ module Woods
       false
     end
 
-    # @return [String, nil] cached latest version if the cache is within TTL
-    def cached_latest(cache_path, ttl, now)
-      data = read_cache(cache_path)
-      return nil unless data
+    # Return the cached latest version when the cache entry is still fresh
+    # (a shorter window applies to a previously-failed probe), otherwise fetch
+    # once and cache the outcome — success *or* failure.
+    #
+    # @return [String, nil]
+    def cached_or_refreshed_latest(cache_path, ttl, now, fetcher)
+      entry = read_cache(cache_path)
+      return entry['latest'] if entry && fresh_entry?(entry, ttl, now)
 
-      checked_at = data['checked_at']
-      return nil unless checked_at.is_a?(Numeric) && (now.to_i - checked_at) < ttl
-
-      data['latest']
+      refresh(cache_path, now, fetcher)
     end
 
-    # Fetch, persist, and return the latest version (nil on any failure).
+    # A success entry is trusted for +ttl+; a failure entry (nil latest) only
+    # for {FAILURE_TTL}.
+    def fresh_entry?(entry, ttl, now)
+      checked_at = entry['checked_at']
+      return false unless checked_at.is_a?(Numeric)
+
+      effective_ttl = entry['latest'] ? ttl : FAILURE_TTL
+      (now.to_i - checked_at) < effective_ttl
+    end
+
+    # Fetch and cache the outcome. A nil latest (unreachable RubyGems, non-2xx,
+    # unparseable body) is cached too, so repeated failures are throttled by
+    # {FAILURE_TTL} instead of re-probing on every call.
+    #
+    # @return [String, nil] the latest version, or nil on failure
     def refresh(cache_path, now, fetcher)
       latest = fetcher.call(RUBYGEMS_LATEST_URL)
-      write_cache(cache_path, latest, now) if latest
+      write_cache(cache_path, latest, now)
       latest
     rescue StandardError
+      write_cache(cache_path, nil, now)
       nil
     end
 
+    # @return [Hash, nil] the parsed cache entry, or nil if absent, unreadable,
+    #   or not a JSON object (guards the "never raise" contract against a
+    #   corrupt/tampered cache holding e.g. +[]+ or +42+)
     def read_cache(cache_path)
       return nil unless File.exist?(cache_path)
 
-      JSON.parse(File.read(cache_path))
+      parsed = JSON.parse(File.read(cache_path))
+      parsed.is_a?(Hash) ? parsed : nil
     rescue StandardError
       nil
     end
 
     def write_cache(cache_path, latest, now)
-      FileUtils.mkdir_p(File.dirname(cache_path))
-      File.write(cache_path, JSON.generate('latest' => latest, 'checked_at' => now.to_i))
+      Woods::AtomicFile.write(cache_path, JSON.generate('latest' => latest, 'checked_at' => now.to_i))
     rescue StandardError
       nil
     end

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "woods-plugin",
+  "description": "Woods user guides for Claude Code: set up, configure MCP servers for, and diagnose the Woods Rails code-intelligence gem.",
+  "version": "1.0.0",
+  "author": {
+    "name": "lost-in-the"
+  },
+  "homepage": "https://github.com/lost-in-the/woods",
+  "repository": "https://github.com/lost-in-the/woods",
+  "license": "MIT",
+  "keywords": [
+    "rails",
+    "woods",
+    "mcp",
+    "code-intelligence",
+    "agent"
+  ]
+}

--- a/plugin/skills/woods-diagnose/SKILL.md
+++ b/plugin/skills/woods-diagnose/SKILL.md
@@ -9,6 +9,21 @@ Work through these steps in order. Most problems are caught by Step 1 or Step 2.
 
 ---
 
+## Version Preflight
+
+Confirm which Woods version is installed and diagnose only against it:
+
+```bash
+bundle info woods        # installed version + path
+```
+
+This workflow targets **Woods ≥ 1.5.0**. Tool counts and behaviors below (29-tool index
+server, 31-tool console) assume a current gem. If the installed version is older, some tools
+or flags mentioned here may not exist — before treating their absence as a bug, check the
+installed version and, if outdated, advise the user to update (`bundle update woods`).
+
+---
+
 ## Step 1: Verify Rails Boots
 
 Woods requires a booted Rails environment. If Rails can't boot, extraction produces no output.
@@ -159,7 +174,7 @@ tools/list returns empty or error?
 
 This is expected behavior for embedded mode (rake task / Docker). Tier 2–4 tools (`console_diagnose_model`, `console_eval`, `console_sql`, etc.) require bridge mode.
 
-To get all 31 tools, switch to Option D (SSH/bridge) from [CONSOLE_MCP_SETUP.md](../../CONSOLE_MCP_SETUP.md).
+To get all 31 tools, switch to Option D (SSH/bridge) from [CONSOLE_MCP_SETUP.md](https://github.com/lost-in-the/woods/blob/main/docs/CONSOLE_MCP_SETUP.md).
 
 ### MCP client shows "connection refused" on HTTP transport
 

--- a/plugin/skills/woods-mcp-config/SKILL.md
+++ b/plugin/skills/woods-mcp-config/SKILL.md
@@ -9,6 +9,22 @@ Use this guide to produce a correct `.mcp.json` for your environment. Answer the
 
 ---
 
+## Version Preflight
+
+Confirm the installed Woods version before generating config — the available MCP executables
+and tool tiers depend on it:
+
+```bash
+bundle info woods        # installed version + path
+```
+
+This guide targets **Woods ≥ 1.5.0**. If the installed gem is older, some executables
+(`woods-mcp-http`, `woods-console-mcp`) or console tool tiers referenced below may not exist —
+tell the user to update (`bundle update woods`) rather than wiring config for tools the
+installed version doesn't ship.
+
+---
+
 ## Environment Detection
 
 **1. Is the Rails app running in Docker?**
@@ -167,7 +183,7 @@ When the Console Server runs as a Rack middleware endpoint instead of a subproce
 }
 ```
 
-Requires `config.console_mcp_enabled = true` in your initializer. See [CONSOLE_MCP_SETUP.md](../../CONSOLE_MCP_SETUP.md) Option C for full setup.
+Requires `config.console_mcp_enabled = true` in your initializer. See [CONSOLE_MCP_SETUP.md](https://github.com/lost-in-the/woods/blob/main/docs/CONSOLE_MCP_SETUP.md) Option C for full setup.
 
 ---
 

--- a/plugin/skills/woods-setup/SKILL.md
+++ b/plugin/skills/woods-setup/SKILL.md
@@ -9,6 +9,21 @@ Follow these steps to set up Woods in a Rails application. Each step builds on t
 
 ---
 
+## Version Preflight
+
+Check which Woods version is installed and operate only against it:
+
+```bash
+bundle info woods        # installed version + path (once the gem is in the Gemfile)
+```
+
+This guide targets **Woods ≥ 1.5.0**. If the installed gem is older, some rake tasks, MCP
+tools, or config keys referenced below may not exist — tell the user to update
+(`bundle update woods`) rather than running commands the installed version doesn't support.
+If a newer release is available on RubyGems, mention it so the user can pick up new features.
+
+---
+
 ## Step 1: Install the Gem
 
 Add to your Rails app's `Gemfile`:
@@ -207,6 +222,6 @@ This should output the tool list and then hang (waiting for more input). Press C
 ## Next Steps
 
 - Run incremental extraction after code changes: `bundle exec rake woods:incremental`
-- Set up CI extraction: see the GitHub Actions example in [MCP_TOOL_COOKBOOK.md](../../MCP_TOOL_COOKBOOK.md)
-- Enable Tier 2–4 console tools (diagnostics, SQL, Ruby eval): see [CONSOLE_MCP_SETUP.md](../../CONSOLE_MCP_SETUP.md) Option D
+- Set up CI extraction: see the GitHub Actions example in [MCP_TOOL_COOKBOOK.md](https://github.com/lost-in-the/woods/blob/main/docs/MCP_TOOL_COOKBOOK.md)
+- Enable Tier 2–4 console tools (diagnostics, SQL, Ruby eval): see [CONSOLE_MCP_SETUP.md](https://github.com/lost-in-the/woods/blob/main/docs/CONSOLE_MCP_SETUP.md) Option D
 - Enable temporal snapshots for change tracking: set `enable_snapshots: true` in your initializer

--- a/spec/mcp/version_aware_tool_dispatch_spec.rb
+++ b/spec/mcp/version_aware_tool_dispatch_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'woods'
+require 'woods/mcp/server'
+
+RSpec.describe Woods::MCP::VersionAwareToolDispatch do
+  let(:fixture_dir) { File.expand_path('../fixtures/woods', __dir__) }
+  let(:server) { Woods::MCP::Server.build(index_dir: fixture_dir, warmup: false) }
+
+  # Drive a tools/call through the real JSON-RPC entry point (what the stdio and
+  # HTTP transports use), so instrumentation/session setup happens exactly as in
+  # production. RequestHandlerError is caught and serialized into the response's
+  # `error` object — the gem places the detailed text in `error.data`.
+  def tools_call(name, arguments: {})
+    request = JSON.generate(
+      jsonrpc: '2.0', id: 1, method: 'tools/call',
+      params: { name: name, arguments: arguments }
+    )
+    JSON.parse(server.handle_json(request))
+  end
+
+  describe 'calling a tool that the installed gem does not define' do
+    it 'returns version-aware guidance instead of a bare "Tool not found"' do
+      response = tools_call('a_tool_from_the_future')
+
+      detail = response.dig('error', 'data')
+      expect(detail).to include('a_tool_from_the_future')
+      expect(detail).to include(Woods::VERSION)
+      expect(detail).to include('bundle update woods')
+    end
+
+    it 'appends the latest published version when the update cache knows one' do
+      allow(Woods::UpdateCheck).to receive(:fetch_latest_version).and_return('999.0.0')
+      Woods::UpdateCheck.check # prime the cache the (cache-only) error path reads
+
+      detail = tools_call('ghost_tool').dig('error', 'data')
+      expect(detail).to include('999.0.0')
+    end
+  end
+
+  describe 'a tool the installed gem does define' do
+    it 'dispatches normally (the override delegates to super)' do
+      response = tools_call('woods_status')
+
+      expect(response).to have_key('result')
+      expect(response).not_to have_key('error')
+    end
+  end
+end

--- a/spec/mcp/woods_status_spec.rb
+++ b/spec/mcp/woods_status_spec.rb
@@ -16,6 +16,26 @@ RSpec.describe 'woods_status tool' do
       expect(status[:server]).to include(name: 'woods', version: Woods::VERSION, index_dir: fixture_dir.to_s)
     end
 
+    it 'embeds an update sub-hash reporting the installed version (no update by default)' do
+      # spec_helper stubs the network fetch to nil, so a hermetic run reports no update.
+      expect(status[:server][:update]).to eq(
+        current_version: Woods::VERSION,
+        latest_version: nil,
+        update_available: false
+      )
+    end
+
+    it 'reports update_available=true when a newer version is published' do
+      allow(Woods::UpdateCheck).to receive(:fetch_latest_version).and_return('999.0.0')
+
+      s = Woods::MCP::Server.build_status(reader: reader, retriever: nil, index_dir: fixture_dir)
+      expect(s[:server][:update]).to include(
+        current_version: Woods::VERSION,
+        latest_version: '999.0.0',
+        update_available: true
+      )
+    end
+
     it 'surfaces extraction metadata from the manifest' do
       expect(status[:index]).to include(
         extracted_at: '2026-01-15T12:00:00Z',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ require 'active_support/core_ext/string/inflections'
 require 'woods/extracted_unit'
 require 'woods/dependency_graph'
 require 'woods/graph_analyzer'
+require 'woods/update_check'
 
 Dir[File.join(__dir__, 'support', '**', '*.rb')].each { |f| require f }
 
@@ -46,5 +47,17 @@ RSpec.configure do |config|
 
   config.after(:each) do
     Woods::ModelNameCache.reset! if defined?(Woods::ModelNameCache) && Woods::ModelNameCache.respond_to?(:reset!)
+  end
+
+  # Keep the RubyGems update check hermetic and deterministic across the suite:
+  # never touch the network, and isolate the cache to a per-process tmp file so
+  # an incidental `build_status`/`woods_status` call can't hit rubygems.org or
+  # read a developer's real ~/.cache. Specs that exercise the update path inject
+  # their own fetcher/cache_path or override these stubs.
+  config.before do
+    cache = File.join(Dir.tmpdir, "woods-update-check-test-#{Process.pid}.json")
+    FileUtils.rm_f(cache)
+    allow(Woods::UpdateCheck).to receive(:default_cache_path).and_return(cache)
+    allow(Woods::UpdateCheck).to receive(:fetch_latest_version).and_return(nil)
   end
 end

--- a/spec/update_check_spec.rb
+++ b/spec/update_check_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'woods/update_check'
+require 'tmpdir'
+require 'json'
+
+RSpec.describe Woods::UpdateCheck do
+  let(:cache_path) { File.join(Dir.mktmpdir, 'update_check.json') }
+  let(:now) { Time.at(1_700_000_000) }
+
+  describe '.check' do
+    it 'reports an update when the fetched latest version is newer' do
+      result = described_class.check(
+        current: '1.5.0', cache_path: cache_path, now: now,
+        fetcher: ->(_url) { '1.6.0' }
+      )
+
+      expect(result[:current]).to eq('1.5.0')
+      expect(result[:latest]).to eq('1.6.0')
+      expect(result[:update_available]).to be(true)
+    end
+
+    it 'reports no update when the installed version is current or newer' do
+      result = described_class.check(
+        current: '1.6.0', cache_path: cache_path, now: now,
+        fetcher: ->(_url) { '1.6.0' }
+      )
+
+      expect(result[:update_available]).to be(false)
+
+      ahead = described_class.check(
+        current: '1.7.0', cache_path: cache_path, now: now,
+        fetcher: ->(_url) { '1.6.0' }
+      )
+      expect(ahead[:update_available]).to be(false)
+    end
+
+    it 'writes a cache entry and reuses it within the TTL without re-fetching' do
+      calls = 0
+      fetcher = lambda do |_url|
+        calls += 1
+        '1.6.0'
+      end
+
+      described_class.check(current: '1.5.0', cache_path: cache_path, now: now, fetcher: fetcher)
+      described_class.check(current: '1.5.0', cache_path: cache_path, now: now + 60, fetcher: fetcher)
+
+      expect(calls).to eq(1)
+      expect(JSON.parse(File.read(cache_path))).to include('latest' => '1.6.0')
+    end
+
+    it 're-fetches once the cache is older than the TTL' do
+      calls = 0
+      fetcher = lambda do |_url|
+        calls += 1
+        '1.6.0'
+      end
+
+      described_class.check(current: '1.5.0', cache_path: cache_path, now: now, fetcher: fetcher)
+      described_class.check(
+        current: '1.5.0', cache_path: cache_path,
+        now: now + described_class::CACHE_TTL + 1, fetcher: fetcher
+      )
+
+      expect(calls).to eq(2)
+    end
+
+    it 'degrades gracefully when the fetch fails (no update signal, no raise)' do
+      result = described_class.check(
+        current: '1.5.0', cache_path: cache_path, now: now,
+        fetcher: ->(_url) { raise SocketError, 'offline' }
+      )
+
+      expect(result[:latest]).to be_nil
+      expect(result[:update_available]).to be(false)
+    end
+
+    it 'is a no-op when disabled via WOODS_NO_UPDATE_CHECK' do
+      calls = 0
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('WOODS_NO_UPDATE_CHECK').and_return('1')
+
+      result = described_class.check(
+        current: '1.5.0', cache_path: cache_path, now: now,
+        fetcher: lambda { |_url|
+          calls += 1
+          '1.6.0'
+        }
+      )
+
+      expect(calls).to eq(0)
+      expect(result[:update_available]).to be(false)
+    end
+  end
+
+  describe '.status_hash' do
+    it 'exposes current/latest/update_available with string-friendly keys' do
+      hash = described_class.status_hash(
+        current: '1.5.0', cache_path: cache_path, now: now,
+        fetcher: ->(_url) { '1.6.0' }
+      )
+
+      expect(hash).to eq(
+        current_version: '1.5.0',
+        latest_version: '1.6.0',
+        update_available: true
+      )
+    end
+  end
+
+  describe '.tool_not_found_message' do
+    it 'names the tool and the installed version and advises updating' do
+      described_class.check(current: '1.5.0', cache_path: cache_path, now: now, fetcher: ->(_url) { '1.6.0' })
+
+      msg = described_class.tool_not_found_message('codebase_retrieve', current: '1.5.0', cache_path: cache_path)
+
+      expect(msg).to include('codebase_retrieve')
+      expect(msg).to include('1.5.0')
+      expect(msg).to include('bundle update woods')
+      expect(msg).to include('1.6.0') # latest, from cache — no network on this path
+    end
+
+    it 'never performs a network fetch (cache-only)' do
+      msg = described_class.tool_not_found_message(
+        'some_tool', current: '1.5.0', cache_path: cache_path,
+                     fetcher: ->(_url) { raise 'must not be called' }
+      )
+
+      expect(msg).to include('some_tool')
+      expect(msg).to include('bundle update woods')
+    end
+  end
+end

--- a/spec/update_check_spec.rb
+++ b/spec/update_check_spec.rb
@@ -76,6 +76,47 @@ RSpec.describe Woods::UpdateCheck do
       expect(result[:update_available]).to be(false)
     end
 
+    it 'negative-caches a failed probe and does not re-fetch within FAILURE_TTL' do
+      calls = 0
+      fetcher = lambda do |_url|
+        calls += 1
+        raise SocketError, 'offline'
+      end
+
+      described_class.check(current: '1.5.0', cache_path: cache_path, now: now, fetcher: fetcher)
+      described_class.check(current: '1.5.0', cache_path: cache_path, now: now + 60, fetcher: fetcher)
+
+      expect(calls).to eq(1)
+    end
+
+    it 're-probes after FAILURE_TTL elapses' do
+      calls = 0
+      fetcher = lambda do |_url|
+        calls += 1
+        nil
+      end
+
+      described_class.check(current: '1.5.0', cache_path: cache_path, now: now, fetcher: fetcher)
+      described_class.check(
+        current: '1.5.0', cache_path: cache_path,
+        now: now + described_class::FAILURE_TTL + 1, fetcher: fetcher
+      )
+
+      expect(calls).to eq(2)
+    end
+
+    it 'ignores a corrupt cache whose JSON is not an object (degrades, never raises)' do
+      File.write(cache_path, '[]')
+
+      result = nil
+      expect do
+        result = described_class.check(
+          current: '1.5.0', cache_path: cache_path, now: now, fetcher: ->(_url) {}
+        )
+      end.not_to raise_error
+      expect(result[:update_available]).to be(false)
+    end
+
     it 'is a no-op when disabled via WOODS_NO_UPDATE_CHECK' do
       calls = 0
       allow(ENV).to receive(:[]).and_call_original
@@ -129,6 +170,15 @@ RSpec.describe Woods::UpdateCheck do
 
       expect(msg).to include('some_tool')
       expect(msg).to include('bundle update woods')
+    end
+
+    it 'still produces guidance when the cache is corrupt (non-object JSON)' do
+      File.write(cache_path, '42')
+
+      msg = nil
+      expect { msg = described_class.tool_not_found_message('x', current: '1.5.0', cache_path: cache_path) }
+        .not_to raise_error
+      expect(msg).to include('x').and include('bundle update woods')
     end
   end
 end


### PR DESCRIPTION
## Summary

Package the three user-facing guide skills as a lean Claude Code plugin distributed from the [`lost-in-the/plugins`](https://github.com/lost-in-the/plugins) marketplace suite, and add MCP-server safeguards so an agent following a newer guide skill than the installed gem degrades gracefully.

## Motivation

Part of lost-in-the/plugins#1. The suite distributes `grove` and `woods` plugins via `git-subdir` sources so installs fetch only the skill subtree (not the whole gem). Because installed users may run an **older** gem than a skill assumes, the skills operate against the installed version and the server now advertises update availability + gives version-aware errors.

## Changes

**Plugin packaging**
- Relocated the three user skills `docs/skills/` → `plugin/skills/{woods-setup,woods-mcp-config,woods-diagnose}/` to form a valid multi-skill plugin root (`plugin/.claude-plugin/plugin.json`). Internal `.claude/skills/` dev-workflow skills stay undistributed.
- Rewrote `../../<doc>` links to absolute GitHub URLs so they resolve from the installed plugin cache.
- Added a **Version Preflight** to each skill (`bundle info woods`, operate only against ≥ 1.5.0).
- Documented the plugin in README/AGENTS (woods had none); added Pre-PR requirements + Claude Code plugin changes rules to CONTRIBUTING.

**MCP update awareness**
- New `Woods::UpdateCheck`: best-effort, 24h-cached RubyGems lookup (disable with `WOODS_NO_UPDATE_CHECK=1`; any failure degrades to "no update", never raises; failed probes negative-cached for 1h; atomic cache write).
- `woods_status` now reports `server.update` (`current_version` / `latest_version` / `update_available`).
- `VersionAwareToolDispatch` (prepended onto the built `MCP::Server`) rewrites the upstream "Tool not found: X" into "not available in the installed Woods vN — run `bundle update woods`", covering both stdio and HTTP transports via the shared `call_tool` seam.

## Testing

- `bundle exec rspec` (full suite): **5149 examples, 0 failures, 2 pending**.
- `bundle exec rubocop`: clean.
- End-to-end drive of the real built server (`Server.build` + `handle_json`, live RubyGems fetch): `woods_status.server.update` populated, unknown tool returns version-aware guidance, known tools dispatch normally.
- Adversarial code review of the update-check module; findings (non-object-JSON crash, missing negative cache, non-atomic write) fixed with regression specs.

## Checklist

- [x] Tests added/updated
- [x] `bundle exec rake spec` passes
- [x] `bundle exec rubocop` passes
- [x] CHANGELOG.md updated
- [x] Documentation updated (README, AGENTS, CONTRIBUTING, TROUBLESHOOTING, AGENT_GUIDE)

> ⚠️ Merge ordering: this and grove#136 should merge before the `lost-in-the/plugins` marketplace goes live, since the suite's `git-subdir` entries reference each repo's `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLC2newcWwC1spUELGc64L)_