### PR TITLE
chore(release): prepare v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-07-16
+
 ### Added
 
 - **MCP update awareness.** A new `Woods::UpdateCheck` module performs a best-effort,

--- a/lib/woods/version.rb
+++ b/lib/woods/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Woods
-  VERSION = '1.5.0'
+  VERSION = '1.6.0'
 end


### PR DESCRIPTION
## Summary

Stamp version 1.6.0 and date the changelog for everything accumulated since v1.5.0: the audit's extraction/graph/flow bugfixes and security hardening (#151), the Obsidian vault export (#143), and the woods-plugin packaging + MCP update awareness (#155).

## Motivation

Main carries a large `[Unreleased]` section — including security fixes (console column validation, `trace_flow` path traversal, TableGate SQL-detection gaps, `EvalGuard` `%x` bypass, `PipelineLock` TOCTOU) and correctness fixes (incremental index corruption, ranker key-form mismatch, embedding-cache model scoping) — that users can't get until a gem is published. Minor bump per SemVer since the set also includes new features.

## Changes

- `lib/woods/version.rb`: `1.5.0` → `1.6.0`
- `CHANGELOG.md`: date the unreleased entries as `[1.6.0] - 2026-07-16`

## Testing

Verified on this exact tree, mirroring the tag-triggered release workflow:

- `rspec`: 5149 examples, 0 failures (2 pending = optional tiktoken benchmarks, absent gem)
- `rubocop`: 490 files inspected, no offenses
- `bundler-audit check --update`: no vulnerabilities
- `gem build woods.gemspec`: builds cleanly

## Checklist

- [ ] Tests added/updated (n/a — version stamp only)
- [x] `bundle exec rake spec` passes
- [x] `bundle exec rubocop` passes
- [x] CHANGELOG.md updated (if user-facing change)
- [ ] Documentation updated (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WPaWmEZTUbrpyaZJdJnPj

---
_Generated by [Claude Code](https://claude.ai/code/session_019WPaWmEZTUbrpyaZJdJnPj)_