### PR TITLE
fix: incremental extraction crash on multi-unit files (v1.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-07-22
+
+### Fixed
+
+- **Incremental extraction crash on multi-unit files.** `woods:incremental` raised
+  `NoMethodError: undefined method 'identifier' for an instance of Array` when re-extracting a
+  unit whose extractor returns several units from one file (a `.rake` file defining multiple
+  tasks; i18n, migration, and lib files are shaped the same way). `Extractor#re_extract_unit`
+  now normalizes the extractor result to an array and registers and writes each unit, matching
+  how full extraction already handles per-type results. Full extraction was unaffected.
+
 ## [1.6.0] - 2026-07-16
 
 ### Added

--- a/lib/woods/extractor.rb
+++ b/lib/woods/extractor.rb
@@ -1127,27 +1127,36 @@ module Woods
 
       return unless unit
 
-      # Update dependency graph. Register BEFORE normalizing the path —
-      # the graph's file_map stores absolute paths (affected_by matches
-      # changed files against them), exactly as full extraction registers
-      # in Phase 1 and only normalizes in Phase 4.5.
-      @dependency_graph.register(unit)
+      # File-based extractors can return several units from one file (a .rake
+      # file defining multiple tasks, etc.); class-based extractors return one.
+      # Normalize to an array so every unit is registered and written — passing
+      # an Array straight to DependencyGraph#register crashes on unit.identifier.
+      units = unit.is_a?(Array) ? unit : [unit]
+      return if units.empty?
 
       # Track which type was affected
       affected_types&.add(extractor_key)
 
-      # Unit JSON carries Rails.root-relative paths (full extraction's
-      # Phase 4.5); writing the raw absolute source_location here would
-      # leak container-absolute paths into the index after incremental runs.
-      unit.file_path = normalize_file_path(unit.file_path)
-
-      # Write updated unit
       type_dir = @output_dir.join(extractor_key.to_s)
 
-      File.write(
-        type_dir.join(collision_safe_filename(unit.identifier)),
-        json_serialize(unit.to_h)
-      )
+      units.each do |extracted|
+        # Update dependency graph. Register BEFORE normalizing the path —
+        # the graph's file_map stores absolute paths (affected_by matches
+        # changed files against them), exactly as full extraction registers
+        # in Phase 1 and only normalizes in Phase 4.5.
+        @dependency_graph.register(extracted)
+
+        # Unit JSON carries Rails.root-relative paths (full extraction's
+        # Phase 4.5); writing the raw absolute source_location here would
+        # leak container-absolute paths into the index after incremental runs.
+        extracted.file_path = normalize_file_path(extracted.file_path)
+
+        # Write updated unit
+        File.write(
+          type_dir.join(collision_safe_filename(extracted.identifier)),
+          json_serialize(extracted.to_h)
+        )
+      end
 
       Rails.logger.info "[Woods] Re-extracted #{unit_id}"
     end

--- a/lib/woods/version.rb
+++ b/lib/woods/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Woods
-  VERSION = '1.6.0'
+  VERSION = '1.6.1'
 end

--- a/spec/extractor_spec.rb
+++ b/spec/extractor_spec.rb
@@ -615,6 +615,40 @@ RSpec.describe Woods::Extractor do
       # The important thing is no error from the format check itself
       expect { extractor.send(:re_extract_unit, 'User') }.not_to raise_error
     end
+
+    it 'registers and writes every unit when a file-based extractor returns multiple units' do
+      # A single .rake file defines multiple tasks, so extract_rake_file returns
+      # an Array of units. re_extract_unit must fan out over them, not pass the
+      # Array straight to DependencyGraph#register.
+      require 'woods' # defines Woods.configuration (json_serialize reads pretty_json)
+      Woods.configuration ||= Woods::Configuration.new
+
+      rake_path = File.join(tmpdir, 'things.rake')
+      FileUtils.touch(rake_path)
+      # The type dir exists in real usage (created by the initial full extraction).
+      rake_dir = File.join(tmpdir, 'output', 'rake_tasks')
+      FileUtils.mkdir_p(rake_dir)
+
+      node = { type: 'rake_task', file_path: rake_path }
+      graph = extractor.instance_variable_get(:@dependency_graph)
+      allow(graph).to receive(:to_h).and_return({ nodes: { 'things:one' => node } })
+      allow(graph).to receive(:register).and_call_original
+
+      unit_one = Woods::ExtractedUnit.new(type: :rake_task, identifier: 'things:one', file_path: rake_path)
+      unit_two = Woods::ExtractedUnit.new(type: :rake_task, identifier: 'things:two', file_path: rake_path)
+
+      rake_extractor = instance_double(Woods::Extractors::RakeTaskExtractor)
+      allow(Woods::Extractors::RakeTaskExtractor).to receive(:new).and_return(rake_extractor)
+      allow(rake_extractor).to receive(:extract_rake_file).with(rake_path).and_return([unit_one, unit_two])
+
+      expect { extractor.send(:re_extract_unit, 'things:one') }.not_to raise_error
+
+      expect(graph).to have_received(:register).with(unit_one)
+      expect(graph).to have_received(:register).with(unit_two)
+
+      expect(File.exist?(File.join(rake_dir, extractor.send(:collision_safe_filename, 'things:one')))).to be(true)
+      expect(File.exist?(File.join(rake_dir, extractor.send(:collision_safe_filename, 'things:two')))).to be(true)
+    end
   end
 
   # ── deduplicate_results ──────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`woods:incremental` crashes with `NoMethodError: undefined method 'identifier' for an instance of Array` whenever a changed file maps to an extractor that returns **multiple units from one file** — a `.rake` file defining several tasks, and similarly i18n / migration / lib files.

`Extractor#re_extract_unit` assumed each extractor method returns a single `ExtractedUnit` and passed it straight to `DependencyGraph#register`, which then called `.identifier` on an Array.

Reproduced end-to-end against a large real host app: a 335-changed-path incremental died mid-run after re-extracting a batch of units. Full extraction was never affected because it already flattens per-type results (`@results.each_value { |units| units.each { register(u) } }`).

## Fix

Normalize the extractor result to an array and register + normalize-path + write each unit, mirroring full extraction's per-type handling. The single-unit path is unchanged (`[unit]`); `nil`/empty results are guarded.

Every array-returning extractor uses `filter_map`, so the arrays never contain nils — matching full extraction, the loop does not `.compact`.

## Testing

- New regression spec in `spec/extractor_spec.rb` (rake file returning two units) — fails with the exact production error before the fix, passes after.
- Full suite: **5150 examples, 0 failures** (4 pre-existing pending, optional `tiktoken_ruby`).
- Rubocop clean.
- End-to-end: the previously-crashing incremental now completes — **"Re-extracted 3800 affected units"**, exit 0.

## Release

Includes `chore(release): prepare v1.6.1` (version bump + CHANGELOG). Merging and tagging `v1.6.1` publishes to RubyGems.